### PR TITLE
Convert vni from int to string. Fix test specs

### DIFF
--- a/mizar/dp/mizar/operators/vpcs/vpcs_operator.py
+++ b/mizar/dp/mizar/operators/vpcs/vpcs_operator.py
@@ -121,7 +121,7 @@ class VpcOperator(object):
         # TODO: There is a tiny chance of collision here, not to worry about now
         if vpc.name == OBJ_DEFAULTS.default_ep_vpc:
             return OBJ_DEFAULTS.default_vpc_vni
-        vpc.set_vni(uuid.uuid4().int & (1 << 24)-1)
+        vpc.set_vni(str(uuid.uuid4().int & (1 << 24)-1))
 
     def deallocate_vni(self, vpc):
         # TODO: Keep track of VNI allocation

--- a/mizar/obj/tests/test_net.yaml
+++ b/mizar/obj/tests/test_net.yaml
@@ -24,9 +24,9 @@ kind: Net
 metadata:
   name: net1
 spec:
-  vpc: "vpc0"
+  vpc: "vpc1"
   vni: "0"
-  ip: "20.0.0.0"
-  spec: "16"
+  ip: "12.0.2.0"
+  prefix: "24"
   status: "Init"
   bouncers: 2

--- a/mizar/obj/tests/test_vpc.yaml
+++ b/mizar/obj/tests/test_vpc.yaml
@@ -22,9 +22,9 @@
 apiVersion: "mizar.com/v1"
 kind: Vpc
 metadata:
-  name: vpc0
+  name: vpc1
 spec:
-  ip: "10.0.0.0"
-  spec: "16"
+  ip: "12.0.0.0"
+  prefix: "16"
   status: "Init"
   dividers: 2


### PR DESCRIPTION
1. VPC vni value needs to be stored as string 
2. Fixing test yam file's spec value. 