### PR TITLE
transit agent creates and pins egress policy check maps

### DIFF
--- a/src/dmn/trn_agent_xdp_usr.h
+++ b/src/dmn/trn_agent_xdp_usr.h
@@ -68,6 +68,11 @@ struct agent_user_metadata_t {
 	int rev_flow_mod_cache_ref_fd;
 	int ep_flow_host_cache_ref_fd;
 	int ep_host_cache_ref_fd;
+	int eg_vsip_enforce_map_fd;
+	int eg_vsip_prim_map_fd;
+	int eg_vsip_ppo_map_fd;
+	int eg_vsip_supp_map_fd;
+	int eg_vsip_except_map_fd;
 
 	int fwd_flow_mod_cache_map_fd;
 	int rev_flow_mod_cache_map_fd;
@@ -83,6 +88,11 @@ struct agent_user_metadata_t {
 	struct bpf_map *ep_flow_host_cache_ref;
 	struct bpf_map *ep_host_cache_ref;
 	struct bpf_map *xdpcap_hook_map;
+	struct bpf_map *eg_vsip_enforce_map;
+	struct bpf_map *eg_vsip_prim_map;
+	struct bpf_map *eg_vsip_ppo_map;
+	struct bpf_map *eg_vsip_supp_map;
+	struct bpf_map *eg_vsip_except_map;
 
 	struct bpf_prog_info info;
 	struct bpf_object *obj;


### PR DESCRIPTION
It fixes #283 

As part of the tranist agent provisioning process, the bpf maps used by agent xdp prog should be created (or identified and reused for shared ones). 

This PR ensures following egress policy related maps being created and pinned properly, and put in the metadata atrributes:
| map name | pinned path |
| ---------------| ---------------- |
| eg_vsip_enforce_map | /sys/fs/bpf/eg_vsip_enforce_map |
| eg_vsip_prim_map | /sys/fs/bpf/eg_vsip_prim_map |
| eg_vsip_ppo_map | /sys/fs/bpf/eg_vsip_ppo_map |
| eg_vsip_supp_map | /sys/fs/bpf/eg_vsip_supp_map |
| eg_vsip_except_map | /sys/fs/bpf/eg_vsip_except_map |
