### PR TITLE
define bpf map for connection tracking

### DIFF
--- a/src/include/trn_datamodel.h
+++ b/src/include/trn_datamodel.h
@@ -167,3 +167,8 @@ struct vsip_ppo_t {
 	__u8 proto;
 	__be16 port;
 } __attribute__((packed));
+
+struct ipv4_ct_tuple_t {
+	struct vpc_key_t vpc;
+	struct ipv4_tuple_t tuple;
+} __attribute__((packed));

--- a/src/xdp/trn_transit_xdp_maps.h
+++ b/src/xdp/trn_transit_xdp_maps.h
@@ -189,3 +189,11 @@ struct bpf_map_def SEC("maps") ing_vsip_except_map = {
 	.map_flags = 1,
 };
 BPF_ANNOTATE_KV_PAIR(ing_vsip_except_map, struct vsip_cidr_t, __u64);
+
+struct bpf_map_def SEC("maps") conn_track_cache = {
+	.type = BPF_MAP_TYPE_LRU_HASH,
+	.key_size = sizeof(struct ipv4_ct_tuple_t),
+	.value_size = sizeof(__u8),
+	.max_entries = TRAN_MAX_CACHE_SIZE,
+};
+BPF_ANNOTATE_KV_PAIR(conn_track_cache, struct ipv4_ct_tuple_t, __u8);


### PR DESCRIPTION
Connection tracking will be used to allow replies of an already established TCP or UDP connection. 
This PR is the initial step in defining connection tracking bpf map. 
