### PR TITLE
transit creates ingress policy check maps

### DIFF
--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -66,11 +66,11 @@ struct ebpf_prog_stage_t {
 	int rev_flow_mod_cache_ref_fd;
 	int ep_flow_host_cache_ref_fd;
 	int ep_host_cache_ref_fd;
-        int ing_vsip_enforce_map_ref_fd;
-        int ing_vsip_prim_map_ref_fd;
-        int ing_vsip_ppo_map_ref_fd;
-        int ing_vsip_supp_map_ref_fd;
-        int ing_vsip_except_map_ref_fd;
+	int ing_vsip_enforce_map_ref_fd;
+	int ing_vsip_prim_map_ref_fd;
+	int ing_vsip_ppo_map_ref_fd;
+	int ing_vsip_supp_map_ref_fd;
+	int ing_vsip_except_map_ref_fd;
 
 	struct bpf_map *networks_map_ref;
 	struct bpf_map *vpc_map_ref;
@@ -84,11 +84,11 @@ struct ebpf_prog_stage_t {
 	struct bpf_map *rev_flow_mod_cache_ref;
 	struct bpf_map *ep_flow_host_cache_ref;
 	struct bpf_map *ep_host_cache_ref;
-        struct bpf_map *ing_vsip_enforce_map_ref;
-        struct bpf_map *ing_vsip_prim_map_ref;
-        struct bpf_map *ing_vsip_ppo_map_ref;
-        struct bpf_map *ing_vsip_supp_map_ref;
-        struct bpf_map *ing_vsip_except_map_ref;
+	struct bpf_map *ing_vsip_enforce_map_ref;
+	struct bpf_map *ing_vsip_prim_map_ref;
+	struct bpf_map *ing_vsip_ppo_map_ref;
+	struct bpf_map *ing_vsip_supp_map_ref;
+	struct bpf_map *ing_vsip_except_map_ref;
 };
 
 struct user_metadata_t {

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -66,6 +66,11 @@ struct ebpf_prog_stage_t {
 	int rev_flow_mod_cache_ref_fd;
 	int ep_flow_host_cache_ref_fd;
 	int ep_host_cache_ref_fd;
+        int ing_vsip_enforce_map_ref_fd;
+        int ing_vsip_prim_map_ref_fd;
+        int ing_vsip_ppo_map_ref_fd;
+        int ing_vsip_supp_map_ref_fd;
+        int ing_vsip_except_map_ref_fd;
 
 	struct bpf_map *networks_map_ref;
 	struct bpf_map *vpc_map_ref;
@@ -79,6 +84,11 @@ struct ebpf_prog_stage_t {
 	struct bpf_map *rev_flow_mod_cache_ref;
 	struct bpf_map *ep_flow_host_cache_ref;
 	struct bpf_map *ep_host_cache_ref;
+        struct bpf_map *ing_vsip_enforce_map_ref;
+        struct bpf_map *ing_vsip_prim_map_ref;
+        struct bpf_map *ing_vsip_ppo_map_ref;
+        struct bpf_map *ing_vsip_supp_map_ref;
+        struct bpf_map *ing_vsip_except_map_ref;
 };
 
 struct user_metadata_t {
@@ -103,6 +113,11 @@ struct user_metadata_t {
 	int rev_flow_mod_cache_fd;
 	int ep_flow_host_cache_fd;
 	int ep_host_cache_fd;
+	int ing_vsip_enforce_map_fd;
+	int ing_vsip_prim_map_fd;
+	int ing_vsip_ppo_map_fd;
+	int ing_vsip_supp_map_fd;
+	int ing_vsip_except_map_fd;
 
 	struct bpf_map *jmp_table_map;
 	struct bpf_map *networks_map;
@@ -117,6 +132,11 @@ struct user_metadata_t {
 	struct bpf_map *ep_flow_host_cache;
 	struct bpf_map *ep_host_cache;
 	struct bpf_map *xdpcap_hook_map;
+	struct bpf_map *ing_vsip_enforce_map;
+	struct bpf_map *ing_vsip_prim_map;
+	struct bpf_map *ing_vsip_ppo_map;
+	struct bpf_map *ing_vsip_supp_map;
+	struct bpf_map *ing_vsip_except_map;
 
 	struct bpf_prog_info info;
 	struct bpf_object *obj;


### PR DESCRIPTION
It closes #284 

When transit is being initialized, it needs to create all the ingress polict related maps, and pin one of them, as depicted by [mizar network policy design draft](https://docs.google.com/document/d/1zgs_iAVwU3DN72FNGU6KTGFmmM8xTiRFWjXJXz6q-R0/edit#heading=h.4adpjtdbpfw5). 

Following maps will be created, and their fds put in fields of the metadata properly:

| map name | pinned path |
| -------------- | -------------- |
| ing_vsip_enforce_map | /sys/fs/bpf/ing_vsip_enforce_map |
| ing_vsip_prim_map | |
| ing_vsip_ppo_map | |
| ing_vsip_supp_map | |
|  ing_vsip_except_map | |
