### PR TITLE
Add transit network policy delete

### DIFF
--- a/src/cli/test/module.mk
+++ b/src/cli/test/module.mk
@@ -28,6 +28,7 @@ CLI_MOCKS += -Wl,--wrap=delete_net_1
 CLI_MOCKS += -Wl,--wrap=delete_ep_1
 CLI_MOCKS += -Wl,--wrap=delete_agent_ep_1
 CLI_MOCKS += -Wl,--wrap=delete_agent_md_1
+CLI_MOCKS += -Wl,--wrap=delete_transit_network_policy_1
 CLI_MOCKS += -Wl,--wrap=setrlimit
 
 unittest:: test_cli

--- a/src/cli/trn_cli.c
+++ b/src/cli/trn_cli.c
@@ -53,6 +53,7 @@ static const struct cmd {
 	{ "load-pipeline-stage", trn_cli_load_pipeline_stage_subcmd },
 	{ "unload-pipeline-stage", trn_cli_unload_pipeline_stage_subcmd },
 	{ "update-network-policy-ingress", trn_cli_update_transit_network_policy_subcmd },
+	{ "delete-network-policy-ingress", trn_cli_delete_transit_network_policy_subcmd },
 	{ 0 },
 };
 

--- a/src/cli/trn_cli.h
+++ b/src/cli/trn_cli.h
@@ -75,6 +75,8 @@ int trn_cli_parse_ebpf_prog_stage(const cJSON *jsonobj,
 				  rpc_trn_ebpf_prog_stage_t *stage);
 int trn_cli_parse_network_policy_cidr(const cJSON *jsonobj,
 					struct rpc_trn_vsip_cidr_t *cidrval);
+int trn_cli_parse_network_policy_cidr_key(const cJSON *jsonobj,
+					  struct rpc_trn_vsip_cidr_key_t *cidrkey);
 
 int trn_cli_update_port_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_update_vpc_subcmd(CLIENT *clnt, int argc, char *argv[]);
@@ -102,6 +104,7 @@ int trn_cli_load_pipeline_stage_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_unload_pipeline_stage_subcmd(CLIENT *clnt, int argc, char *argv[]);
 
 int trn_cli_update_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *argv[]);
+int trn_cli_delete_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *argv[]);
 
 void dump_vpc(struct rpc_trn_vpc_t *vpc);
 void dump_net(struct rpc_trn_network_t *net);

--- a/src/cli/trn_cli_common.c
+++ b/src/cli/trn_cli_common.c
@@ -675,6 +675,55 @@ int trn_cli_parse_network_policy_cidr(const cJSON *jsonobj,
 	return 0;
 }
 
+int trn_cli_parse_network_policy_cidr_key(const cJSON *jsonobj,
+					  struct rpc_trn_vsip_cidr_key_t *cidrkey)
+{
+	cJSON *tunnel_id = cJSON_GetObjectItem(jsonobj, "tunnel_id");
+	cJSON *local_ip = cJSON_GetObjectItem(jsonobj, "local_ip");
+	cJSON *cidr_prefixlen = cJSON_GetObjectItem(jsonobj, "cidr_prefixlen");
+	cJSON *cidr_ip = cJSON_GetObjectItem(jsonobj, "cidr_ip");
+	cJSON *cidr_type = cJSON_GetObjectItem(jsonobj, "cidr_type");
+
+	if (tunnel_id == NULL) {
+		cidrkey->tunid = 0;
+	} else if (cJSON_IsString(tunnel_id)) {
+		cidrkey->tunid = atoi(tunnel_id->valuestring);
+	} else {
+		print_err("Error: Network policy tunnel_id is non-string.\n");
+		return -EINVAL;
+	}
+
+	if (local_ip != NULL && cJSON_IsString(local_ip)) {
+		cidrkey->local_ip = parse_ip_address(local_ip);
+	} else {
+		print_err("Error: Network policy local IP is missing or non-string\n");
+		return -EINVAL;
+	}
+
+	if (cidr_ip != NULL && cJSON_IsString(cidr_ip)) {
+		cidrkey->cidr_ip = parse_ip_address(cidr_ip);
+	} else {
+		print_err("Error: Network policy CIDR IP is missing or non-string\n");
+		return -EINVAL;
+	}
+
+	if (cJSON_IsString(cidr_prefixlen)) {
+		cidrkey->cidr_prefixlen = atoi(cidr_prefixlen->valuestring);
+	} else {
+		print_err("Error: Network policy prefixlen Error\n");
+		return -EINVAL;
+	}
+
+	if (cJSON_IsString(cidr_type)) {
+		cidrkey->cidr_type = atoi(cidr_type->valuestring);
+	} else {
+		print_err("Error: Network Policy cidr type Error\n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 uint32_t parse_ip_address(const cJSON *ipobj)
 {
 	struct sockaddr_in sa;

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1313,3 +1313,55 @@ int *update_transit_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc
 error:
 	return &result;
 }
+
+int *delete_transit_network_policy_1_svc(rpc_trn_vsip_cidr_key_t *policy_key, struct svc_req *rqstp)
+{
+	UNUSED(rqstp);
+	static int result;
+	int rc;
+	char *itf = policy_key->interface;
+	struct vsip_cidr_t cidr;
+
+	TRN_LOG_INFO("delete_transit_network_policy_1_svc service");
+
+	struct user_metadata_t *md = trn_itf_table_find(itf);
+	if (!md) {
+		TRN_LOG_ERROR("Cannot find interface metadata for %s", itf);
+		result = RPC_TRN_ERROR;
+		goto error;
+	}
+
+	cidr.tunnel_id = policy_key->tunid;
+	// Add explaination here for magic number 96
+	cidr.prefixlen = policy_key->cidr_prefixlen + 96;
+	cidr.local_ip = policy_key->local_ip;
+	cidr.remote_ip = policy_key->cidr_ip;
+
+	switch (policy_key->cidr_type) {
+	case PRIMARY:
+		rc = trn_delete_transit_network_policy_primary_map(md, &cidr);
+		break;
+	case SUPPLEMENTARY:
+		rc = trn_delete_transit_network_policy_supplementary_map(md, &cidr);
+		break;
+	case EXCEPTION:
+		rc = trn_delete_transit_network_policy_except_map(md, &cidr);
+		break;
+	default:
+		result = RPC_TRN_FATAL;
+		goto error;
+	}
+
+	if (rc != 0) {
+		TRN_LOG_ERROR("Failure deleting transit network policy map cidr: 0x%x / %d, for interface %s",
+					policy_key->cidr_ip, policy_key->cidr_prefixlen, policy_key->interface);
+		result = RPC_TRN_FATAL;
+		goto error;
+	}
+
+	result = 0;
+	return &result;
+
+error:
+	return &result;
+}

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1332,7 +1332,10 @@ int *delete_transit_network_policy_1_svc(rpc_trn_vsip_cidr_key_t *policy_key, st
 	}
 
 	cidr.tunnel_id = policy_key->tunid;
-	// Add explaination here for magic number 96
+
+	// cidr-related maps have tunnel-id(64 bits),
+	// local-ip(32 bits) prior to destination cidr;
+	// hence the final prefix length is 64+32+{cidr prefix}
 	cidr.prefixlen = policy_key->cidr_prefixlen + 96;
 	cidr.local_ip = policy_key->local_ip;
 	cidr.remote_ip = policy_key->cidr_ip;

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -619,3 +619,38 @@ int trn_update_transit_network_policy_except_map(struct user_metadata_t *md,
 	return 0;
 }
 
+int trn_delete_transit_network_policy_primary_map(struct user_metadata_t *md,
+						  struct vsip_cidr_t *cidr)
+{
+	int err = bpf_map_delete_elem(md->ing_vsip_prim_map_fd, cidr);
+	if (err) {
+		TRN_LOG_ERROR("Delete Primary ingress map failed (err:%d).",
+			      err);
+		return 1;
+	}
+	return 0;
+}
+
+int trn_delete_transit_network_policy_supplementary_map(struct user_metadata_t *md,
+							struct vsip_cidr_t *cidr)
+{
+	int err = bpf_map_delete_elem(md->ing_vsip_supp_map_fd, cidr);
+	if (err) {
+		TRN_LOG_ERROR("Delete Supplementary ingress map failed (err:%d).",
+			      err);
+		return 1;
+	}
+	return 0;
+}
+
+int trn_delete_transit_network_policy_except_map(struct user_metadata_t *md,
+						 struct vsip_cidr_t *cidr)
+{
+	int err = bpf_map_delete_elem(md->ing_vsip_except_map_fd, cidr);
+	if (err) {
+		TRN_LOG_ERROR("Delete Except ingress map failed (err:%d).",
+			      err);
+		return 1;
+	}
+	return 0;
+}

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -199,3 +199,12 @@ int trn_update_transit_network_policy_supplementary_map(struct user_metadata_t *
 int trn_update_transit_network_policy_except_map(struct user_metadata_t *md,
 						 struct vsip_cidr_t *cidr,
 						 __u64 bitmap);
+
+int trn_delete_transit_network_policy_primary_map(struct user_metadata_t *md,
+						  struct vsip_cidr_t *cidr);
+
+int trn_delete_transit_network_policy_supplementary_map(struct user_metadata_t *md,
+							struct vsip_cidr_t *cidr);
+
+int trn_delete_transit_network_policy_except_map(struct user_metadata_t *md,
+						 struct vsip_cidr_t *cidr);

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -171,6 +171,16 @@ struct rpc_trn_vsip_cidr_t {
        uint64_t bit_val;
 };
 
+/* Defines a network policy table key */
+struct rpc_trn_vsip_cidr_key_t {
+       string interface<20>;
+       uint64_t tunid;
+       uint32_t local_ip;
+       uint32_t cidr_ip;
+       uint32_t cidr_prefixlen;
+       int cidr_type;
+};
+
 /*----- Protocol. -----*/
 
 program RPC_TRANSIT_REMOTE_PROTOCOL {
@@ -204,6 +214,7 @@ program RPC_TRANSIT_REMOTE_PROTOCOL {
                 int UNLOAD_TRANSIT_XDP_PIPELINE_STAGE(rpc_trn_ebpf_prog_stage_t) = 22;
 
                 int UPDATE_TRANSIT_NETWORK_POLICY(rpc_trn_vsip_cidr_t) = 23;
+                int DELETE_TRANSIT_NETWORK_POLICY(rpc_trn_vsip_cidr_key_t) = 24;
 
           } = 1;
 


### PR DESCRIPTION
This PR partially resolves issue #270 #269 

User inputs cli command delete-network-policy-ingress to delete entries in network policy bpf maps. 

The Cli command triggers RPC call and then perform bpf map delete in transit agent. 