### PR TITLE
create and pin conntrack map

### DIFF
--- a/src/dmn/trn_agent_xdp_usr.h
+++ b/src/dmn/trn_agent_xdp_usr.h
@@ -73,6 +73,7 @@ struct agent_user_metadata_t {
 	int eg_vsip_ppo_map_fd;
 	int eg_vsip_supp_map_fd;
 	int eg_vsip_except_map_fd;
+	int conn_track_cache_fd;
 
 	int fwd_flow_mod_cache_map_fd;
 	int rev_flow_mod_cache_map_fd;
@@ -93,6 +94,7 @@ struct agent_user_metadata_t {
 	struct bpf_map *eg_vsip_ppo_map;
 	struct bpf_map *eg_vsip_supp_map;
 	struct bpf_map *eg_vsip_except_map;
+	struct bpf_map *conn_track_cache;
 
 	struct bpf_prog_info info;
 	struct bpf_object *obj;

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -71,6 +71,7 @@ struct ebpf_prog_stage_t {
 	int ing_vsip_ppo_map_ref_fd;
 	int ing_vsip_supp_map_ref_fd;
 	int ing_vsip_except_map_ref_fd;
+	int conn_track_cache_ref_fd;
 
 	struct bpf_map *networks_map_ref;
 	struct bpf_map *vpc_map_ref;
@@ -89,6 +90,7 @@ struct ebpf_prog_stage_t {
 	struct bpf_map *ing_vsip_ppo_map_ref;
 	struct bpf_map *ing_vsip_supp_map_ref;
 	struct bpf_map *ing_vsip_except_map_ref;
+	struct bpf_map *conn_track_cache_ref;
 };
 
 struct user_metadata_t {
@@ -118,6 +120,7 @@ struct user_metadata_t {
 	int ing_vsip_ppo_map_fd;
 	int ing_vsip_supp_map_fd;
 	int ing_vsip_except_map_fd;
+	int conn_track_cache_fd;
 
 	struct bpf_map *jmp_table_map;
 	struct bpf_map *networks_map;
@@ -137,6 +140,7 @@ struct user_metadata_t {
 	struct bpf_map *ing_vsip_ppo_map;
 	struct bpf_map *ing_vsip_supp_map;
 	struct bpf_map *ing_vsip_except_map;
+	struct bpf_map *conn_track_chche;
 
 	struct bpf_prog_info info;
 	struct bpf_object *obj;

--- a/src/xdp/trn_agent_xdp_maps.h
+++ b/src/xdp/trn_agent_xdp_maps.h
@@ -148,3 +148,11 @@ struct bpf_map_def SEC("maps") eg_vsip_except_map = {
 	.map_flags = 1,
 };
 BPF_ANNOTATE_KV_PAIR(eg_vsip_except_map, struct vsip_cidr_t, __u64);
+
+struct bpf_map_def SEC("maps") conn_track_cache = {
+	.type = BPF_MAP_TYPE_LRU_HASH,
+	.key_size = sizeof(struct ipv4_ct_tuple_t),
+	.value_size = sizeof(__u8),
+	.max_entries = TRAN_MAX_CACHE_SIZE,
+};
+BPF_ANNOTATE_KV_PAIR(conn_track_cache, struct ipv4_ct_tuple_t, __u8);


### PR DESCRIPTION
This closes #264

Based on mizar network policy design, connection track (conntrack in short) is one of the critical parts in network policy enforcement - it helps enfrocer xdp prog to allow reply packets. Both egress and ingress policy prog will look up the shared conntrack map, which is pinned to /sys/fs/bpf/conn_track_cache.

This PR ensures the conn_track_cache map to be created and pinned properly.  

When and how entries in this map are inserted to/updated/used, will be addressed by others PRs that are coming soon. 