### PR TITLE
insert tcp or udp connection to conn_track map

### DIFF
--- a/src/dmn/trn_agent_xdp_usr.c
+++ b/src/dmn/trn_agent_xdp_usr.c
@@ -274,7 +274,7 @@ int trn_agent_bpf_maps_init(struct agent_user_metadata_t *md)
 	    !md->ep_flow_host_cache_ref || !md->ep_host_cache_ref ||
 	    !md->eg_vsip_enforce_map || !md->eg_vsip_prim_map ||
 	    !md->eg_vsip_ppo_map || !md->eg_vsip_supp_map ||
-	    !md->eg_vsip_except_map) {
+	    !md->eg_vsip_except_map || !md->conn_track_cache) {
 		TRN_LOG_ERROR("Failure finding maps objects.");
 		return 1;
 	}

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -120,9 +120,9 @@ int trn_bpf_maps_init(struct user_metadata_t *md)
 	    !md->fwd_flow_mod_cache || !md->rev_flow_mod_cache ||
 	    !md->ep_flow_host_cache || !md->ep_host_cache ||
 	    !md->xdpcap_hook_map || !md->jmp_table_map ||
-	    !md->xdpcap_hook_map || !md->ing_vsip_ppo_map ||
-	    !md->ing_vsip_supp_map || !md->ing_vsip_except_map ||
-	    !md->conn_track_chche) {
+	    !md->ing_vsip_enforce_map || !md->ing_vsip_prim_map ||
+	    !md->ing_vsip_ppo_map || !md->ing_vsip_supp_map ||
+	    !md->ing_vsip_except_map || !md->conn_track_chche) {
 		TRN_LOG_ERROR("Failure finding maps objects.");
 		return 1;
 	}

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -119,7 +119,10 @@ int trn_bpf_maps_init(struct user_metadata_t *md)
 	    !md->interface_config_map || !md->interfaces_map ||
 	    !md->fwd_flow_mod_cache || !md->rev_flow_mod_cache ||
 	    !md->ep_flow_host_cache || !md->ep_host_cache ||
-	    !md->xdpcap_hook_map || !md->jmp_table_map) {
+	    !md->xdpcap_hook_map || !md->jmp_table_map ||
+	    !md->xdpcap_hook_map || !md->ing_vsip_ppo_map ||
+	    !md->ing_vsip_supp_map || !md->ing_vsip_except_map ||
+	    !md->conn_track_chche) {
 		TRN_LOG_ERROR("Failure finding maps objects.");
 		return 1;
 	}
@@ -507,6 +510,11 @@ int trn_user_metadata_init(struct user_metadata_t *md, char *itf,
 	int err_code;
 	if (0 != (err_code = _reuse_shared_map_if_exists(md->obj, "ing_vsip_enforce_map", ing_vsip_enforce_map_path))) {
 		TRN_LOG_INFO("failed to reuse shared map at %s, error code %d\n", ing_vsip_enforce_map_path, err_code);
+		return 1;
+	}
+
+	if (0 != (err_code = _reuse_shared_map_if_exists(md->obj, "conn_track_cache", conn_track_cache_path))) {
+		TRN_LOG_INFO("failed to reuse shared map at %s, error code %d\n", conn_track_cache_path, err_code);
 		return 1;
 	}
 

--- a/src/xdp/conntrack_common.h
+++ b/src/xdp/conntrack_common.h
@@ -26,12 +26,14 @@
 #include "trn_kern.h"
 
 __ALWAYS_INLINE__
-static inline int conntrack_insert_connection(void *conntracks, __u64 tunnel_id, const struct ipv4_tuple_t *tuple)
+static inline int conntrack_insert_tcpudp_conn(void *conntracks, __u64 tunnel_id, const struct ipv4_tuple_t *tuple)
 {
 	struct ipv4_ct_tuple_t conn = {
 		.vpc.tunnel_id = tunnel_id,
 		.tuple = *tuple,
 	};
 	__u8 value = 1;
-	return bpf_map_update_elem(conntracks, &conn, &value, 0);
+	return (tuple->protocol == IPPROTO_TCP || tuple->protocol == IPPROTO_UDP) ?
+		bpf_map_update_elem(conntracks, &conn, &value, 0) : 0;
 }
+

--- a/src/xdp/conntrack_common.h
+++ b/src/xdp/conntrack_common.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/**
+ * @file conntrack_common.h
+ * @author Hongwei Chen (@hong.chen@futurewei.com)
+ *
+ * @brief Defines common code used in conntrack feature
+ *
+ * @copyright Copyright (c) 2020 The Authors.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+#pragma once
+
+#include "trn_kern.h"
+
+__ALWAYS_INLINE__
+static inline int conntrack_insert_connection(void *conntracks, __u64 tunnel_id, const struct ipv4_tuple_t *tuple)
+{
+	struct ipv4_ct_tuple_t conn = {
+		.vpc.tunnel_id = tunnel_id,
+		.tuple = *tuple,
+	};
+	__u8 value = 1;
+	return bpf_map_update_elem(conntracks, &conn, &value, 0);
+}

--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -344,7 +344,6 @@ static __inline int enforce_egress_policy(const struct transit_packet *pkt)
 static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 {
 	pkt->inner_ip = (void *)pkt->inner_eth + pkt->inner_eth_off;
-	__u32 ipproto;
 
 	if (pkt->inner_ip + 1 > pkt->data_end) {
 		bpf_debug("[Agent:%ld.0x%x] ABORTED: Bad offset [%d]\n",
@@ -408,10 +407,10 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 				return XDP_ABORTED;
 			}
 		}
-
-		// todo: handle error in case it happens
-		conntrack_insert_connection(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple);
 	}
+
+	// todo: consider to handle error in case it happens
+	conntrack_insert_tcpudp_conn(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple);
 
 	/* Check if we need to apply a forward flow update */
 

--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -43,6 +43,7 @@
 #include "trn_datamodel.h"
 #include "trn_agent_xdp_maps.h"
 #include "trn_kern.h"
+#include "conntrack_common.h"
 
 int _version SEC("version") = 1;
 #define SPORT_MAX 6553
@@ -407,6 +408,9 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 				return XDP_ABORTED;
 			}
 		}
+
+		// todo: handle error in case it happens
+		conntrack_insert_connection(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple);
 	}
 
 	/* Check if we need to apply a forward flow update */

--- a/src/xdp/trn_transit_xdp.c
+++ b/src/xdp/trn_transit_xdp.c
@@ -45,6 +45,7 @@
 #include "trn_datamodel.h"
 #include "trn_transit_xdp_maps.h"
 #include "trn_kern.h"
+#include "conntrack_common.h"
 
 int _version SEC("version") = 1;
 
@@ -518,6 +519,9 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 				return XDP_ABORTED;
 			}
 		}
+
+		// todo: handle error in case it happens
+		conntrack_insert_connection(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple);
 	}
 
 	/* Lookup the source endpoint*/

--- a/src/xdp/trn_transit_xdp.c
+++ b/src/xdp/trn_transit_xdp.c
@@ -519,10 +519,10 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 				return XDP_ABORTED;
 			}
 		}
-
-		// todo: handle error in case it happens
-		conntrack_insert_connection(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple);
 	}
+
+	// todo: consider to handle error in case it happens
+	conntrack_insert_tcpudp_conn(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple);
 
 	/* Lookup the source endpoint*/
 	struct endpoint_t *src_ep;


### PR DESCRIPTION
It fixes #266.

As part of conn-track management, transit and agent xdp progs need to keep track of new TCP or UDP connections by saving the L4 from-initiator-to-answer  tuple in the shared conn_track_cache map.

This PR also include trivial code corrections when transit_dmn component is initializing xdp endpoints.