### PR TITLE
remove connection from conn_track when policy explicitly denies it

### DIFF
--- a/src/xdp/conntrack_common.h
+++ b/src/xdp/conntrack_common.h
@@ -37,3 +37,13 @@ static inline int conntrack_insert_tcpudp_conn(void *conntracks, __u64 tunnel_id
 		bpf_map_update_elem(conntracks, &conn, &value, 0) : 0;
 }
 
+__ALWAYS_INLINE__
+static inline int conntrack_remove_tcpudp_conn(void *conntracks, __u64 tunnel_id, const struct ipv4_tuple_t *tuple)
+{
+	struct ipv4_ct_tuple_t conn = {
+		.vpc.tunnel_id = tunnel_id,
+		.tuple = *tuple,
+	};
+	return (tuple->protocol == IPPROTO_TCP || tuple->protocol == IPPROTO_UDP) ?
+		bpf_map_delete_elem(conntracks, &conn) : 0;
+}

--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -404,6 +404,7 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 					pkt->agent_ep_tunid,
 					bpf_ntohl(pkt->agent_ep_ipv4),
 					bpf_ntohl(pkt->inner_ip->daddr));
+				conntrack_remove_tcpudp_conn(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple);
 				return XDP_ABORTED;
 			}
 		}

--- a/src/xdp/trn_transit_xdp.c
+++ b/src/xdp/trn_transit_xdp.c
@@ -512,18 +512,18 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 		if (is_ingress_enforced(tunnel_id, pkt->inner_ipv4_tuple.daddr)) {
 			if (0 != enforce_ingress_policy(tunnel_id, &pkt->inner_ipv4_tuple)) {
 				bpf_debug(
-					"[Transit:%d] ABORTED: packet to 0x%x from 0x%x ingress policy denied\n",
-					__LINE__,
+					"[Transit:vpc 0x%lx] ABORTED: packet to 0x%x from 0x%x ingress policy denied\n",
+					tunnel_id,
 					bpf_ntohl(pkt->inner_ipv4_tuple.daddr),
 					bpf_ntohl(pkt->inner_ipv4_tuple.saddr));
-				conntrack_remove_tcpudp_conn(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple);
+				conntrack_remove_tcpudp_conn(&conn_track_cache, tunnel_id, &pkt->inner_ipv4_tuple);
 				return XDP_ABORTED;
 			}
 		}
 	}
 
 	// todo: consider to handle error in case it happens
-	conntrack_insert_tcpudp_conn(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple);
+	conntrack_insert_tcpudp_conn(&conn_track_cache, tunnel_id, &pkt->inner_ipv4_tuple);
 
 	/* Lookup the source endpoint*/
 	struct endpoint_t *src_ep;

--- a/src/xdp/trn_transit_xdp.c
+++ b/src/xdp/trn_transit_xdp.c
@@ -516,6 +516,7 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 					__LINE__,
 					bpf_ntohl(pkt->inner_ipv4_tuple.daddr),
 					bpf_ntohl(pkt->inner_ipv4_tuple.saddr));
+				conntrack_remove_tcpudp_conn(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple);
 				return XDP_ABORTED;
 			}
 		}


### PR DESCRIPTION
This fixes #303.

According to mizar network policy and connection track related design, whenever a packet is decided to block based on policy check, conn_track map should remove it if it was tracked before.

Transit program should use the tunnel id(VPC) wrapped in Geneve header, not the one as part of endpoint metadata (as agent does).