### PR TITLE
update network policy enforcement transit map

### DIFF
--- a/src/cli/test/module.mk
+++ b/src/cli/test/module.mk
@@ -14,6 +14,7 @@ CLI_MOCKS += -Wl,--wrap=update_ep_1
 CLI_MOCKS += -Wl,--wrap=update_agent_ep_1
 CLI_MOCKS += -Wl,--wrap=update_agent_md_1
 CLI_MOCKS += -Wl,--wrap=update_transit_network_policy_1
+CLI_MOCKS += -Wl,--wrap=update_transit_network_policy_enforcement_1
 CLI_MOCKS += -Wl,--wrap=load_transit_xdp_1
 CLI_MOCKS += -Wl,--wrap=unload_transit_xdp_1
 CLI_MOCKS += -Wl,--wrap=load_transit_agent_xdp_1

--- a/src/cli/trn_cli.c
+++ b/src/cli/trn_cli.c
@@ -54,6 +54,7 @@ static const struct cmd {
 	{ "unload-pipeline-stage", trn_cli_unload_pipeline_stage_subcmd },
 	{ "update-network-policy-ingress", trn_cli_update_transit_network_policy_subcmd },
 	{ "delete-network-policy-ingress", trn_cli_delete_transit_network_policy_subcmd },
+	{ "update-network-policy-enforcement-ingress", trn_cli_update_transit_network_policy_enforcement_subcmd },
 	{ 0 },
 };
 

--- a/src/cli/trn_cli.h
+++ b/src/cli/trn_cli.h
@@ -77,6 +77,8 @@ int trn_cli_parse_network_policy_cidr(const cJSON *jsonobj,
 					struct rpc_trn_vsip_cidr_t *cidrval);
 int trn_cli_parse_network_policy_cidr_key(const cJSON *jsonobj,
 					  struct rpc_trn_vsip_cidr_key_t *cidrkey);
+int trn_cli_parse_network_policy_enforcement(const cJSON *jsonobj,
+					     struct rpc_trn_vsip_enforce_t *enforce);
 
 int trn_cli_update_port_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_update_vpc_subcmd(CLIENT *clnt, int argc, char *argv[]);
@@ -105,6 +107,7 @@ int trn_cli_unload_pipeline_stage_subcmd(CLIENT *clnt, int argc, char *argv[]);
 
 int trn_cli_update_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_delete_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *argv[]);
+int trn_cli_update_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int argc, char *argv[]);
 
 void dump_vpc(struct rpc_trn_vpc_t *vpc);
 void dump_net(struct rpc_trn_network_t *net);
@@ -112,4 +115,5 @@ void dump_ep(struct rpc_trn_endpoint_t *ep);
 void dump_port(struct rpc_trn_port_t *port);
 void dump_agent_md(struct rpc_trn_agent_metadata_t *agent_md);
 void dump_network_policy(struct rpc_trn_vsip_cidr_t *policy);
+void dump_enforced_policy(struct rpc_trn_vsip_enforce_t *enforce);
 uint32_t parse_ip_address(const cJSON *ipobj);

--- a/src/cli/trn_cli_common.c
+++ b/src/cli/trn_cli_common.c
@@ -724,6 +724,31 @@ int trn_cli_parse_network_policy_cidr_key(const cJSON *jsonobj,
 	return 0;
 }
 
+int trn_cli_parse_network_policy_enforcement(const cJSON *jsonobj,
+					     struct rpc_trn_vsip_enforce_t *enforce)
+{
+	cJSON *tunnel_id = cJSON_GetObjectItem(jsonobj, "tunnel_id");
+	cJSON *ip = cJSON_GetObjectItem(jsonobj, "ip");
+
+	if (tunnel_id == NULL) {
+		enforce->tunid = 0;
+	} else if (cJSON_IsString(tunnel_id)) {
+		enforce->tunid = atoi(tunnel_id->valuestring);
+	} else {
+		print_err("Error: Network policy enforcement tunnel_id is non-string.\n");
+		return -EINVAL;
+	}
+
+	if (ip != NULL && cJSON_IsString(ip)) {
+		enforce->local_ip = parse_ip_address(ip);
+	} else {
+		print_err("Error: Network policy enforcement local IP is missing or non-string\n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 uint32_t parse_ip_address(const cJSON *ipobj)
 {
 	struct sockaddr_in sa;

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -638,6 +638,24 @@ static void test_delete_transit_network_policy_1_svc(void **state)
 	assert_int_equal(*rc, RPC_TRN_ERROR);
 }
 
+static void test_update_transit_network_policy_enforcement_1_svc(void **state)
+{
+	UNUSED(state);
+
+	char itf[] = "lo";
+
+	struct rpc_trn_vsip_enforce_t enforce1 = {
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x100000a
+	};
+
+	int *rc;
+	expect_function_call(__wrap_bpf_map_update_elem);
+	rc = update_transit_network_policy_enforcement_1_svc(&enforce1, NULL);
+	assert_int_equal(*rc, 0);
+}
+
 static void test_get_vpc_1_svc(void **state)
 {
 	UNUSED(state);
@@ -1232,7 +1250,8 @@ int main()
 		cmocka_unit_test(test_delete_agent_ep_1_svc),
 		cmocka_unit_test(test_delete_agent_md_1_svc),
 		cmocka_unit_test(test_update_transit_network_policy_1_svc),
-		cmocka_unit_test(test_delete_transit_network_policy_1_svc)
+		cmocka_unit_test(test_delete_transit_network_policy_1_svc),
+		cmocka_unit_test(test_update_transit_network_policy_enforcement_1_svc)
 	};
 
 	int result = cmocka_run_group_tests(tests, groupSetup, groupTeardown);

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1368,3 +1368,41 @@ int *delete_transit_network_policy_1_svc(rpc_trn_vsip_cidr_key_t *policy_key, st
 error:
 	return &result;
 }
+
+int *update_transit_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *enforce, struct svc_req *rqstp)
+{
+	UNUSED(rqstp);
+	static int result;
+	int rc;
+	char *itf = enforce->interface;
+	struct vsip_enforce_t enf;
+	__u8 val;
+
+	TRN_LOG_INFO("update_transit_network_policy_enforcement_1_svc service");
+
+	struct user_metadata_t *md = trn_itf_table_find(itf);
+	if (!md) {
+		TRN_LOG_ERROR("Cannot find interface metadata for %s", itf);
+		result = RPC_TRN_ERROR;
+		goto error;
+	}
+
+	enf.tunnel_id = enforce->tunid;
+	enf.local_ip = enforce->local_ip;
+	val = 1;
+
+	rc = trn_update_transit_network_policy_enforcement_map(md, &enf, val);
+
+	if (rc != 0) {
+		TRN_LOG_ERROR("Failure updating transit network policy enforcement map ip address: 0x%x, for interface %s",
+					enforce->local_ip, enforce->interface);
+		result = RPC_TRN_FATAL;
+		goto error;
+	}
+
+	result = 0;
+	return &result;
+
+error:
+	return &result;
+}

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -668,3 +668,17 @@ int trn_delete_transit_network_policy_except_map(struct user_metadata_t *md,
 	}
 	return 0;
 }
+
+int trn_update_transit_network_policy_enforcement_map(struct user_metadata_t *md,
+						      struct vsip_enforce_t *local,
+						      __u8 isenforce)
+{
+	int err = bpf_map_update_elem(md->ing_vsip_enforce_map_fd, local, &isenforce, 0);
+
+	if (err) {
+		TRN_LOG_ERROR("Update Enforcement ingress map failed (err:%d).",
+				err);
+		return 1;
+	}
+	return 0;
+}

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -212,3 +212,7 @@ int trn_delete_transit_network_policy_supplementary_map(struct user_metadata_t *
 
 int trn_delete_transit_network_policy_except_map(struct user_metadata_t *md,
 						 struct vsip_cidr_t *cidr);
+
+int trn_update_transit_network_policy_enforcement_map(struct user_metadata_t *md,
+						      struct vsip_enforce_t *local,
+						      __u8 isenforce);

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -181,6 +181,13 @@ struct rpc_trn_vsip_cidr_key_t {
        int cidr_type;
 };
 
+/* Defines a network policy enforcement table key */
+struct rpc_trn_vsip_enforce_t {
+       string interface<20>;
+	uint64_t tunid;
+	uint32_t local_ip;
+};
+
 /*----- Protocol. -----*/
 
 program RPC_TRANSIT_REMOTE_PROTOCOL {
@@ -215,6 +222,7 @@ program RPC_TRANSIT_REMOTE_PROTOCOL {
 
                 int UPDATE_TRANSIT_NETWORK_POLICY(rpc_trn_vsip_cidr_t) = 23;
                 int DELETE_TRANSIT_NETWORK_POLICY(rpc_trn_vsip_cidr_key_t) = 24;
+                int UPDATE_TRANSIT_NETWORK_POLICY_ENFORCEMENT(rpc_trn_vsip_enforce_t) = 25;
 
           } = 1;
 


### PR DESCRIPTION
This PR partially resolves issue #270 #269

User inputs cli update-network-policy-enforcement-ingress to update entries in network policy enforcement bpf maps.
If Enforcement = 1, means pod / ep is enforced by network policy

The Cli command triggers RPC call and then perform bpf map update in transit agent.