### PR TITLE
conn_track: add is_reply function to check a packet being reply of a tracked connection or not

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ CLANGFLAGS= -I.\
 			-Wno-compare-distinct-pointer-types \
 			-Wno-gnu-variable-sized-type-not-at-end \
 			-Wno-address-of-packed-member -Wno-tautological-compare \
-			-Wno-unknown-warning-option -O3 -emit-llvm -c -o -
+			-Wno-unknown-warning-option -O1 -emit-llvm -c -o -
 
 CLANGFLAGS_DEBUG:= -DDEBUG -D__KERNEL__ -g -D__BPF_TRACING__ $(CLANGFLAGS)
 

--- a/src/extern/jhash.h
+++ b/src/extern/jhash.h
@@ -4,6 +4,7 @@
  * can compile it into valid sequence of bpf instructions
  */
 
+__ALWAYS_INLINE__
 static inline __u32 rol32(__u32 word, unsigned int shift)
 {
   return (word << shift) | (word >> ((-shift) & 31));
@@ -34,6 +35,7 @@ static inline __u32 rol32(__u32 word, unsigned int shift)
 
 typedef unsigned int u32;
 
+__ALWAYS_INLINE__
 static inline u32 jhash(const void *key, u32 length, u32 initval)
 {
   u32 a, b, c;
@@ -70,6 +72,7 @@ static inline u32 jhash(const void *key, u32 length, u32 initval)
   return c;
 }
 
+__ALWAYS_INLINE__
 static inline u32 __jhash_nwords(u32 a, u32 b, u32 c, u32 initval)
 {
   a += initval;
@@ -79,6 +82,7 @@ static inline u32 __jhash_nwords(u32 a, u32 b, u32 c, u32 initval)
   return c;
 }
 
+__ALWAYS_INLINE__
 static inline u32 jhash_2words(u32 a, u32 b, u32 initval)
 {
   return __jhash_nwords(a, b, 0, initval + JHASH_INITVAL + (2 << 2));

--- a/src/xdp/conntrack_common.h
+++ b/src/xdp/conntrack_common.h
@@ -47,3 +47,19 @@ static inline int conntrack_remove_tcpudp_conn(void *conntracks, __u64 tunnel_id
 	return (tuple->protocol == IPPROTO_TCP || tuple->protocol == IPPROTO_UDP) ?
 		bpf_map_delete_elem(conntracks, &conn) : 0;
 }
+
+__ALWAYS_INLINE__
+static inline int conntrack_is_reply_of_tracked_conn(void *conntracks, __u64 tunnel_id, const struct ipv4_tuple_t *tuple)
+{
+	struct ipv4_ct_tuple_t rev_conn = {
+		.vpc.tunnel_id = tunnel_id,
+		.tuple = {
+			.protocol = tuple->protocol,
+			.saddr = tuple->daddr,
+			.daddr = tuple->saddr,
+			.sport = tuple->dport,
+			.dport = tuple->sport,
+		},
+	};
+	return NULL != bpf_map_lookup_elem(conntracks, &rev_conn);
+}

--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -398,6 +398,9 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 
 	// todo: add conn_track related logic properly
 	if (pkt->inner_ipv4_tuple.protocol == IPPROTO_TCP || pkt->inner_ipv4_tuple.protocol == IPPROTO_UDP) {
+		if (conntrack_is_reply_of_tracked_conn(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple))
+			goto xdp_continue;
+
 		if (is_egress_enforced(pkt->agent_ep_tunid, pkt->inner_ip->saddr)) {
 			if (0 != enforce_egress_policy(pkt)) {
 				bpf_debug("[Agent:%ld.0x%x] ABORTED: packet to 0x%x egress policy denied\n",
@@ -417,6 +420,7 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 
 	struct ipv4_tuple_t in_tuple;
 	struct scaled_endpoint_remote_t *out_tuple;
+xdp_continue:
 	__builtin_memcpy(&in_tuple, &pkt->inner_ipv4_tuple,
 			 sizeof(struct ipv4_tuple_t));
 

--- a/src/xdp/trn_kern.h
+++ b/src/xdp/trn_kern.h
@@ -193,6 +193,7 @@ static __be64 trn_vni_to_tunnel_id(const __u8 *vni)
 	return (vni[0] << 16) | (vni[1] << 8) | vni[2];
 }
 
+__ALWAYS_INLINE__
 static void trn_tunnel_id_to_vni(__be64 tun_id, __u8 *vni)
 {
 	/* Big endian! */

--- a/src/xdp/trn_transit_xdp.c
+++ b/src/xdp/trn_transit_xdp.c
@@ -509,6 +509,9 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 
 	// todo: add conn_track related logic properly
 	if (pkt->inner_ipv4_tuple.protocol == IPPROTO_TCP || pkt->inner_ipv4_tuple.protocol == IPPROTO_UDP) {
+		if (conntrack_is_reply_of_tracked_conn(&conn_track_cache, tunnel_id, &pkt->inner_ipv4_tuple))
+			goto xdp_continue;
+
 		if (is_ingress_enforced(tunnel_id, pkt->inner_ipv4_tuple.daddr)) {
 			if (0 != enforce_ingress_policy(tunnel_id, &pkt->inner_ipv4_tuple)) {
 				bpf_debug(
@@ -528,7 +531,7 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 	/* Lookup the source endpoint*/
 	struct endpoint_t *src_ep;
 	struct endpoint_key_t src_epkey;
-
+xdp_continue:
 	__builtin_memcpy(&src_epkey.tunip[0], &tunnel_id, sizeof(tunnel_id));
 	src_epkey.tunip[2] = pkt->inner_ip->saddr;
 	src_ep = bpf_map_lookup_elem(&endpoints_map, &src_epkey);


### PR DESCRIPTION
It fixes #265.

Functio to check a packet is reply flow of a known tracked connection is the key to proper policy enforcement. This PR provides the basic implementation.

Also, this PR includes changes that lowers compiler optimization level to -O1. This -O1 change is necessary; the generted bpf code is having difficulty to passs the verifier when -O2/-O3 is used (this is a well known issue of BPF code).