### PR TITLE
Delete transit network policy enforcement map

### DIFF
--- a/src/cli/test/module.mk
+++ b/src/cli/test/module.mk
@@ -30,6 +30,7 @@ CLI_MOCKS += -Wl,--wrap=delete_ep_1
 CLI_MOCKS += -Wl,--wrap=delete_agent_ep_1
 CLI_MOCKS += -Wl,--wrap=delete_agent_md_1
 CLI_MOCKS += -Wl,--wrap=delete_transit_network_policy_1
+CLI_MOCKS += -Wl,--wrap=delete_transit_network_policy_enforcement_1
 CLI_MOCKS += -Wl,--wrap=setrlimit
 
 unittest:: test_cli

--- a/src/cli/trn_cli.c
+++ b/src/cli/trn_cli.c
@@ -55,6 +55,7 @@ static const struct cmd {
 	{ "update-network-policy-ingress", trn_cli_update_transit_network_policy_subcmd },
 	{ "delete-network-policy-ingress", trn_cli_delete_transit_network_policy_subcmd },
 	{ "update-network-policy-enforcement-ingress", trn_cli_update_transit_network_policy_enforcement_subcmd },
+	{ "delete-network-policy-enforcement-ingress", trn_cli_delete_transit_network_policy_enforcement_subcmd },
 	{ 0 },
 };
 

--- a/src/cli/trn_cli.h
+++ b/src/cli/trn_cli.h
@@ -108,6 +108,7 @@ int trn_cli_unload_pipeline_stage_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_update_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_delete_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_update_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int argc, char *argv[]);
+int trn_cli_delete_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int argc, char *argv[]);
 
 void dump_vpc(struct rpc_trn_vpc_t *vpc);
 void dump_net(struct rpc_trn_network_t *net);

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1406,3 +1406,39 @@ int *update_transit_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *enf
 error:
 	return &result;
 }
+
+int *delete_transit_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *enforce, struct svc_req *rqstp)
+{
+	UNUSED(rqstp);
+	static int result;
+	int rc;
+	char *itf = enforce->interface;
+	struct vsip_enforce_t enf;
+
+	TRN_LOG_INFO("delete_transit_network_policy_enforcement_1_svc service");
+
+	struct user_metadata_t *md = trn_itf_table_find(itf);
+	if (!md) {
+		TRN_LOG_ERROR("Cannot find interface metadata for %s", itf);
+		result = RPC_TRN_ERROR;
+		goto error;
+	}
+
+	enf.tunnel_id = enforce->tunid;
+	enf.local_ip = enforce->local_ip;
+
+	rc = trn_delete_transit_network_policy_enforcement_map(md, &enf);
+
+	if (rc != 0) {
+		TRN_LOG_ERROR("Failure deleting transit network policy enforcement map ip address: 0x%x, for interface %s",
+					enforce->local_ip, enforce->interface);
+		result = RPC_TRN_FATAL;
+		goto error;
+	}
+
+	result = 0;
+	return &result;
+
+error:
+	return &result;
+}

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -682,3 +682,16 @@ int trn_update_transit_network_policy_enforcement_map(struct user_metadata_t *md
 	}
 	return 0;
 }
+
+int trn_delete_transit_network_policy_enforcement_map(struct user_metadata_t *md,
+						      struct vsip_enforce_t *local)
+{
+	int err = bpf_map_delete_elem(md->ing_vsip_enforce_map_fd, local);
+
+	if (err) {
+		TRN_LOG_ERROR("Delete Enforcement ingress map failed (err:%d).",
+				err);
+		return 1;
+	}
+	return 0;
+}

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -216,3 +216,6 @@ int trn_delete_transit_network_policy_except_map(struct user_metadata_t *md,
 int trn_update_transit_network_policy_enforcement_map(struct user_metadata_t *md,
 						      struct vsip_enforce_t *local,
 						      __u8 isenforce);
+
+int trn_delete_transit_network_policy_enforcement_map(struct user_metadata_t *md,
+						      struct vsip_enforce_t *local);

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -223,6 +223,7 @@ program RPC_TRANSIT_REMOTE_PROTOCOL {
                 int UPDATE_TRANSIT_NETWORK_POLICY(rpc_trn_vsip_cidr_t) = 23;
                 int DELETE_TRANSIT_NETWORK_POLICY(rpc_trn_vsip_cidr_key_t) = 24;
                 int UPDATE_TRANSIT_NETWORK_POLICY_ENFORCEMENT(rpc_trn_vsip_enforce_t) = 25;
+                int DELETE_TRANSIT_NETWORK_POLICY_ENFORCEMENT(rpc_trn_vsip_enforce_t) = 26;
 
           } = 1;
 


### PR DESCRIPTION
This PR partially resolves issue #270 #269

User inputs cli delete-network-policy-enforcement-ingress to delete entries in network policy enforcement bpf maps.

The Cli command triggers RPC call and then perform bpf map delete in transit agent.