### PR TITLE
Adding install iproute2 for deployment error

### DIFF
--- a/etc/docker/daemon.Dockerfile
+++ b/etc/docker/daemon.Dockerfile
@@ -21,5 +21,6 @@
 
 FROM fwnetworking/python_base:latest
 COPY . /var/mizar/
+RUN apt-get install -y iproute2
 RUN pip3 install /var/mizar/
 CMD mizard

--- a/etc/docker/python_base.Dockerfile
+++ b/etc/docker/python_base.Dockerfile
@@ -23,6 +23,7 @@ FROM python:3.7
 RUN apt-get update -y
 RUN apt-get install -y net-tools
 RUN apt-get install -y ethtool
+RUN apt-get install -y iproute2
 RUN apt-get install -y sudo
 RUN pip3 install PyYAML
 RUN pip3 install kopf


### PR DESCRIPTION
This fixes issue #296 

Adding iproute2 installation which will satisfy missing ip tool
