### PR TITLE
update transit network policy protocol port maps

### DIFF
--- a/src/cli/test/module.mk
+++ b/src/cli/test/module.mk
@@ -15,6 +15,7 @@ CLI_MOCKS += -Wl,--wrap=update_agent_ep_1
 CLI_MOCKS += -Wl,--wrap=update_agent_md_1
 CLI_MOCKS += -Wl,--wrap=update_transit_network_policy_1
 CLI_MOCKS += -Wl,--wrap=update_transit_network_policy_enforcement_1
+CLI_MOCKS += -Wl,--wrap=update_transit_network_policy_protocol_port_1
 CLI_MOCKS += -Wl,--wrap=load_transit_xdp_1
 CLI_MOCKS += -Wl,--wrap=unload_transit_xdp_1
 CLI_MOCKS += -Wl,--wrap=load_transit_agent_xdp_1

--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -152,6 +152,15 @@ int *__wrap_delete_transit_network_policy_enforcement_1(rpc_trn_vsip_enforce_t *
 	return retval;
 }
 
+int *__wrap_update_transit_network_policy_protocol_port_1(rpc_trn_vsip_ppo_t *ppo, CLIENT *clnt)
+{
+	check_expected_ptr(ppo);
+	check_expected_ptr(clnt);
+	int *retval = mock_ptr_type(int *);
+	function_called();
+	return retval;
+}
+
 rpc_trn_vpc_t *__wrap_get_vpc_1(rpc_trn_vpc_key_t *argp, CLIENT *clnt)
 {
 	check_expected_ptr(argp);
@@ -598,6 +607,40 @@ static int check_policy_enforcement_equal(const LargestIntegralType value,
 	}
 
 	if (enforce->local_ip != c_enforce->local_ip) {
+		return false;
+	}
+
+	return true;
+}
+
+static int check_policy_protocol_port_equal(const LargestIntegralType value,
+					    const LargestIntegralType check_value_data)
+{
+	struct rpc_trn_vsip_ppo_t *policy = (struct rpc_trn_vsip_ppo_t *)value;
+	struct rpc_trn_vsip_ppo_t *c_policy =
+		(struct rpc_trn_vsip_ppo_t *)check_value_data;
+
+	if (strcmp(policy->interface, c_policy->interface) != 0) {
+		return false;
+	}
+
+	if (policy->tunid != c_policy->tunid) {
+		return false;
+	}
+
+	if (policy->local_ip != c_policy->local_ip) {
+		return false;
+	}
+
+	if (policy->proto != c_policy->proto) {
+		return false;
+	}
+
+	if (policy->port != c_policy->port) {
+		return false;
+	}
+
+	if (policy->bit_val != c_policy->bit_val) {
 		return false;
 	}
 
@@ -2347,6 +2390,88 @@ static void test_trn_cli_delete_transit_network_policy_enforcement_subcmd(void *
 	assert_int_equal(rc, -EINVAL);
 }
 
+static void test_trn_cli_update_transit_network_policy_protocol_port_subcmd(void **state)
+{
+	UNUSED(state);
+	int rc;
+	int argc = 5;
+	int update_transit_network_policy_proto_port_1_ret_val = 0;
+
+	/* Test cases */
+	char *argv1[] = { "update-network-policy-ingress", "-i", "eth0", "-j", QUOTE({
+				  "tunnel_id": "3",
+				  "local_ip": "10.0.0.3",
+				  "protocol": "6",
+				  "port": "6379",
+				  "bit_value": "10"
+			  }) };
+
+	char *argv2[] = { "update-network-policy-ingress", "-i", "eth0", "-j", QUOTE({
+				  "tunnel_id": 3,
+				  "local_ip": "10.0.0.3",
+				  "protocol": "6",
+				  "port": "6379",
+				  "bit_value": "10"
+			  }) };
+
+	char *argv3[] = { "update-network-policy-ingress", "-i", "eth0", "-j", QUOTE({
+				  "tunnel_id": "3",
+				  "local_ip": 10.0.0.3,
+				  "protocol": "6",
+				  "port": "6379",
+				  "bit_value": "10"
+			  }) };
+	char itf[] = "eth0";
+
+	struct rpc_trn_vsip_ppo_t exp_ppo = {
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x300000a,
+		.proto = 6,
+		.port = 6379,
+		.bit_val = 10
+	};
+
+	/* Test call update_transit_network_policy successfully */
+	TEST_CASE("update_transit_network_policy_protocol_port succeed with well formed policy json input");
+	update_transit_network_policy_proto_port_1_ret_val = 0;
+	expect_function_call(__wrap_update_transit_network_policy_protocol_port_1);
+	will_return(__wrap_update_transit_network_policy_protocol_port_1, &update_transit_network_policy_proto_port_1_ret_val);
+	expect_check(__wrap_update_transit_network_policy_protocol_port_1, ppo, check_policy_protocol_port_equal, &exp_ppo);
+	expect_any(__wrap_update_transit_network_policy_protocol_port_1, clnt);
+	rc = trn_cli_update_transit_network_policy_protocol_port_subcmd(NULL, argc, argv1);
+	assert_int_equal(rc, 0);
+
+	/* Test parse network policy input error*/
+	TEST_CASE("update_transit_network_policy_protocol_port is not called with non-string field");
+	rc = trn_cli_update_transit_network_policy_protocol_port_subcmd(NULL, argc, argv2);
+	assert_int_equal(rc, -EINVAL);
+
+	/* Test parse network policy input error 2*/
+	TEST_CASE("update_transit_network_policy_protocol_port is not called malformed json");
+	rc = trn_cli_update_transit_network_policy_protocol_port_subcmd(NULL, argc, argv3);
+	assert_int_equal(rc, -EINVAL);
+
+	/* Test call update_transit_network_policy_1 return error*/
+	TEST_CASE("update_transit_network_policy_protocol_port subcommand fails if update_transit_network_policy_protocol_port_1 returns error");
+	update_transit_network_policy_proto_port_1_ret_val = -EINVAL;
+	expect_function_call(__wrap_update_transit_network_policy_protocol_port_1);
+	will_return(__wrap_update_transit_network_policy_protocol_port_1, &update_transit_network_policy_proto_port_1_ret_val);
+	expect_any(__wrap_update_transit_network_policy_protocol_port_1, ppo);
+	expect_any(__wrap_update_transit_network_policy_protocol_port_1, clnt);
+	rc = trn_cli_update_transit_network_policy_protocol_port_subcmd(NULL, argc, argv1);
+	assert_int_equal(rc, -EINVAL);
+
+	/* Test call update_transit_network_policy_1 return NULL*/
+	TEST_CASE("update-network-policy-ingress subcommand fails if update_transit_network_policy_1 returns NULL");
+	expect_function_call(__wrap_update_transit_network_policy_protocol_port_1);
+	will_return(__wrap_update_transit_network_policy_protocol_port_1, NULL);
+	expect_any(__wrap_update_transit_network_policy_protocol_port_1, ppo);
+	expect_any(__wrap_update_transit_network_policy_protocol_port_1, clnt);
+	rc = trn_cli_update_transit_network_policy_protocol_port_subcmd(NULL, argc, argv1);
+	assert_int_equal(rc, -EINVAL);
+}
+
 int main()
 {
 	const struct CMUnitTest tests[] = {
@@ -2372,7 +2497,8 @@ int main()
 		cmocka_unit_test(test_trn_cli_update_transit_network_policy_subcmd),
 		cmocka_unit_test(test_trn_cli_delete_transit_network_policy_subcmd),
 		cmocka_unit_test(test_trn_cli_update_transit_network_policy_enforcement_subcmd),
-		cmocka_unit_test(test_trn_cli_delete_transit_network_policy_enforcement_subcmd)
+		cmocka_unit_test(test_trn_cli_delete_transit_network_policy_enforcement_subcmd),
+		cmocka_unit_test(test_trn_cli_update_transit_network_policy_protocol_port_subcmd)
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/cli/trn_cli.h
+++ b/src/cli/trn_cli.h
@@ -79,6 +79,8 @@ int trn_cli_parse_network_policy_cidr_key(const cJSON *jsonobj,
 					  struct rpc_trn_vsip_cidr_key_t *cidrkey);
 int trn_cli_parse_network_policy_enforcement(const cJSON *jsonobj,
 					     struct rpc_trn_vsip_enforce_t *enforce);
+int trn_cli_parse_network_policy_protocol_port(const cJSON *jsonobj,
+					       struct rpc_trn_vsip_ppo_t *ppo);
 
 int trn_cli_update_port_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_update_vpc_subcmd(CLIENT *clnt, int argc, char *argv[]);
@@ -109,6 +111,7 @@ int trn_cli_update_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *a
 int trn_cli_delete_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_update_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_delete_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int argc, char *argv[]);
+int trn_cli_update_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int argc, char *argv[]);
 
 void dump_vpc(struct rpc_trn_vpc_t *vpc);
 void dump_net(struct rpc_trn_network_t *net);
@@ -117,4 +120,5 @@ void dump_port(struct rpc_trn_port_t *port);
 void dump_agent_md(struct rpc_trn_agent_metadata_t *agent_md);
 void dump_network_policy(struct rpc_trn_vsip_cidr_t *policy);
 void dump_enforced_policy(struct rpc_trn_vsip_enforce_t *enforce);
+void dump_protocol_port_policy(struct rpc_trn_vsip_ppo_t *ppo);
 uint32_t parse_ip_address(const cJSON *ipobj);

--- a/src/cli/trn_cli_common.c
+++ b/src/cli/trn_cli_common.c
@@ -749,6 +749,55 @@ int trn_cli_parse_network_policy_enforcement(const cJSON *jsonobj,
 	return 0;
 }
 
+int trn_cli_parse_network_policy_protocol_port(const cJSON *jsonobj,
+				      	       struct rpc_trn_vsip_ppo_t *ppo)
+{
+	cJSON *tunnel_id = cJSON_GetObjectItem(jsonobj, "tunnel_id");
+	cJSON *local_ip = cJSON_GetObjectItem(jsonobj, "local_ip");
+	cJSON *protocol = cJSON_GetObjectItem(jsonobj, "protocol");
+	cJSON *port = cJSON_GetObjectItem(jsonobj, "port");
+	cJSON *bit_val = cJSON_GetObjectItem(jsonobj, "bit_value");
+
+	if (tunnel_id == NULL) {
+		ppo->tunid = 0;
+	} else if (cJSON_IsString(tunnel_id)) {
+		ppo->tunid = atoi(tunnel_id->valuestring);
+	} else {
+		print_err("Error: Network policy tunnel_id is non-string.\n");
+		return -EINVAL;
+	}
+
+	if (local_ip != NULL && cJSON_IsString(local_ip)) {
+		ppo->local_ip = parse_ip_address(local_ip);
+	} else {
+		print_err("Error: Network policy local IP is missing or non-string\n");
+		return -EINVAL;
+	}
+
+	if (cJSON_IsString(protocol)) {
+		ppo->proto = atoi(protocol->valuestring);
+	} else {
+		print_err("Error: Network policy protocol Error\n");
+		return -EINVAL;
+	}
+
+	if (cJSON_IsString(port)) {
+		ppo->port = atoi(port->valuestring);
+	} else {
+		print_err("Error: Network policy port Error\n");
+		return -EINVAL;
+	}
+
+	if (cJSON_IsString(bit_val)) {
+		ppo->bit_val = atoi(bit_val->valuestring);
+	} else {
+		print_err("Error: Network policy bit map Error\n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 uint32_t parse_ip_address(const cJSON *ipobj)
 {
 	struct sockaddr_in sa;

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -686,6 +686,26 @@ static void test_delete_transit_network_policy_enforcement_1_svc(void **state)
 	assert_int_equal(*rc, RPC_TRN_ERROR);
 }
 
+static void test_update_transit_network_policy_protocol_port_1_svc(void **state)
+{
+	UNUSED(state);
+	char itf[] = "lo";
+
+	struct rpc_trn_vsip_ppo_t ppo1 = {
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x300000a,
+		.proto = 6,
+		.port = 6379,
+		.bit_val = 10
+	};
+
+	int *rc;
+	expect_function_call(__wrap_bpf_map_update_elem);
+	rc = update_transit_network_policy_protocol_port_1_svc(&ppo1, NULL);
+	assert_int_equal(*rc, 0);
+}
+
 static void test_get_vpc_1_svc(void **state)
 {
 	UNUSED(state);
@@ -1282,7 +1302,8 @@ int main()
 		cmocka_unit_test(test_update_transit_network_policy_1_svc),
 		cmocka_unit_test(test_delete_transit_network_policy_1_svc),
 		cmocka_unit_test(test_update_transit_network_policy_enforcement_1_svc),
-		cmocka_unit_test(test_delete_transit_network_policy_enforcement_1_svc)
+		cmocka_unit_test(test_delete_transit_network_policy_enforcement_1_svc),
+		cmocka_unit_test(test_update_transit_network_policy_protocol_port_1_svc)
 	};
 
 	int result = cmocka_run_group_tests(tests, groupSetup, groupTeardown);

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1442,3 +1442,42 @@ int *delete_transit_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *enf
 error:
 	return &result;
 }
+
+int *update_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_t *ppo, struct svc_req *rqstp)
+{
+	UNUSED(rqstp);
+	static int result;
+	int rc;
+	char *itf = ppo->interface;
+	struct vsip_ppo_t policy;
+
+	TRN_LOG_INFO("update_transit_network_policy_protocol_port_1_svc service");
+
+	struct user_metadata_t *md = trn_itf_table_find(itf);
+	if (!md) {
+		TRN_LOG_ERROR("Cannot find interface metadata for %s", itf);
+		result = RPC_TRN_ERROR;
+		goto error;
+	}
+
+	policy.tunnel_id = ppo->tunid;
+	policy.local_ip = ppo->local_ip;
+	policy.proto = ppo->proto;
+	policy.port = ppo->port;
+	__u64 bitmap = ppo->bit_val;
+
+	rc = trn_update_transit_network_policy_protocol_port_map(md, &policy, bitmap);
+
+	if (rc != 0) {
+		TRN_LOG_ERROR("Failure updating transit network policy enforcement map ip address: 0x%x, for interface %s",
+					ppo->local_ip, ppo->interface);
+		result = RPC_TRN_FATAL;
+		goto error;
+	}
+
+	result = 0;
+	return &result;
+
+error:
+	return &result;
+}

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1464,9 +1464,8 @@ int *update_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_t *ppo, 
 	policy.local_ip = ppo->local_ip;
 	policy.proto = ppo->proto;
 	policy.port = ppo->port;
-	__u64 bitmap = ppo->bit_val;
 
-	rc = trn_update_transit_network_policy_protocol_port_map(md, &policy, bitmap);
+	rc = trn_update_transit_network_policy_protocol_port_map(md, &policy, ppo->bit_val);
 
 	if (rc != 0) {
 		TRN_LOG_ERROR("Failure updating transit network policy enforcement map ip address: 0x%x, for interface %s",

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -695,3 +695,17 @@ int trn_delete_transit_network_policy_enforcement_map(struct user_metadata_t *md
 	}
 	return 0;
 }
+
+int trn_update_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
+						        struct vsip_ppo_t *policy,
+						        __u64 bitmap)
+{
+	int err = bpf_map_update_elem(md->ing_vsip_ppo_map_fd, policy, &bitmap, 0);
+
+	if (err) {
+		TRN_LOG_ERROR("Update Protocol-Port ingress map failed (err:%d).",
+				err);
+		return 1;
+	}
+	return 0;
+}

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -219,3 +219,7 @@ int trn_update_transit_network_policy_enforcement_map(struct user_metadata_t *md
 
 int trn_delete_transit_network_policy_enforcement_map(struct user_metadata_t *md,
 						      struct vsip_enforce_t *local);
+
+int trn_update_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
+						        struct vsip_ppo_t *policy,
+						        __u64 bitmap);

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -188,6 +188,16 @@ struct rpc_trn_vsip_enforce_t {
 	uint32_t local_ip;
 };
 
+/* Defines a network policy protocol port table entry */
+struct rpc_trn_vsip_ppo_t {
+       string interface<20>;
+	uint64_t tunid;
+	uint32_t local_ip;
+	uint8_t proto;
+	uint16_t port;
+       uint64_t bit_val;
+};
+
 /*----- Protocol. -----*/
 
 program RPC_TRANSIT_REMOTE_PROTOCOL {
@@ -224,6 +234,7 @@ program RPC_TRANSIT_REMOTE_PROTOCOL {
                 int DELETE_TRANSIT_NETWORK_POLICY(rpc_trn_vsip_cidr_key_t) = 24;
                 int UPDATE_TRANSIT_NETWORK_POLICY_ENFORCEMENT(rpc_trn_vsip_enforce_t) = 25;
                 int DELETE_TRANSIT_NETWORK_POLICY_ENFORCEMENT(rpc_trn_vsip_enforce_t) = 26;
+                int UPDATE_TRANSIT_NETWORK_POLICY_PROTOCOL_PORT(rpc_trn_vsip_ppo_t) = 27;
 
           } = 1;
 

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -184,17 +184,17 @@ struct rpc_trn_vsip_cidr_key_t {
 /* Defines a network policy enforcement table key */
 struct rpc_trn_vsip_enforce_t {
        string interface<20>;
-	uint64_t tunid;
-	uint32_t local_ip;
+       uint64_t tunid;
+       uint32_t local_ip;
 };
 
 /* Defines a network policy protocol port table entry */
 struct rpc_trn_vsip_ppo_t {
        string interface<20>;
-	uint64_t tunid;
-	uint32_t local_ip;
-	uint8_t proto;
-	uint16_t port;
+       uint64_t tunid;
+       uint32_t local_ip;
+       uint8_t proto;
+       uint16_t port;
        uint64_t bit_val;
 };
 


### PR DESCRIPTION
This PR partially resolves issue #270 #269

User inputs cli update-network-policy-protocol-port-ingress to update entries in network policy protocol port bpf maps.

The Cli command triggers RPC call and then perform bpf map update in transit agent.