### PR TITLE
exposes maps of network policies and conn_track to ingress/egress xdp progs

### DIFF
--- a/src/dmn/trn_agent_xdp_usr.c
+++ b/src/dmn/trn_agent_xdp_usr.c
@@ -305,6 +305,11 @@ int trn_agent_bpf_maps_init(struct agent_user_metadata_t *md)
 	md->eg_vsip_ppo_map_fd		= bpf_map__fd(md->eg_vsip_ppo_map);
 	md->eg_vsip_supp_map_fd		= bpf_map__fd(md->eg_vsip_supp_map);
 	md->eg_vsip_except_map_fd	= bpf_map__fd(md->eg_vsip_except_map);
+	md->ing_vsip_enforce_map_fd	= bpf_map__fd(md->ing_vsip_enforce_map);
+	md->ing_vsip_prim_map_fd	= bpf_map__fd(md->ing_vsip_prim_map);
+	md->ing_vsip_ppo_map_fd		= bpf_map__fd(md->ing_vsip_ppo_map);
+	md->ing_vsip_supp_map_fd	= bpf_map__fd(md->ing_vsip_supp_map);
+	md->ing_vsip_except_map_fd	= bpf_map__fd(md->ing_vsip_except_map);
 	md->conn_track_cache_fd		= bpf_map__fd(md->conn_track_cache);
 
 	if (bpf_map__unpin(md->xdpcap_hook_map, md->pcapfile) == 0) {

--- a/src/dmn/trn_agent_xdp_usr.c
+++ b/src/dmn/trn_agent_xdp_usr.c
@@ -26,19 +26,24 @@
 #include "extern/linux/err.h"
 #include "trn_agent_xdp_usr.h"
 #include "trn_log.h"
+#include "shared_map_names.h"
+
+#define _REUSE_MAP_IF_PINNED(map)                                        	\
+	do {									\
+		int err_code;							\
+		if (0 != (err_code = _reuse_pinned_map_if_exists(md->obj, 	\
+			#map, 							\
+			map##_path)))						\
+		{ 								\
+			TRN_LOG_INFO("failed to reuse shared map at %s, error code %d\n", map##_path, err_code); \
+			return 1;						\
+		}								\
+	} while (0)
 
 static int def_fwd_flow_mod_cache_map_fd = -1;
 static int def_rev_flow_mod_cache_map_fd = -1;
 static int def_ep_flow_host_cache_map_fd = -1;
 static int def_ep_host_cache_map_fd = -1;
-
-// global pinned map file paths
-const char *eg_vsip_enforce_map_path	= "/sys/fs/bpf/eg_vsip_enforce_map";
-const char *eg_vsip_prim_map_path	= "/sys/fs/bpf/eg_vsip_prim_map";
-const char *eg_vsip_ppo_map_path	= "/sys/fs/bpf/eg_vsip_ppo_map";
-const char *eg_vsip_supp_map_path	= "/sys/fs/bpf/eg_vsip_supp_map";
-const char *eg_vsip_except_map_path	= "/sys/fs/bpf/eg_vsip_except_map";
-const char *conn_track_cache_path	= "/sys/fs/bpf/conn_track_cache";
 
 int trn_agent_user_metadata_free(struct agent_user_metadata_t *md)
 {
@@ -261,12 +266,17 @@ int trn_agent_bpf_maps_init(struct agent_user_metadata_t *md)
 		bpf_map__next(md->rev_flow_mod_cache_ref, md->obj);
 	md->ep_host_cache_ref =
 		bpf_map__next(md->ep_flow_host_cache_ref, md->obj);
-	md->eg_vsip_enforce_map	= bpf_map__next(md->ep_host_cache_ref, md->obj);
-	md->eg_vsip_prim_map 	= bpf_map__next(md->eg_vsip_enforce_map, md->obj);
-	md->eg_vsip_ppo_map 	= bpf_map__next(md->eg_vsip_prim_map, md->obj);
-	md->eg_vsip_supp_map 	= bpf_map__next(md->eg_vsip_ppo_map, md->obj);
-	md->eg_vsip_except_map 	= bpf_map__next(md->eg_vsip_supp_map, md->obj);
-	md->conn_track_cache	= bpf_map__next(md->eg_vsip_except_map, md->obj);
+	md->eg_vsip_enforce_map = bpf_map__next(md->ep_host_cache_ref, md->obj);
+	md->eg_vsip_prim_map = bpf_map__next(md->eg_vsip_enforce_map, md->obj);
+	md->eg_vsip_ppo_map = bpf_map__next(md->eg_vsip_prim_map, md->obj);
+	md->eg_vsip_supp_map = bpf_map__next(md->eg_vsip_ppo_map, md->obj);
+	md->eg_vsip_except_map = bpf_map__next(md->eg_vsip_supp_map, md->obj);
+	md->ing_vsip_enforce_map = bpf_map__next(md->eg_vsip_except_map, md->obj);
+	md->ing_vsip_prim_map = bpf_map__next(md->ing_vsip_enforce_map, md->obj);
+	md->ing_vsip_ppo_map = bpf_map__next(md->ing_vsip_prim_map, md->obj);
+	md->ing_vsip_supp_map = bpf_map__next(md->ing_vsip_ppo_map, md->obj);
+	md->ing_vsip_except_map = bpf_map__next(md->ing_vsip_supp_map, md->obj);
+	md->conn_track_cache = bpf_map__next(md->ing_vsip_except_map, md->obj);
 
 	if (!md->jmp_table_map || !md->agentmetadata_map ||
 	    !md->endpoints_map || !md->xdpcap_hook_map ||
@@ -274,7 +284,10 @@ int trn_agent_bpf_maps_init(struct agent_user_metadata_t *md)
 	    !md->ep_flow_host_cache_ref || !md->ep_host_cache_ref ||
 	    !md->eg_vsip_enforce_map || !md->eg_vsip_prim_map ||
 	    !md->eg_vsip_ppo_map || !md->eg_vsip_supp_map ||
-	    !md->eg_vsip_except_map || !md->conn_track_cache) {
+	    !md->eg_vsip_except_map ||  !md->ing_vsip_enforce_map ||
+	    !md->ing_vsip_prim_map || !md->ing_vsip_ppo_map ||
+	    !md->ing_vsip_supp_map || !md->ing_vsip_except_map ||
+	    !md->conn_track_cache) {
 		TRN_LOG_ERROR("Failure finding maps objects.");
 		return 1;
 	}
@@ -305,12 +318,17 @@ int trn_agent_bpf_maps_init(struct agent_user_metadata_t *md)
 		return 1;
 	}
 
-	// pins the egress policy maps if not yet
+	// pins the policy maps & conn_track map if not yet
 	bpf_map__pin(md->eg_vsip_enforce_map, eg_vsip_enforce_map_path);
 	bpf_map__pin(md->eg_vsip_prim_map, eg_vsip_prim_map_path);
 	bpf_map__pin(md->eg_vsip_ppo_map, eg_vsip_ppo_map_path);
 	bpf_map__pin(md->eg_vsip_supp_map, eg_vsip_supp_map_path);
 	bpf_map__pin(md->eg_vsip_except_map, eg_vsip_except_map_path);
+	bpf_map__pin(md->ing_vsip_enforce_map, ing_vsip_enforce_map_path);
+	bpf_map__pin(md->ing_vsip_prim_map, ing_vsip_prim_map_path);
+	bpf_map__pin(md->ing_vsip_ppo_map, ing_vsip_ppo_map_path);
+	bpf_map__pin(md->ing_vsip_supp_map, ing_vsip_supp_map_path);
+	bpf_map__pin(md->ing_vsip_except_map, ing_vsip_except_map_path);
 	bpf_map__pin(md->conn_track_cache, conn_track_cache_path);
 
 	return 0;
@@ -443,31 +461,17 @@ static int _trn_bpf_agent_prog_load_xattr(struct agent_user_metadata_t *md,
 	}
 
 	// to share the pinned egress policy maps, if applicable
-	int err_code;
-	if (0 != (err_code = _reuse_pinned_map_if_exists(*pobj, "eg_vsip_enforce_map", eg_vsip_enforce_map_path))) {
-		TRN_LOG_INFO("failed to reuse shared map at %s, error code: %d\n", eg_vsip_enforce_map_path, err_code);
-		goto error;
-	}
-	if (0 != (err_code = _reuse_pinned_map_if_exists(*pobj, "eg_vsip_prim_map", eg_vsip_prim_map_path))) {
-		TRN_LOG_INFO("failed to reuse shared map at %s, error code: %d\n", eg_vsip_prim_map_path, err_code);
-		goto error;
-	}
-	if (0 != (err_code = _reuse_pinned_map_if_exists(*pobj, "eg_vsip_ppo_map", eg_vsip_ppo_map_path))) {
-		TRN_LOG_INFO("failed to reuse shared map at %s, error code: %d\n", eg_vsip_ppo_map_path, err_code);
-		goto error;
-	}
-	if (0 != (err_code = _reuse_pinned_map_if_exists(*pobj, "eg_vsip_supp_map", eg_vsip_supp_map_path))) {
-		TRN_LOG_INFO("failed to reuse shared map at %s, error code: %d\n", eg_vsip_supp_map_path, err_code);
-		goto error;
-	}
-	if (0 != (err_code = _reuse_pinned_map_if_exists(*pobj, "eg_vsip_except_map", eg_vsip_except_map_path))) {
-		TRN_LOG_INFO("failed to reuse shared map at %s, error code: %d\n", eg_vsip_except_map_path, err_code);
-		goto error;
-	}
-	if (0 != (err_code = _reuse_pinned_map_if_exists(*pobj, "conn_track_cache", conn_track_cache_path))) {
-		TRN_LOG_INFO("failed to reuse shared map at %s, error code: %d\n", conn_track_cache_path, err_code);
-		goto error;
-	}
+	_REUSE_MAP_IF_PINNED(eg_vsip_enforce_map);
+	_REUSE_MAP_IF_PINNED(eg_vsip_prim_map);
+	_REUSE_MAP_IF_PINNED(eg_vsip_ppo_map);
+	_REUSE_MAP_IF_PINNED(eg_vsip_supp_map);
+	_REUSE_MAP_IF_PINNED(eg_vsip_except_map);
+	_REUSE_MAP_IF_PINNED(ing_vsip_enforce_map);
+	_REUSE_MAP_IF_PINNED(ing_vsip_prim_map);
+	_REUSE_MAP_IF_PINNED(ing_vsip_ppo_map);
+	_REUSE_MAP_IF_PINNED(ing_vsip_supp_map);
+	_REUSE_MAP_IF_PINNED(ing_vsip_except_map);
+	_REUSE_MAP_IF_PINNED(conn_track_cache);
 
 	/* Only one prog is supported */
 	bpf_object__for_each_program(prog, *pobj)

--- a/src/dmn/trn_agent_xdp_usr.h
+++ b/src/dmn/trn_agent_xdp_usr.h
@@ -73,6 +73,11 @@ struct agent_user_metadata_t {
 	int eg_vsip_ppo_map_fd;
 	int eg_vsip_supp_map_fd;
 	int eg_vsip_except_map_fd;
+	int ing_vsip_enforce_map_fd;
+	int ing_vsip_prim_map_fd;
+	int ing_vsip_ppo_map_fd;
+	int ing_vsip_supp_map_fd;
+	int ing_vsip_except_map_fd;
 	int conn_track_cache_fd;
 
 	int fwd_flow_mod_cache_map_fd;

--- a/src/dmn/trn_agent_xdp_usr.h
+++ b/src/dmn/trn_agent_xdp_usr.h
@@ -94,6 +94,11 @@ struct agent_user_metadata_t {
 	struct bpf_map *eg_vsip_ppo_map;
 	struct bpf_map *eg_vsip_supp_map;
 	struct bpf_map *eg_vsip_except_map;
+	struct bpf_map *ing_vsip_enforce_map;
+	struct bpf_map *ing_vsip_prim_map;
+	struct bpf_map *ing_vsip_ppo_map;
+	struct bpf_map *ing_vsip_supp_map;
+	struct bpf_map *ing_vsip_except_map;
 	struct bpf_map *conn_track_cache;
 
 	struct bpf_prog_info info;

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -66,6 +66,11 @@ struct ebpf_prog_stage_t {
 	int rev_flow_mod_cache_ref_fd;
 	int ep_flow_host_cache_ref_fd;
 	int ep_host_cache_ref_fd;
+	int eg_vsip_enforce_map_ref_fd;
+	int eg_vsip_prim_map_ref_fd;
+	int eg_vsip_ppo_map_ref_fd;
+	int eg_vsip_supp_map_ref_fd;
+	int eg_vsip_except_map_ref_fd;
 	int ing_vsip_enforce_map_ref_fd;
 	int ing_vsip_prim_map_ref_fd;
 	int ing_vsip_ppo_map_ref_fd;
@@ -85,6 +90,11 @@ struct ebpf_prog_stage_t {
 	struct bpf_map *rev_flow_mod_cache_ref;
 	struct bpf_map *ep_flow_host_cache_ref;
 	struct bpf_map *ep_host_cache_ref;
+	struct bpf_map *eg_vsip_enforce_map_ref;
+	struct bpf_map *eg_vsip_prim_map_ref;
+	struct bpf_map *eg_vsip_ppo_map_ref;
+	struct bpf_map *eg_vsip_supp_map_ref;
+	struct bpf_map *eg_vsip_except_map_ref;
 	struct bpf_map *ing_vsip_enforce_map_ref;
 	struct bpf_map *ing_vsip_prim_map_ref;
 	struct bpf_map *ing_vsip_ppo_map_ref;
@@ -115,6 +125,11 @@ struct user_metadata_t {
 	int rev_flow_mod_cache_fd;
 	int ep_flow_host_cache_fd;
 	int ep_host_cache_fd;
+	int eg_vsip_enforce_map_fd;
+	int eg_vsip_prim_map_fd;
+	int eg_vsip_ppo_map_fd;
+	int eg_vsip_supp_map_fd;
+	int eg_vsip_except_map_fd;
 	int ing_vsip_enforce_map_fd;
 	int ing_vsip_prim_map_fd;
 	int ing_vsip_ppo_map_fd;
@@ -135,12 +150,17 @@ struct user_metadata_t {
 	struct bpf_map *ep_flow_host_cache;
 	struct bpf_map *ep_host_cache;
 	struct bpf_map *xdpcap_hook_map;
+	struct bpf_map *eg_vsip_enforce_map;
+	struct bpf_map *eg_vsip_prim_map;
+	struct bpf_map *eg_vsip_ppo_map;
+	struct bpf_map *eg_vsip_supp_map;
+	struct bpf_map *eg_vsip_except_map;
 	struct bpf_map *ing_vsip_enforce_map;
 	struct bpf_map *ing_vsip_prim_map;
 	struct bpf_map *ing_vsip_ppo_map;
 	struct bpf_map *ing_vsip_supp_map;
 	struct bpf_map *ing_vsip_except_map;
-	struct bpf_map *conn_track_chche;
+	struct bpf_map *conn_track_cache;
 
 	struct bpf_prog_info info;
 	struct bpf_object *obj;

--- a/src/include/shared_map_names.h
+++ b/src/include/shared_map_names.h
@@ -1,3 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/**
+ * @file conntrack_common.h
+ * @author Hongwei Chen (@hong.chen@futurewei.com)
+ *
+ * @brief Defines common code used in metwork policy and conntrack feature
+ *
+ * @copyright Copyright (c) 2020 The Authors.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 #pragma once
 
 // global pinned map file paths

--- a/src/include/shared_map_names.h
+++ b/src/include/shared_map_names.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// global pinned map file paths
+static const char *eg_vsip_enforce_map_path	= "/sys/fs/bpf/eg_vsip_enforce_map";
+static const char *eg_vsip_prim_map_path	= "/sys/fs/bpf/eg_vsip_prim_map";
+static const char *eg_vsip_ppo_map_path		= "/sys/fs/bpf/eg_vsip_ppo_map";
+static const char *eg_vsip_supp_map_path	= "/sys/fs/bpf/eg_vsip_supp_map";
+static const char *eg_vsip_except_map_path	= "/sys/fs/bpf/eg_vsip_except_map";
+static const char *ing_vsip_enforce_map_path	= "/sys/fs/bpf/ing_vsip_enforce_map";
+static const char *ing_vsip_prim_map_path	= "/sys/fs/bpf/ing_vsip_prim_map";
+static const char *ing_vsip_ppo_map_path	= "/sys/fs/bpf/ing_vsip_ppo_map";
+static const char *ing_vsip_supp_map_path	= "/sys/fs/bpf/ing_vsip_supp_map";
+static const char *ing_vsip_except_map_path	= "/sys/fs/bpf/ing_vsip_except_map";
+static const char *conn_track_cache_path	= "/sys/fs/bpf/conn_track_cache";

--- a/src/include/shared_map_names.h
+++ b/src/include/shared_map_names.h
@@ -3,7 +3,7 @@
 // global pinned map file paths
 static const char *eg_vsip_enforce_map_path	= "/sys/fs/bpf/eg_vsip_enforce_map";
 static const char *eg_vsip_prim_map_path	= "/sys/fs/bpf/eg_vsip_prim_map";
-static const char *eg_vsip_ppo_map_path		= "/sys/fs/bpf/eg_vsip_ppo_map";
+static const char *eg_vsip_ppo_map_path 	= "/sys/fs/bpf/eg_vsip_ppo_map";
 static const char *eg_vsip_supp_map_path	= "/sys/fs/bpf/eg_vsip_supp_map";
 static const char *eg_vsip_except_map_path	= "/sys/fs/bpf/eg_vsip_except_map";
 static const char *ing_vsip_enforce_map_path	= "/sys/fs/bpf/ing_vsip_enforce_map";

--- a/src/xdp/shared_map_defs.h
+++ b/src/xdp/shared_map_defs.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <linux/bpf.h>
+
+#include "extern/bpf_helpers.h"
+#include "extern/xdpcap_hook.h"
+
+#include "trn_datamodel.h"
+
+// common map definitions for network policy check;
+// they are shared acrossed ingress and egress XDP prog
+
+// for egress policies
+struct bpf_map_def SEC("maps") eg_vsip_enforce_map = {
+	.type = BPF_MAP_TYPE_HASH,
+	.key_size = sizeof(struct vsip_enforce_t),
+	.value_size = sizeof(__u8),
+	.max_entries = 1024,
+	.map_flags = 0,
+};
+BPF_ANNOTATE_KV_PAIR(eg_vsip_enforce_map, struct vsip_enforce_t, __u8);
+
+struct bpf_map_def SEC("maps") eg_vsip_prim_map = {
+	.type = BPF_MAP_TYPE_LPM_TRIE,
+	.key_size = sizeof(struct vsip_cidr_t),
+	.value_size = sizeof(__u64),
+	.max_entries = 1024 * 1024,
+	.map_flags = 1,
+};
+BPF_ANNOTATE_KV_PAIR(eg_vsip_prim_map, struct vsip_cidr_t, __u64);
+
+struct bpf_map_def SEC("maps") eg_vsip_ppo_map = {
+	.type = BPF_MAP_TYPE_HASH,
+	.key_size = sizeof(struct vsip_ppo_t),
+	.value_size = sizeof(__u64),
+	.max_entries = 1024 * 1024,
+	.map_flags = 0,
+};
+BPF_ANNOTATE_KV_PAIR(eg_vsip_ppo_map, struct vsip_ppo_t, __u64);
+
+struct bpf_map_def SEC("maps") eg_vsip_supp_map = {
+	.type = BPF_MAP_TYPE_LPM_TRIE,
+	.key_size = sizeof(struct vsip_cidr_t),
+	.value_size = sizeof(__u64),
+	.max_entries = 1024 * 1024,
+	.map_flags = 1,
+};
+BPF_ANNOTATE_KV_PAIR(eg_vsip_supp_map, struct vsip_cidr_t, __u64);
+
+struct bpf_map_def SEC("maps") eg_vsip_except_map = {
+	.type = BPF_MAP_TYPE_LPM_TRIE,
+	.key_size = sizeof(struct vsip_cidr_t),
+	.value_size = sizeof(__u64),
+	.max_entries = 1024 * 1024,
+	.map_flags = 1,
+};
+BPF_ANNOTATE_KV_PAIR(eg_vsip_except_map, struct vsip_cidr_t, __u64);
+
+// for ingress policies
+struct bpf_map_def SEC("maps") ing_vsip_enforce_map = {
+	.type = BPF_MAP_TYPE_HASH,
+	.key_size = sizeof(struct vsip_enforce_t),
+	.value_size = sizeof(__u8),
+	.max_entries = 1024,
+	.map_flags = 0,
+};
+BPF_ANNOTATE_KV_PAIR(ing_vsip_enforce_map, struct vsip_enforce_t, __u8);
+
+struct bpf_map_def SEC("maps") ing_vsip_prim_map = {
+	.type = BPF_MAP_TYPE_LPM_TRIE,
+	.key_size = sizeof(struct vsip_cidr_t),
+	.value_size = sizeof(__u64),
+	.max_entries = 1024 * 1024,
+	.map_flags = 1,
+};
+BPF_ANNOTATE_KV_PAIR(ing_vsip_prim_map, struct vsip_cidr_t, __u64);
+
+struct bpf_map_def SEC("maps") ing_vsip_ppo_map = {
+	.type = BPF_MAP_TYPE_HASH,
+	.key_size = sizeof(struct vsip_ppo_t),
+	.value_size = sizeof(__u64),
+	.max_entries = 1024 * 1024,
+	.map_flags = 0,
+};
+BPF_ANNOTATE_KV_PAIR(ing_vsip_ppo_map, struct vsip_ppo_t, __u64);
+
+struct bpf_map_def SEC("maps") ing_vsip_supp_map = {
+	.type = BPF_MAP_TYPE_LPM_TRIE,
+	.key_size = sizeof(struct vsip_cidr_t),
+	.value_size = sizeof(__u64),
+	.max_entries = 1024 * 1024,
+	.map_flags = 1,
+};
+BPF_ANNOTATE_KV_PAIR(ing_vsip_supp_map, struct vsip_cidr_t, __u64);
+
+struct bpf_map_def SEC("maps") ing_vsip_except_map = {
+	.type = BPF_MAP_TYPE_LPM_TRIE,
+	.key_size = sizeof(struct vsip_cidr_t),
+	.value_size = sizeof(__u64),
+	.max_entries = 1024 * 1024,
+	.map_flags = 1,
+};
+BPF_ANNOTATE_KV_PAIR(ing_vsip_except_map, struct vsip_cidr_t, __u64);
+
+// the global connection track map
+struct bpf_map_def SEC("maps") conn_track_cache = {
+	.type = BPF_MAP_TYPE_LRU_HASH,
+	.key_size = sizeof(struct ipv4_ct_tuple_t),
+	.value_size = sizeof(__u8),
+	.max_entries = TRAN_MAX_CACHE_SIZE,
+};
+BPF_ANNOTATE_KV_PAIR(conn_track_cache, struct ipv4_ct_tuple_t, __u8);

--- a/src/xdp/shared_map_defs.h
+++ b/src/xdp/shared_map_defs.h
@@ -1,3 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/**
+ * @file conntrack_common.h
+ * @author Hongwei Chen (@hong.chen@futurewei.com)
+ *
+ * @brief Defines common code used in network policy and conntrack feature
+ *
+ * @copyright Copyright (c) 2020 The Authors.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 #pragma once
 
 #include <linux/bpf.h>

--- a/src/xdp/trn_agent_xdp_maps.h
+++ b/src/xdp/trn_agent_xdp_maps.h
@@ -29,7 +29,6 @@
 #include "extern/xdpcap_hook.h"
 
 #include "trn_datamodel.h"
-
 struct bpf_map_def SEC("maps") jmp_table = {
 	.type = BPF_MAP_TYPE_PROG_ARRAY,
 	.key_size = sizeof(__u32),
@@ -102,57 +101,7 @@ struct bpf_map_def SEC("maps") ep_host_cache_ref = {
 };
 BPF_ANNOTATE_KV_PAIR(ep_host_cache_ref, int, __u32);
 
+// DONOT change the location of this inlude for now.
 // pinned maps for egress policy checks (shared by transit agent xdp progs)
-
-struct bpf_map_def SEC("maps") eg_vsip_enforce_map = {
-	.type = BPF_MAP_TYPE_HASH,
-	.key_size = sizeof(struct vsip_enforce_t),
-	.value_size = sizeof(__u8),
-	.max_entries = 1024,
-	.map_flags = 0,
-};
-BPF_ANNOTATE_KV_PAIR(eg_vsip_enforce_map, struct vsip_enforce_t, __u8);
-
-struct bpf_map_def SEC("maps") eg_vsip_prim_map = {
-	.type = BPF_MAP_TYPE_LPM_TRIE,
-	.key_size = sizeof(struct vsip_cidr_t),
-	.value_size = sizeof(__u64),
-	.max_entries = 1024 * 1024,
-	.map_flags = 1,
-};
-BPF_ANNOTATE_KV_PAIR(eg_vsip_prim_map, struct vsip_cidr_t, __u64);
-
-struct bpf_map_def SEC("maps") eg_vsip_ppo_map = {
-	.type = BPF_MAP_TYPE_HASH,
-	.key_size = sizeof(struct vsip_ppo_t),
-	.value_size = sizeof(__u64),
-	.max_entries = 1024 * 1024,
-	.map_flags = 0,
-};
-BPF_ANNOTATE_KV_PAIR(eg_vsip_ppo_map, struct vsip_ppo_t, __u64);
-
-struct bpf_map_def SEC("maps") eg_vsip_supp_map = {
-	.type = BPF_MAP_TYPE_LPM_TRIE,
-	.key_size = sizeof(struct vsip_cidr_t),
-	.value_size = sizeof(__u64),
-	.max_entries = 1024 * 1024,
-	.map_flags = 1,
-};
-BPF_ANNOTATE_KV_PAIR(eg_vsip_supp_map, struct vsip_cidr_t, __u64);
-
-struct bpf_map_def SEC("maps") eg_vsip_except_map = {
-	.type = BPF_MAP_TYPE_LPM_TRIE,
-	.key_size = sizeof(struct vsip_cidr_t),
-	.value_size = sizeof(__u64),
-	.max_entries = 1024 * 1024,
-	.map_flags = 1,
-};
-BPF_ANNOTATE_KV_PAIR(eg_vsip_except_map, struct vsip_cidr_t, __u64);
-
-struct bpf_map_def SEC("maps") conn_track_cache = {
-	.type = BPF_MAP_TYPE_LRU_HASH,
-	.key_size = sizeof(struct ipv4_ct_tuple_t),
-	.value_size = sizeof(__u8),
-	.max_entries = TRAN_MAX_CACHE_SIZE,
-};
-BPF_ANNOTATE_KV_PAIR(conn_track_cache, struct ipv4_ct_tuple_t, __u8);
+// and the global conn_track map
+#include "shared_map_defs.h"

--- a/src/xdp/trn_transit_xdp_maps.h
+++ b/src/xdp/trn_transit_xdp_maps.h
@@ -143,57 +143,7 @@ BPF_ANNOTATE_KV_PAIR(ep_host_cache, struct endpoint_key_t,
 
 struct bpf_map_def SEC("maps") xdpcap_hook = XDPCAP_HOOK();
 
-// maps for ingress policy checks (used by transit xdp prog)
-
-struct bpf_map_def SEC("maps") ing_vsip_enforce_map = {
-	.type = BPF_MAP_TYPE_HASH,
-	.key_size = sizeof(struct vsip_enforce_t),
-	.value_size = sizeof(__u8),
-	.max_entries = 1024,
-	.map_flags = 0,
-};
-BPF_ANNOTATE_KV_PAIR(ing_vsip_enforce_map, struct vsip_enforce_t, __u8);
-
-struct bpf_map_def SEC("maps") ing_vsip_prim_map = {
-	.type = BPF_MAP_TYPE_LPM_TRIE,
-	.key_size = sizeof(struct vsip_cidr_t),
-	.value_size = sizeof(__u64),
-	.max_entries = 1024 * 1024,
-	.map_flags = 1,
-};
-BPF_ANNOTATE_KV_PAIR(ing_vsip_prim_map, struct vsip_cidr_t, __u64);
-
-struct bpf_map_def SEC("maps") ing_vsip_ppo_map = {
-	.type = BPF_MAP_TYPE_HASH,
-	.key_size = sizeof(struct vsip_ppo_t),
-	.value_size = sizeof(__u64),
-	.max_entries = 1024 * 1024,
-	.map_flags = 0,
-};
-BPF_ANNOTATE_KV_PAIR(ing_vsip_ppo_map, struct vsip_ppo_t, __u64);
-
-struct bpf_map_def SEC("maps") ing_vsip_supp_map = {
-	.type = BPF_MAP_TYPE_LPM_TRIE,
-	.key_size = sizeof(struct vsip_cidr_t),
-	.value_size = sizeof(__u64),
-	.max_entries = 1024 * 1024,
-	.map_flags = 1,
-};
-BPF_ANNOTATE_KV_PAIR(ing_vsip_supp_map, struct vsip_cidr_t, __u64);
-
-struct bpf_map_def SEC("maps") ing_vsip_except_map = {
-	.type = BPF_MAP_TYPE_LPM_TRIE,
-	.key_size = sizeof(struct vsip_cidr_t),
-	.value_size = sizeof(__u64),
-	.max_entries = 1024 * 1024,
-	.map_flags = 1,
-};
-BPF_ANNOTATE_KV_PAIR(ing_vsip_except_map, struct vsip_cidr_t, __u64);
-
-struct bpf_map_def SEC("maps") conn_track_cache = {
-	.type = BPF_MAP_TYPE_LRU_HASH,
-	.key_size = sizeof(struct ipv4_ct_tuple_t),
-	.value_size = sizeof(__u8),
-	.max_entries = TRAN_MAX_CACHE_SIZE,
-};
-BPF_ANNOTATE_KV_PAIR(conn_track_cache, struct ipv4_ct_tuple_t, __u8);
+// DONOT change the location of this inlude for now.
+// pinned maps for egress policy checks (shared by transit agent xdp progs)
+// and the global conn_track map
+#include "shared_map_defs.h"


### PR DESCRIPTION
It fixes #304.

According to conn_track design of mizar network policy, in order to block the reply UDP packets after the policy updates and intends to block the originated udp traffic, policy enforcement logic needs signifiacnt enhancement. Due to udp being one directional protocol in nature, the _logical_ reply packets could go without the _loogical_ originated packet; this imposes some difficulty for policy neforcement, as there might be no packet emitted on the _originated direction_ wire, and the policy enforcement at the other direction has to handle w/o the help from the _original direction_. The proposal in the design is, for udp reply packet of a tracked connection, it consults the relevant policies to decide whether the _originated_ packet should be allowed or denied; based the this decision, the reply packet will be allowed or denied, respectively.

This PR is part of the implementation of the proposal: it exposes ingress policies to egress enforcement prog, and vise versa. The change of xdp prog to consulte polices and decide whether the udp reply packet should be allowed or denied is in the PR coming soon.

In the future implementation of conn_track, when tracked connections have states to differentaie being allowed or denied explicitly, the enforcement prog will disregard the state but relies on policy calculation when deciding where the reply packet should go or block.
