### PR TITLE
transit network policy protocol port map delete

### DIFF
--- a/src/cli/test/module.mk
+++ b/src/cli/test/module.mk
@@ -32,6 +32,7 @@ CLI_MOCKS += -Wl,--wrap=delete_agent_ep_1
 CLI_MOCKS += -Wl,--wrap=delete_agent_md_1
 CLI_MOCKS += -Wl,--wrap=delete_transit_network_policy_1
 CLI_MOCKS += -Wl,--wrap=delete_transit_network_policy_enforcement_1
+CLI_MOCKS += -Wl,--wrap=delete_transit_network_policy_protocol_port_1
 CLI_MOCKS += -Wl,--wrap=setrlimit
 
 unittest:: test_cli

--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -161,6 +161,15 @@ int *__wrap_update_transit_network_policy_protocol_port_1(rpc_trn_vsip_ppo_t *pp
 	return retval;
 }
 
+int *__wrap_delete_transit_network_policy_protocol_port_1(rpc_trn_vsip_ppo_key_t *ppo, CLIENT *clnt)
+{
+	check_expected_ptr(ppo);
+	check_expected_ptr(clnt);
+	int *retval = mock_ptr_type(int *);
+	function_called();
+	return retval;
+}
+
 rpc_trn_vpc_t *__wrap_get_vpc_1(rpc_trn_vpc_key_t *argp, CLIENT *clnt)
 {
 	check_expected_ptr(argp);
@@ -641,6 +650,36 @@ static int check_policy_protocol_port_equal(const LargestIntegralType value,
 	}
 
 	if (policy->bit_val != c_policy->bit_val) {
+		return false;
+	}
+
+	return true;
+}
+
+static int check_policy_protocol_port_key_equal(const LargestIntegralType value,
+						const LargestIntegralType check_value_data)
+{
+	struct rpc_trn_vsip_ppo_key_t *policy = (struct rpc_trn_vsip_ppo_key_t *)value;
+	struct rpc_trn_vsip_ppo_key_t *c_policy =
+		(struct rpc_trn_vsip_ppo_key_t *)check_value_data;
+
+	if (strcmp(policy->interface, c_policy->interface) != 0) {
+		return false;
+	}
+
+	if (policy->tunid != c_policy->tunid) {
+		return false;
+	}
+
+	if (policy->local_ip != c_policy->local_ip) {
+		return false;
+	}
+
+	if (policy->proto != c_policy->proto) {
+		return false;
+	}
+
+	if (policy->port != c_policy->port) {
 		return false;
 	}
 
@@ -2321,22 +2360,22 @@ static void test_trn_cli_delete_transit_network_policy_enforcement_subcmd(void *
 	int delete_transit_network_policy_enforcement_1_ret_val;
 
 	/* Test cases */
-	char *argv1[] = { "update-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv1[] = { "delete-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": "3",
 				  "ip": "10.0.0.3"
 			  }) };
 
-	char *argv2[] = { "update-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv2[] = { "delete-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": 3,
 				  "ip": "10.0.0.3"
 			  }) };
 
-	char *argv3[] = { "update-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv3[] = { "delete-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": "3",
 				  "ip": 10.0.0.3
 			  }) };
 
-	char *argv4[] = { "delete-network-policy-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv4[] = { "delete-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": "3"
 			  }) };
 
@@ -2398,7 +2437,7 @@ static void test_trn_cli_update_transit_network_policy_protocol_port_subcmd(void
 	int update_transit_network_policy_proto_port_1_ret_val = 0;
 
 	/* Test cases */
-	char *argv1[] = { "update-network-policy-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv1[] = { "update-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": "3",
 				  "local_ip": "10.0.0.3",
 				  "protocol": "6",
@@ -2406,7 +2445,7 @@ static void test_trn_cli_update_transit_network_policy_protocol_port_subcmd(void
 				  "bit_value": "10"
 			  }) };
 
-	char *argv2[] = { "update-network-policy-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv2[] = { "update-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": 3,
 				  "local_ip": "10.0.0.3",
 				  "protocol": "6",
@@ -2414,7 +2453,7 @@ static void test_trn_cli_update_transit_network_policy_protocol_port_subcmd(void
 				  "bit_value": "10"
 			  }) };
 
-	char *argv3[] = { "update-network-policy-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv3[] = { "update-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": "3",
 				  "local_ip": 10.0.0.3,
 				  "protocol": "6",
@@ -2463,12 +2502,100 @@ static void test_trn_cli_update_transit_network_policy_protocol_port_subcmd(void
 	assert_int_equal(rc, -EINVAL);
 
 	/* Test call update_transit_network_policy_1 return NULL*/
-	TEST_CASE("update-network-policy-ingress subcommand fails if update_transit_network_policy_1 returns NULL");
+	TEST_CASE("update-network-policy-ingress subcommand fails if update_transit_network_policy_protocol_port_1 returns NULL");
 	expect_function_call(__wrap_update_transit_network_policy_protocol_port_1);
 	will_return(__wrap_update_transit_network_policy_protocol_port_1, NULL);
 	expect_any(__wrap_update_transit_network_policy_protocol_port_1, ppo);
 	expect_any(__wrap_update_transit_network_policy_protocol_port_1, clnt);
 	rc = trn_cli_update_transit_network_policy_protocol_port_subcmd(NULL, argc, argv1);
+	assert_int_equal(rc, -EINVAL);
+}
+
+static void test_trn_cli_delete_transit_network_policy_protocol_port_subcmd(void **state)
+{
+	UNUSED(state);
+	int rc;
+	int argc = 5;
+	char itf[] = "eth0";
+	int delete_transit_network_policy_protocol_port_1_ret_val;
+
+	/* Test cases */
+	char *argv1[] = { "delete-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE({
+				  "tunnel_id": "3",
+				  "local_ip": "10.0.0.3",
+				  "protocol": "6",
+				  "port": "6379"
+			  }) };
+
+	char *argv2[] = { "delete-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE({
+				  "tunnel_id": 3,
+				  "local_ip": "10.0.0.3",
+				  "protocol": "6",
+				  "port": "6379"
+			  }) };
+
+	char *argv3[] = { "delete-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE({
+				  "tunnel_id": "3",
+				  "local_ip": 10.0.0.3,
+				  "protocol": "6",
+				  "port": "6379"
+			  }) };
+
+	char *argv4[] = { "delete-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE({
+				  "tunnel_id": "3",
+				  "protocol": "6",
+				  "port": "6379"
+			  }) };
+
+	struct rpc_trn_vsip_ppo_t exp_ppo = {
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x300000a,
+		.proto = 6,
+		.port = 6379
+	};
+
+	/* Test call delete_transit_network_policy_protocol_port_1 successfully */
+	TEST_CASE("delete-network-policy-protocol-port-ingress succeed with well formed policy json input");
+	delete_transit_network_policy_protocol_port_1_ret_val = 0;
+	expect_function_call(__wrap_delete_transit_network_policy_protocol_port_1);
+	will_return(__wrap_delete_transit_network_policy_protocol_port_1, &delete_transit_network_policy_protocol_port_1_ret_val);
+	expect_check(__wrap_delete_transit_network_policy_protocol_port_1, ppo, check_policy_enforcement_equal, &exp_ppo);
+	expect_any(__wrap_delete_transit_network_policy_protocol_port_1, clnt);
+	rc = trn_cli_delete_transit_network_policy_protocol_port_subcmd(NULL, argc, argv1);
+	assert_int_equal(rc, 0);
+
+	/* Test parse network policy input error*/
+	TEST_CASE("delete-network-policy-protocol-port-ingress is not called with non-string field");
+	rc = trn_cli_delete_transit_network_policy_protocol_port_subcmd(NULL, argc, argv2);
+	assert_int_equal(rc, -EINVAL);
+
+	/* Test parse network policy input error 2*/
+	TEST_CASE("delete-network-policy-protocol-port-ingress is not called malformed json");
+	rc = trn_cli_delete_transit_network_policy_protocol_port_subcmd(NULL, argc, argv3);
+	assert_int_equal(rc, -EINVAL);
+
+	TEST_CASE("delete-network-policy-protocol-port-ingress is not called with missing required field");
+	rc = trn_cli_delete_transit_network_policy_protocol_port_subcmd(NULL, argc, argv4);
+	assert_int_equal(rc, -EINVAL);
+
+	/* Test call delete_transit_network_policy_protocol_port_1 return error*/
+	TEST_CASE("delete-network-policy-protocol-port-ingress subcommand fails if delete_transit_network_policy_protocol_port_1 returns error");
+	delete_transit_network_policy_protocol_port_1_ret_val = -EINVAL;
+	expect_function_call(__wrap_delete_transit_network_policy_protocol_port_1);
+	will_return(__wrap_delete_transit_network_policy_protocol_port_1, &delete_transit_network_policy_protocol_port_1_ret_val);
+	expect_any(__wrap_delete_transit_network_policy_protocol_port_1, ppo);
+	expect_any(__wrap_delete_transit_network_policy_protocol_port_1, clnt);
+	rc = trn_cli_delete_transit_network_policy_protocol_port_subcmd(NULL, argc, argv1);
+	assert_int_equal(rc, -EINVAL);
+
+	/* Test call delete_transit_network_policy_protocol_port_1 return NULL*/
+	TEST_CASE("delete-network-policy-protocol-port-ingress subcommand fails if delete_transit_network_policy_protocol_port_1 returns NULL");
+	expect_function_call(__wrap_delete_transit_network_policy_protocol_port_1);
+	will_return(__wrap_delete_transit_network_policy_protocol_port_1, NULL);
+	expect_any(__wrap_delete_transit_network_policy_protocol_port_1, ppo);
+	expect_any(__wrap_delete_transit_network_policy_protocol_port_1, clnt);
+	rc = trn_cli_delete_transit_network_policy_protocol_port_subcmd(NULL, argc, argv1);
 	assert_int_equal(rc, -EINVAL);
 }
 
@@ -2498,7 +2625,8 @@ int main()
 		cmocka_unit_test(test_trn_cli_delete_transit_network_policy_subcmd),
 		cmocka_unit_test(test_trn_cli_update_transit_network_policy_enforcement_subcmd),
 		cmocka_unit_test(test_trn_cli_delete_transit_network_policy_enforcement_subcmd),
-		cmocka_unit_test(test_trn_cli_update_transit_network_policy_protocol_port_subcmd)
+		cmocka_unit_test(test_trn_cli_update_transit_network_policy_protocol_port_subcmd),
+		cmocka_unit_test(test_trn_cli_delete_transit_network_policy_protocol_port_subcmd)
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -2311,7 +2311,7 @@ static void test_trn_cli_update_transit_network_policy_enforcement_subcmd(void *
 		.local_ip = 0x300000a
 	};
 
-	/* Test call update_transit_network_policy successfully */
+	/* Test call update_transit_network_policy_enforcement successfully */
 	TEST_CASE("update-network-policy-enforcement-ingress succeed with well formed policy json input");
 	update_transit_network_policy_enforcement_1_ret_val = 0;
 	expect_function_call(__wrap_update_transit_network_policy_enforcement_1);
@@ -2331,7 +2331,7 @@ static void test_trn_cli_update_transit_network_policy_enforcement_subcmd(void *
 	rc = trn_cli_update_transit_network_policy_enforcement_subcmd(NULL, argc, argv3);
 	assert_int_equal(rc, -EINVAL);
 
-	/* Test call update_transit_network_policy_1 return error*/
+	/* Test call update_transit_network_policy_enforcement_1 return error*/
 	TEST_CASE("update-network-policy-enforcement-ingress subcommand fails if update_transit_network_policy_enforcement_1 returns error");
 	update_transit_network_policy_enforcement_1_ret_val = -EINVAL;
 	expect_function_call(__wrap_update_transit_network_policy_enforcement_1);
@@ -2341,7 +2341,7 @@ static void test_trn_cli_update_transit_network_policy_enforcement_subcmd(void *
 	rc = trn_cli_update_transit_network_policy_enforcement_subcmd(NULL, argc, argv1);
 	assert_int_equal(rc, -EINVAL);
 
-	/* Test call update_transit_network_policy_1 return NULL*/
+	/* Test call update_transit_network_policy_enforcement_1 return NULL*/
 	TEST_CASE("update-network-policy-enforcement-ingress subcommand fails if update_transit_network_policy_enforcement_1 returns NULL");
 	expect_function_call(__wrap_update_transit_network_policy_enforcement_1);
 	will_return(__wrap_update_transit_network_policy_enforcement_1, NULL);
@@ -2385,7 +2385,7 @@ static void test_trn_cli_delete_transit_network_policy_enforcement_subcmd(void *
 		.local_ip = 0x300000a
 	};
 
-	/* Test call delete_transit_network_policy_enforcement_1 successfully */
+	/* Test call delete_transit_network_policy_enforcement successfully */
 	TEST_CASE("delete-network-policy-enforcement-ingress succeed with well formed policy json input");
 	delete_transit_network_policy_enforcement_1_ret_val = 0;
 	expect_function_call(__wrap_delete_transit_network_policy_enforcement_1);
@@ -2410,7 +2410,7 @@ static void test_trn_cli_delete_transit_network_policy_enforcement_subcmd(void *
 	assert_int_equal(rc, -EINVAL);
 
 	/* Test call delete_transit_network_policy_enforcement_1 return error*/
-	TEST_CASE("delete-network-policy-enforcement-ingress subcommand fails if delete_transit_network_policy_1 returns error");
+	TEST_CASE("delete-network-policy-enforcement-ingress subcommand fails if delete-network-policy-enforcement-ingress_1 returns error");
 	delete_transit_network_policy_enforcement_1_ret_val = -EINVAL;
 	expect_function_call(__wrap_delete_transit_network_policy_enforcement_1);
 	will_return(__wrap_delete_transit_network_policy_enforcement_1, &delete_transit_network_policy_enforcement_1_ret_val);
@@ -2420,7 +2420,7 @@ static void test_trn_cli_delete_transit_network_policy_enforcement_subcmd(void *
 	assert_int_equal(rc, -EINVAL);
 
 	/* Test call delete_transit_network_policy_enforcement_1 return NULL*/
-	TEST_CASE("delete-network-policy-enforcement-ingress subcommand fails if delete_transit_network_policy_1 returns NULL");
+	TEST_CASE("delete-network-policy-enforcement-ingress subcommand fails if delete-network-policy-enforcement-ingress_1 returns NULL");
 	expect_function_call(__wrap_delete_transit_network_policy_enforcement_1);
 	will_return(__wrap_delete_transit_network_policy_enforcement_1, NULL);
 	expect_any(__wrap_delete_transit_network_policy_enforcement_1, enforce);
@@ -2471,7 +2471,7 @@ static void test_trn_cli_update_transit_network_policy_protocol_port_subcmd(void
 		.bit_val = 10
 	};
 
-	/* Test call update_transit_network_policy successfully */
+	/* Test call update_transit_network_policy_protocol_port successfully */
 	TEST_CASE("update_transit_network_policy_protocol_port succeed with well formed policy json input");
 	update_transit_network_policy_proto_port_1_ret_val = 0;
 	expect_function_call(__wrap_update_transit_network_policy_protocol_port_1);
@@ -2502,7 +2502,7 @@ static void test_trn_cli_update_transit_network_policy_protocol_port_subcmd(void
 	assert_int_equal(rc, -EINVAL);
 
 	/* Test call update_transit_network_policy_1 return NULL*/
-	TEST_CASE("update-network-policy-ingress subcommand fails if update_transit_network_policy_protocol_port_1 returns NULL");
+	TEST_CASE("update_transit_network_policy_protocol_port subcommand fails if update_transit_network_policy_protocol_port_1 returns NULL");
 	expect_function_call(__wrap_update_transit_network_policy_protocol_port_1);
 	will_return(__wrap_update_transit_network_policy_protocol_port_1, NULL);
 	expect_any(__wrap_update_transit_network_policy_protocol_port_1, ppo);
@@ -2555,12 +2555,12 @@ static void test_trn_cli_delete_transit_network_policy_protocol_port_subcmd(void
 		.port = 6379
 	};
 
-	/* Test call delete_transit_network_policy_protocol_port_1 successfully */
+	/* Test call delete_transit_network_policy_protocol_port successfully */
 	TEST_CASE("delete-network-policy-protocol-port-ingress succeed with well formed policy json input");
 	delete_transit_network_policy_protocol_port_1_ret_val = 0;
 	expect_function_call(__wrap_delete_transit_network_policy_protocol_port_1);
 	will_return(__wrap_delete_transit_network_policy_protocol_port_1, &delete_transit_network_policy_protocol_port_1_ret_val);
-	expect_check(__wrap_delete_transit_network_policy_protocol_port_1, ppo, check_policy_enforcement_equal, &exp_ppo);
+	expect_check(__wrap_delete_transit_network_policy_protocol_port_1, ppo, check_policy_protocol_port_key_equal, &exp_ppo);
 	expect_any(__wrap_delete_transit_network_policy_protocol_port_1, clnt);
 	rc = trn_cli_delete_transit_network_policy_protocol_port_subcmd(NULL, argc, argv1);
 	assert_int_equal(rc, 0);

--- a/src/cli/trn_cli.c
+++ b/src/cli/trn_cli.c
@@ -56,6 +56,8 @@ static const struct cmd {
 	{ "delete-network-policy-ingress", trn_cli_delete_transit_network_policy_subcmd },
 	{ "update-network-policy-enforcement-ingress", trn_cli_update_transit_network_policy_enforcement_subcmd },
 	{ "delete-network-policy-enforcement-ingress", trn_cli_delete_transit_network_policy_enforcement_subcmd },
+	{ "update-network-policy-protocol-port-ingress", trn_cli_update_transit_network_policy_protocol_port_subcmd },
+	{ "delete-network-policy-protocol-port-ingress", trn_cli_delete_transit_network_policy_protocol_port_subcmd },
 	{ 0 },
 };
 

--- a/src/cli/trn_cli.h
+++ b/src/cli/trn_cli.h
@@ -82,6 +82,9 @@ int trn_cli_parse_network_policy_enforcement(const cJSON *jsonobj,
 int trn_cli_parse_network_policy_protocol_port(const cJSON *jsonobj,
 					       struct rpc_trn_vsip_ppo_t *ppo);
 
+int trn_cli_parse_network_policy_protocol_port_key(const cJSON *jsonobj,
+						   struct rpc_trn_vsip_ppo_key_t *ppo_key);
+
 int trn_cli_update_port_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_update_vpc_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_update_net_subcmd(CLIENT *clnt, int argc, char *argv[]);
@@ -112,6 +115,7 @@ int trn_cli_delete_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *a
 int trn_cli_update_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_delete_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_update_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int argc, char *argv[]);
+int trn_cli_delete_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int argc, char *argv[]);
 
 void dump_vpc(struct rpc_trn_vpc_t *vpc);
 void dump_net(struct rpc_trn_network_t *net);

--- a/src/cli/trn_cli_common.c
+++ b/src/cli/trn_cli_common.c
@@ -798,6 +798,47 @@ int trn_cli_parse_network_policy_protocol_port(const cJSON *jsonobj,
 	return 0;
 }
 
+int trn_cli_parse_network_policy_protocol_port_key(const cJSON *jsonobj,
+						   struct rpc_trn_vsip_ppo_key_t *ppo_key)
+{
+	cJSON *tunnel_id = cJSON_GetObjectItem(jsonobj, "tunnel_id");
+	cJSON *local_ip = cJSON_GetObjectItem(jsonobj, "local_ip");
+	cJSON *protocol = cJSON_GetObjectItem(jsonobj, "protocol");
+	cJSON *port = cJSON_GetObjectItem(jsonobj, "port");
+
+	if (tunnel_id == NULL) {
+		ppo_key->tunid = 0;
+	} else if (cJSON_IsString(tunnel_id)) {
+		ppo_key->tunid = atoi(tunnel_id->valuestring);
+	} else {
+		print_err("Error: Network policy tunnel_id is non-string.\n");
+		return -EINVAL;
+	}
+
+	if (local_ip != NULL && cJSON_IsString(local_ip)) {
+		ppo_key->local_ip = parse_ip_address(local_ip);
+	} else {
+		print_err("Error: Network policy local IP is missing or non-string\n");
+		return -EINVAL;
+	}
+
+	if (cJSON_IsString(protocol)) {
+		ppo_key->proto = atoi(protocol->valuestring);
+	} else {
+		print_err("Error: Network policy protocol Error\n");
+		return -EINVAL;
+	}
+
+	if (cJSON_IsString(port)) {
+		ppo_key->port = atoi(port->valuestring);
+	} else {
+		print_err("Error: Network policy port Error\n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 uint32_t parse_ip_address(const cJSON *ipobj)
 {
 	struct sockaddr_in sa;

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -706,6 +706,38 @@ static void test_update_transit_network_policy_protocol_port_1_svc(void **state)
 	assert_int_equal(*rc, 0);
 }
 
+static void test_delete_transit_network_policy_protocol_port_1_svc(void **state)
+{
+	UNUSED(state);
+	char itf[] = "lo";
+
+	struct rpc_trn_vsip_ppo_key_t ppo_key = {
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x300000a,
+		.proto = 6,
+		.port = 6379
+	};
+
+	int *rc;
+	/* Test delete_transit_network_policy_protocol_port_1 with valid ppo_key */
+	will_return(__wrap_bpf_map_delete_elem, TRUE);
+	expect_function_call(__wrap_bpf_map_delete_elem);
+	rc = delete_transit_network_policy_protocol_port_1_svc(&ppo_key, NULL);
+	assert_int_equal(*rc, 0);
+
+	/* Test delete_transit_network_policy_protocol_port_1 with invalid ppo_key */
+	will_return(__wrap_bpf_map_delete_elem, FALSE);
+	expect_function_call(__wrap_bpf_map_delete_elem);
+	rc = delete_transit_network_policy_protocol_port_1_svc(&ppo_key, NULL);
+	assert_int_equal(*rc, RPC_TRN_FATAL);
+
+	/* Test delete_transit_network_policy_protocol_port_1 with invalid interface*/
+	ppo_key.interface = "";
+	rc = delete_transit_network_policy_protocol_port_1_svc(&ppo_key, NULL);
+	assert_int_equal(*rc, RPC_TRN_ERROR);
+}
+
 static void test_get_vpc_1_svc(void **state)
 {
 	UNUSED(state);
@@ -1303,7 +1335,8 @@ int main()
 		cmocka_unit_test(test_delete_transit_network_policy_1_svc),
 		cmocka_unit_test(test_update_transit_network_policy_enforcement_1_svc),
 		cmocka_unit_test(test_delete_transit_network_policy_enforcement_1_svc),
-		cmocka_unit_test(test_update_transit_network_policy_protocol_port_1_svc)
+		cmocka_unit_test(test_update_transit_network_policy_protocol_port_1_svc),
+		cmocka_unit_test(test_delete_transit_network_policy_protocol_port_1_svc)
 	};
 
 	int result = cmocka_run_group_tests(tests, groupSetup, groupTeardown);

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1480,3 +1480,41 @@ int *update_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_t *ppo, 
 error:
 	return &result;
 }
+
+int *delete_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_key_t *ppo_key, struct svc_req *rqstp)
+{
+	UNUSED(rqstp);
+	static int result;
+	int rc;
+	char *itf = ppo_key->interface;
+	struct vsip_ppo_t policy;
+
+	TRN_LOG_INFO("delete_transit_network_policy_protocol_port_1 service");
+
+	struct user_metadata_t *md = trn_itf_table_find(itf);
+	if (!md) {
+		TRN_LOG_ERROR("Cannot find interface metadata for %s", itf);
+		result = RPC_TRN_ERROR;
+		goto error;
+	}
+
+	policy.tunnel_id = ppo_key->tunid;
+	policy.local_ip = ppo_key->local_ip;
+	policy.proto = ppo_key->proto;
+	policy.port = ppo_key->port;
+
+	rc = trn_delete_transit_network_policy_protocol_port_map(md, &policy);
+
+	if (rc != 0) {
+		TRN_LOG_ERROR("Failure updating transit network policy enforcement map ip address: 0x%x, for interface %s",
+					ppo_key->local_ip, ppo_key->interface);
+		result = RPC_TRN_FATAL;
+		goto error;
+	}
+
+	result = 0;
+	return &result;
+
+error:
+	return &result;
+}

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -752,3 +752,16 @@ int trn_update_transit_network_policy_protocol_port_map(struct user_metadata_t *
 	}
 	return 0;
 }
+
+int trn_delete_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
+						        struct vsip_ppo_t *policy)
+{
+	int err = bpf_map_delete_elem(md->ing_vsip_ppo_map_fd, policy);
+
+	if (err) {
+		TRN_LOG_ERROR("Delete Protocol-Port ingress map failed (err:%d).",
+				err);
+		return 1;
+	}
+	return 0;
+}

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -243,3 +243,6 @@ int trn_delete_transit_network_policy_enforcement_map(struct user_metadata_t *md
 int trn_update_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
 						        struct vsip_ppo_t *policy,
 						        __u64 bitmap);
+
+int trn_delete_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
+						        struct vsip_ppo_t *policy);

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -198,6 +198,15 @@ struct rpc_trn_vsip_ppo_t {
        uint64_t bit_val;
 };
 
+/* Defines a network policy protocol port table key */
+struct rpc_trn_vsip_ppo_key_t {
+       string interface<20>;
+       uint64_t tunid;
+       uint32_t local_ip;
+       uint8_t proto;
+       uint16_t port;
+};
+
 /*----- Protocol. -----*/
 
 program RPC_TRANSIT_REMOTE_PROTOCOL {
@@ -235,6 +244,7 @@ program RPC_TRANSIT_REMOTE_PROTOCOL {
                 int UPDATE_TRANSIT_NETWORK_POLICY_ENFORCEMENT(rpc_trn_vsip_enforce_t) = 25;
                 int DELETE_TRANSIT_NETWORK_POLICY_ENFORCEMENT(rpc_trn_vsip_enforce_t) = 26;
                 int UPDATE_TRANSIT_NETWORK_POLICY_PROTOCOL_PORT(rpc_trn_vsip_ppo_t) = 27;
+                int DELETE_TRANSIT_NETWORK_POLICY_PROTOCOL_PORT(rpc_trn_vsip_ppo_key_t) = 28;
 
           } = 1;
 


### PR DESCRIPTION
This PR partially resolves issue #270 #269

User inputs cli delete-network-policy-protocol-port-ingress to delete entries in network policy protocol port bpf maps.

The Cli command triggers RPC call and then perform bpf map delete in transit agent.