### PR TITLE
egress and ingress xdp consult the derived policy to check reply UDP packets

### DIFF
--- a/src/xdp/conntrack_common.h
+++ b/src/xdp/conntrack_common.h
@@ -63,3 +63,163 @@ static inline int conntrack_is_reply_of_tracked_conn(void *conntracks, __u64 tun
 	};
 	return NULL != bpf_map_lookup_elem(conntracks, &rev_conn);
 }
+
+/*
+   check if ingress network policy should be enforced to specific destination
+   return value:
+     0 (false) :    no ingress policy
+     non-0 (true) : need to enforce ingress policy check
+*/
+__ALWAYS_INLINE__
+static inline int is_ingress_enforced(__u64 tunnel_id, __be32 ip_addr)
+{
+	struct vsip_enforce_t vsip = { .tunnel_id = tunnel_id,
+				       .local_ip = ip_addr };
+	__u8 *v = bpf_map_lookup_elem(&ing_vsip_enforce_map, &vsip);
+	return v && *v;
+}
+
+/*
+   enforce_ingress_policy enforces egress network policy with the (incoming) packet
+   return value:
+     0: ingress policy allows this packet; no error
+    -1: ingress policy denies this packet; ingress policy denial error
+*/
+__ALWAYS_INLINE__
+static inline int enforce_ingress_policy(__u64 tunnel_id, const struct ipv4_tuple_t *ipv4_tuple)
+{
+	const __u32 full_vsip_cidr_prefix = (__u32)(sizeof(struct vsip_cidr_t) - sizeof(__u32)) * 8;
+
+	struct vsip_ppo_t vsip_ppo = {
+		.tunnel_id = tunnel_id,
+		.local_ip = ipv4_tuple->daddr,
+		.proto = 0, 	// L3
+		.port = 0, 	// L3
+	};
+	__u64 *policies_l3 = bpf_map_lookup_elem(&ing_vsip_ppo_map, &vsip_ppo);
+	__u64 policies_ppo = (policies_l3) ? *policies_l3 : 0;
+
+	vsip_ppo.proto = ipv4_tuple->protocol;	// L4
+	vsip_ppo.port = ipv4_tuple->dport;	// L4
+	__u64 *policies_l4 = bpf_map_lookup_elem(&ing_vsip_ppo_map, &vsip_ppo);
+	if (policies_l4) policies_ppo |= *policies_l4;
+
+	if (0 == policies_ppo) return -1;
+
+	struct vsip_cidr_t vsip_cidr = {
+		.prefixlen = full_vsip_cidr_prefix,
+		.tunnel_id = tunnel_id,
+		.local_ip = ipv4_tuple->daddr,
+		.remote_ip = ipv4_tuple->saddr,
+	};
+	__u64 *policies_sip_prim = bpf_map_lookup_elem(&ing_vsip_prim_map, &vsip_cidr);
+	if (policies_sip_prim && (policies_ppo & *policies_sip_prim))
+		return 0;
+
+	__u64 *policies_sip_supp = bpf_map_lookup_elem(&ing_vsip_supp_map, &vsip_cidr);
+	__u64 *policies_sip_except = bpf_map_lookup_elem(&ing_vsip_except_map, &vsip_cidr);
+	if (policies_sip_supp) {
+		__u64 excepts = (policies_sip_except) ? *policies_sip_except : 0;
+		if ((*policies_sip_supp & ~excepts) & policies_ppo)
+			return 0;
+	}
+
+	return -1;
+}
+
+/*
+   ingress_policy_check checks whether an incoming packet of the specific tunnel id and connection tuple
+     should be allowed or denied
+   return value:
+     0: allows this packet; no error (by either open policy or an allowing ingress policy)
+    -1: denies this packet; ingress policy denial error
+*/
+__ALWAYS_INLINE__
+static inline int ingress_policy_check(__u64 tunnel_id, const struct ipv4_tuple_t *ipv4_tuple)
+{
+	if (!is_ingress_enforced(tunnel_id, ipv4_tuple->daddr))
+		return 0;
+
+	return enforce_ingress_policy(tunnel_id, ipv4_tuple);
+}
+
+/*
+   check if egress network policy should be enforced
+   return value:
+     0 (false) :    no egress policy
+     non-0 (true) : need to enforce egress policy check
+*/
+__ALWAYS_INLINE__
+static inline int is_egress_enforced(__u64 tunnel_id, __be32 ip_addr)
+{
+	// todo: use agent metadata applicable field in lieu of packet metadata
+	struct vsip_enforce_t vsip = {.tunnel_id = tunnel_id, .local_ip = ip_addr};
+	__u8 *v = bpf_map_lookup_elem(&eg_vsip_enforce_map, &vsip);
+	return v && *v;
+}
+
+/*
+   enforce_egress_policy enforces egress network policy with the (outgoing) packet
+   return value:
+     0: egress policy allows this packet; no error
+    -1: egress policy denies this packet; egress policy denial error
+*/
+__ALWAYS_INLINE__
+static inline int enforce_egress_policy(__u64 tunnel_id, const struct ipv4_tuple_t *ipv4_tuple)
+{
+	const __u32 full_vsip_cidr_prefix = (__u32)(sizeof(struct vsip_cidr_t) - sizeof(__u32)) * 8;
+
+	struct vsip_ppo_t vsip_ppo = {
+		.tunnel_id = tunnel_id,
+		.local_ip = ipv4_tuple->saddr,
+		.proto = 0,	// L3
+		.port = 0,	// L3
+	};
+	__u64 *policies_l3 = bpf_map_lookup_elem(&eg_vsip_ppo_map, &vsip_ppo);
+	__u64 policies_ppo = (policies_l3) ? *policies_l3 : 0;
+
+	vsip_ppo.proto = ipv4_tuple->protocol;	// L4
+	vsip_ppo.port = ipv4_tuple->dport;	// L4
+	__u64 *policies_l4 = bpf_map_lookup_elem(&eg_vsip_ppo_map, &vsip_ppo);
+	if (policies_l4) policies_ppo |= *policies_l4;
+
+	if (0 == policies_ppo) {
+		return -1;
+	}
+
+	struct vsip_cidr_t vsip_cidr = {
+		.prefixlen = full_vsip_cidr_prefix,
+		.tunnel_id = tunnel_id,
+		.local_ip = ipv4_tuple->saddr,
+		.remote_ip = ipv4_tuple->daddr,
+	};
+	__u64 *policies_dip_prim = bpf_map_lookup_elem(&eg_vsip_prim_map, &vsip_cidr);
+	if (policies_dip_prim && (policies_ppo & *policies_dip_prim))
+		return 0;
+
+	__u64 *policies_dip_supp = bpf_map_lookup_elem(&eg_vsip_supp_map, &vsip_cidr);
+	__u64 *policies_dip_except = bpf_map_lookup_elem(&eg_vsip_except_map, &vsip_cidr);
+	if (policies_dip_supp) {
+		__u64 excepts = (policies_dip_except) ? *policies_dip_except : 0;
+		if ((*policies_dip_supp & ~excepts) & policies_ppo)
+			return 0;
+	}
+
+	return -1;
+}
+
+/*
+   egress_policy_check checks whether an incoming packet of the specific tunnel id and connection tuple
+     should be allowed or denied
+   return value:
+     0: allows this packet; no error (by either open policy or an allowing egress policy)
+    -1: denies this packet; ingress policy denial error
+*/
+__ALWAYS_INLINE__
+static inline int egress_policy_check(__u64 tunnel_id, const struct ipv4_tuple_t *ipv4_tuple)
+{
+	if (!is_egress_enforced(tunnel_id, ipv4_tuple->saddr))
+		return 0;
+
+	return enforce_egress_policy(tunnel_id, ipv4_tuple);
+}

--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -336,7 +336,7 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 	// todo: add conn_track related logic properly
 	if (pkt->inner_ipv4_tuple.protocol == IPPROTO_TCP || pkt->inner_ipv4_tuple.protocol == IPPROTO_UDP) {
 		// todo: handle udp reply even when the originated connection is marked as denied;
-		// this is necessary to check the derived policy rules as policy night have been updated to allow;
+		// this is necessary to check the derived policy rules as policy might have been updated to allow;
 		// the impl will be after the conn_track has connection states.
 		if (conntrack_is_reply_of_tracked_conn(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple)){
 			if (pkt->inner_ipv4_tuple.protocol == IPPROTO_UDP) {
@@ -356,6 +356,7 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 					return XDP_ABORTED;
 				}
 			}
+			// todo: get rid of goto
 			goto xdp_continue;
 		}
 

--- a/src/xdp/trn_transit_xdp.c
+++ b/src/xdp/trn_transit_xdp.c
@@ -449,7 +449,7 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 	// todo: add conn_track related logic properly
 	if (pkt->inner_ipv4_tuple.protocol == IPPROTO_TCP || pkt->inner_ipv4_tuple.protocol == IPPROTO_UDP) {
 		// todo: handle udp reply even when the originated connection is marked as denied;
-		// this is necessary to check the derived policy rules as policy night have been updated to allow;
+		// this is necessary to check the derived policy rules as policy might have been updated to allow;
 		// the impl will be after the conn_track has connection states.
 		if (conntrack_is_reply_of_tracked_conn(&conn_track_cache, tunnel_id, &pkt->inner_ipv4_tuple)){
 			if (pkt->inner_ipv4_tuple.protocol == IPPROTO_UDP) {
@@ -470,6 +470,7 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 					return XDP_ABORTED;
 				}
 			}
+			// todo: get rid of goto
 			goto xdp_continue;
 		}
 


### PR DESCRIPTION
This closes #305.

Based on the mizar network policy and conn_track design, the decision to allow or deny UDP a reply packet should consult the _derived_ policy rule (which is derived from the one of originated direction), so that UDP stream in reply direction can be blocked after the originated policy has updated to deny the _originated_ traffic, the reply stream should go to halt as the reasonable intent. To check the _derived_ rule of a udp reply, ingress policy enforcement can simply work out the egress policy result of a synthesized egress packet, and egress policy enforcement does to ingress policy result of a synthesized ingress packet, respectively.

This PR moves all the policy check functions in the shared header which will be included by both ingress and egress xdp source code, and it implements the _derived_ policy check logic for ingress/egress policy reply packet check using hese functions.

There will be more PRs to introduce tracked connection states, which will cause slight change to the code that the PR makes.