### PR TITLE
switch to batch update for transit network policy cidr

### DIFF
--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -2145,7 +2145,7 @@ static void test_trn_cli_update_transit_network_policy_subcmd(void **state)
 			  }]) };
 	char itf[] = "eth0";
 
-	struct rpc_trn_vsip_cidr_t exp_policy1 = {
+	struct rpc_trn_vsip_cidr_t policies[2] = {{
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x300000a,
@@ -2153,9 +2153,8 @@ static void test_trn_cli_update_transit_network_policy_subcmd(void **state)
 		.cidr_ip = 0x90000ac,
 		.cidr_type = 1,
 		.bit_val = 10
-	};
-
-	struct rpc_trn_vsip_cidr_t exp_policy2 = {
+	},
+	{
 		.interface = itf,
 		.tunid = 1,
 		.local_ip = 0x100000a,
@@ -2163,11 +2162,7 @@ static void test_trn_cli_update_transit_network_policy_subcmd(void **state)
 		.cidr_ip = 0x60000ac,
 		.cidr_type = 2,
 		.bit_val = 1
-	};
-
-	struct rpc_trn_vsip_cidr_t policies[2];
-	policies[0] = exp_policy1;
-	policies[1] = exp_policy2;
+	}};
 
 	/* Test call update_transit_network_policy successfully */
 	TEST_CASE("update-network-policy-ingress succeed with well formed policy json input");

--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -2110,35 +2110,42 @@ static void test_trn_cli_update_transit_network_policy_subcmd(void **state)
 	int update_transit_network_policy_1_ret_val = 0;
 
 	/* Test cases */
-	char *argv1[] = { "update-network-policy-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv1[] = { "update-network-policy-ingress", "-i", "eth0", "-j", QUOTE([{
 				  "tunnel_id": "3",
 				  "local_ip": "10.0.0.3",
 				  "cidr_prefixlen": "16",
 				  "cidr_ip": "172.0.0.9",
 				  "cidr_type": "1",
 				  "bit_value": "10"
-			  }) };
+			  },
+			  {
+				  "tunnel_id": "1",
+				  "local_ip": "10.0.0.1",
+				  "cidr_prefixlen": "17",
+				  "cidr_ip": "172.0.0.6",
+				  "cidr_type": "2",
+				  "bit_value": "1"
+			  }]) };
 
-	char *argv2[] = { "update-network-policy-ingress", "-i", "eth0", "-j", QUOTE({
-				  "tunnel_id": 3,
-				  "local_ip": "10.0.0.3",
-				  "cidr_prefixlen": "16",
-				  "cidr_ip": "172.0.0.9",
-				  "cidr_type": "1",
-				  "bit_value": "10"
-			  }) };
-
-	char *argv3[] = { "update-network-policy-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv2[] = { "update-network-policy-ingress", "-i", "eth0", "-j", QUOTE([{
 				  "tunnel_id": "3",
 				  "local_ip": 10.0.0.3,
 				  "cidr_prefixlen": "16",
 				  "cidr_ip": "172.0.0.9",
 				  "cidr_type": "1",
 				  "bit_value": "10"
-			  }) };
+			  },
+			  {
+				  "tunnel_id": "1",
+				  "local_ip": 10.0.0.1,
+				  "cidr_prefixlen": "17",
+				  "cidr_ip": "172.0.0.6",
+				  "cidr_type": "2",
+				  "bit_value": "1"
+			  }]) };
 	char itf[] = "eth0";
 
-	struct rpc_trn_vsip_cidr_t exp_policy = {
+	struct rpc_trn_vsip_cidr_t exp_policy1 = {
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x300000a,
@@ -2148,24 +2155,33 @@ static void test_trn_cli_update_transit_network_policy_subcmd(void **state)
 		.bit_val = 10
 	};
 
+	struct rpc_trn_vsip_cidr_t exp_policy2 = {
+		.interface = itf,
+		.tunid = 1,
+		.local_ip = 0x100000a,
+		.cidr_prefixlen = 17,
+		.cidr_ip = 0x60000ac,
+		.cidr_type = 2,
+		.bit_val = 1
+	};
+
+	struct rpc_trn_vsip_cidr_t policies[2];
+	policies[0] = exp_policy1;
+	policies[1] = exp_policy2;
+
 	/* Test call update_transit_network_policy successfully */
 	TEST_CASE("update-network-policy-ingress succeed with well formed policy json input");
 	update_transit_network_policy_1_ret_val = 0;
 	expect_function_call(__wrap_update_transit_network_policy_1);
 	will_return(__wrap_update_transit_network_policy_1, &update_transit_network_policy_1_ret_val);
-	expect_check(__wrap_update_transit_network_policy_1, policy, check_policy_equal, &exp_policy);
+	expect_check(__wrap_update_transit_network_policy_1, policy, check_policy_equal, policies);
 	expect_any(__wrap_update_transit_network_policy_1, clnt);
 	rc = trn_cli_update_transit_network_policy_subcmd(NULL, argc, argv1);
 	assert_int_equal(rc, 0);
 
-	/* Test parse network policy input error*/
-	TEST_CASE("update-network-policy-ingress is not called with non-string field");
-	rc = trn_cli_update_transit_network_policy_subcmd(NULL, argc, argv2);
-	assert_int_equal(rc, -EINVAL);
-
 	/* Test parse network policy input error 2*/
 	TEST_CASE("update-network-policy-ingress is not called malformed json");
-	rc = trn_cli_update_transit_network_policy_subcmd(NULL, argc, argv3);
+	rc = trn_cli_update_transit_network_policy_subcmd(NULL, argc, argv2);
 	assert_int_equal(rc, -EINVAL);
 
 	/* Test call update_transit_network_policy_1 return error*/

--- a/src/cli/trn_cli_network_policy.c
+++ b/src/cli/trn_cli_network_policy.c
@@ -49,6 +49,7 @@ int trn_cli_update_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *a
 	{
 		struct rpc_trn_vsip_cidr_t cidrval;
 		cidrval.interface = conf.intf;
+		cidrval.count = counter;
 		cJSON *policy = cJSON_GetArrayItem(json_str, i);
 		int err = trn_cli_parse_network_policy_cidr(policy, &cidrval);
 
@@ -344,6 +345,7 @@ void dump_network_policy(struct rpc_trn_vsip_cidr_t *policy)
 	print_msg("CIDR IP: %x\n", policy->cidr_ip);
 	print_msg("CIDR Type: %d\n", policy->cidr_type);
 	print_msg("bit value: %ld\n", policy->bit_val);
+	print_msg("counter: %d\n", policy->count);
 }
 
 void dump_enforced_policy(struct rpc_trn_vsip_enforce_t *enforce)

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -587,8 +587,8 @@ static void test_update_agent_md_1_svc(void **state)
 static void test_update_transit_network_policy_1_svc(void **state)
 {
 	UNUSED(state);
-
 	char itf[] = "lo";
+	struct rpc_trn_vsip_cidr_t policies[2];
 
 	struct rpc_trn_vsip_cidr_t policy1 = {
 		.interface = itf,
@@ -600,9 +600,21 @@ static void test_update_transit_network_policy_1_svc(void **state)
 		.bit_val = 4
 	};
 
+	struct rpc_trn_vsip_cidr_t policy2 = {
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x100000a,
+		.cidr_prefixlen = 16,
+		.cidr_ip = 0xac00012,
+		.cidr_type = 2,
+		.bit_val = 4
+	};
+
+	policies[0] = policy1;
+	policies[1] = policy2;
+
 	int *rc;
-	expect_function_call(__wrap_bpf_map_update_elem);
-	rc = update_transit_network_policy_1_svc(&policy1, NULL);
+	rc = update_transit_network_policy_1_svc(policies, NULL);
 	assert_int_equal(*rc, 0);
 }
 

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -588,9 +588,8 @@ static void test_update_transit_network_policy_1_svc(void **state)
 {
 	UNUSED(state);
 	char itf[] = "lo";
-	struct rpc_trn_vsip_cidr_t policies[2];
 
-	struct rpc_trn_vsip_cidr_t policy1 = {
+	struct rpc_trn_vsip_cidr_t policies[2] = {{
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x100000a,
@@ -598,9 +597,8 @@ static void test_update_transit_network_policy_1_svc(void **state)
 		.cidr_ip = 0xac00012,
 		.cidr_type = 1,
 		.bit_val = 4
-	};
-
-	struct rpc_trn_vsip_cidr_t policy2 = {
+	},
+	{
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x100000a,
@@ -608,10 +606,7 @@ static void test_update_transit_network_policy_1_svc(void **state)
 		.cidr_ip = 0xac00012,
 		.cidr_type = 2,
 		.bit_val = 4
-	};
-
-	policies[0] = policy1;
-	policies[1] = policy2;
+	}};
 
 	int *rc;
 	rc = update_transit_network_policy_1_svc(policies, NULL);

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -596,7 +596,8 @@ static void test_update_transit_network_policy_1_svc(void **state)
 		.cidr_prefixlen = 16,
 		.cidr_ip = 0xac00012,
 		.cidr_type = 1,
-		.bit_val = 4
+		.bit_val = 4,
+		.count = 2
 	},
 	{
 		.interface = itf,
@@ -605,10 +606,12 @@ static void test_update_transit_network_policy_1_svc(void **state)
 		.cidr_prefixlen = 16,
 		.cidr_ip = 0xac00012,
 		.cidr_type = 2,
-		.bit_val = 4
+		.bit_val = 4,
+		.count = 2
 	}};
 
 	int *rc;
+	expect_function_calls(__wrap_bpf_map_update_elem, 2);
 	rc = update_transit_network_policy_1_svc(policies, NULL);
 	assert_int_equal(*rc, 0);
 }

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1269,7 +1269,7 @@ int *update_transit_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc
 	char *itf = policy->interface;
 	int type = policy->cidr_type;
 
-	int counter = (int)(sizeof(policy) / sizeof(rpc_trn_vsip_cidr_t));
+	int counter = (int)(sizeof(policy) / sizeof(struct rpc_trn_vsip_cidr_t));
 	if (counter == 0)
 	{
 		TRN_LOG_INFO("policy has length of 0. Nothing to do");

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1267,7 +1267,18 @@ int *update_transit_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc
 	static int result;
 	int rc;
 	char *itf = policy->interface;
-	struct vsip_cidr_t cidr;
+	int type = policy->cidr_type;
+
+	int counter = (int)(sizeof(policy) / sizeof(rpc_trn_vsip_cidr_t));
+	if (counter == 0)
+	{
+		TRN_LOG_INFO("policy has length of 0. Nothing to do");
+		result = 0;
+		return &result;
+	}
+
+	struct vsip_cidr_t cidr[counter];
+	__u64 bitmap[counter];
 
 	TRN_LOG_INFO("update_transit_network_policy_1_svc service");
 
@@ -1278,22 +1289,26 @@ int *update_transit_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc
 		goto error;
 	}
 
-	cidr.tunnel_id = policy->tunid;
-	// Add explaination here for magic number 96
-	cidr.prefixlen = policy->cidr_prefixlen + 96;
-	cidr.local_ip = policy->local_ip;
-	cidr.remote_ip = policy->cidr_ip;
-	__u64 bitmap = policy->bit_val;
+	for (int i = 0; i < counter; i++)
+	{
+		cidr[i].tunnel_id = policy->tunid;
+		// Add explaination here for magic number 96
+		cidr[i].prefixlen = policy->cidr_prefixlen + 96;
+		cidr[i].local_ip = policy->local_ip;
+		cidr[i].remote_ip = policy->cidr_ip;
+		bitmap[i] = policy->bit_val;
+		policy++;
+	}
 
-	switch (policy->cidr_type) {
+	switch (type) {
 	case PRIMARY:
-		rc = trn_update_transit_network_policy_primary_map(md, &cidr, bitmap);
+		rc = trn_update_transit_network_policy_primary_map(md, cidr, bitmap);
 		break;
 	case SUPPLEMENTARY:
-		rc = trn_update_transit_network_policy_supplementary_map(md, &cidr, bitmap);
+		rc = trn_update_transit_network_policy_supplementary_map(md, cidr, bitmap);
 		break;
 	case EXCEPTION:
-		rc = trn_update_transit_network_policy_except_map(md, &cidr, bitmap);
+		rc = trn_update_transit_network_policy_except_map(md, cidr, bitmap);
 		break;
 	default:
 		result = RPC_TRN_FATAL;
@@ -1301,8 +1316,7 @@ int *update_transit_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc
 	}
 
 	if (rc != 0) {
-		TRN_LOG_ERROR("Failure updating transit network policy map cidr: 0x%x / %d, for interface %s",
-					policy->cidr_ip, policy->cidr_prefixlen, policy->interface);
+		TRN_LOG_ERROR("Failure updating transit network policy map cidr.");
 		result = RPC_TRN_FATAL;
 		goto error;
 	}

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1266,10 +1266,10 @@ int *update_transit_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc
 	UNUSED(rqstp);
 	static int result;
 	int rc;
-	char *itf = policy->interface;
-	int type = policy->cidr_type;
+	char *itf = policy[0].interface;
+	int type = policy[0].cidr_type;
 
-	int counter = (int)(sizeof(policy) / sizeof(struct rpc_trn_vsip_cidr_t));
+	int counter = policy[0].count;
 	if (counter == 0)
 	{
 		TRN_LOG_INFO("policy has length of 0. Nothing to do");
@@ -1302,13 +1302,13 @@ int *update_transit_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc
 
 	switch (type) {
 	case PRIMARY:
-		rc = trn_update_transit_network_policy_primary_map(md, cidr, bitmap);
+		rc = trn_update_transit_network_policy_primary_map(md, cidr, bitmap, counter);
 		break;
 	case SUPPLEMENTARY:
-		rc = trn_update_transit_network_policy_supplementary_map(md, cidr, bitmap);
+		rc = trn_update_transit_network_policy_supplementary_map(md, cidr, bitmap, counter);
 		break;
 	case EXCEPTION:
-		rc = trn_update_transit_network_policy_except_map(md, cidr, bitmap);
+		rc = trn_update_transit_network_policy_except_map(md, cidr, bitmap, counter);
 		break;
 	default:
 		result = RPC_TRN_FATAL;

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -639,39 +639,58 @@ uint32_t trn_get_interface_ipv4(int itf_idx)
 
 int trn_update_transit_network_policy_primary_map(struct user_metadata_t *md,
 						  struct vsip_cidr_t *ipcidr,
-						  __u64 bitmap)
+						  __u64 *bitmap)
 {
-	int err = bpf_map_update_elem(md->ing_vsip_prim_map_fd, ipcidr, &bitmap, 0);
-	if (err) {
-		TRN_LOG_ERROR("Store Primary ingress map failed (err:%d).",
-			      err);
-		return 1;
+	int counter = (int)(sizeof(ipcidr) / sizeof(*ipcidr));
+	for (int i = 0; i < counter; i++)
+	{
+		int err = bpf_map_update_elem(md->ing_vsip_prim_map_fd, ipcidr, bitmap, 0);
+		if (err) {
+			TRN_LOG_ERROR("Store Primary ingress map failed (err:%d).",
+				err);
+			return 1;
+		}
+		ipcidr++;
+		bitmap++;
 	}
+
 	return 0;
 }
 
 int trn_update_transit_network_policy_supplementary_map(struct user_metadata_t *md,
 							struct vsip_cidr_t *ipcidr,
-							__u64 bitmap)
+							__u64 *bitmap)
 {
-	int err = bpf_map_update_elem(md->ing_vsip_supp_map_fd, ipcidr, &bitmap, 0);
-	if (err) {
-		TRN_LOG_ERROR("Store Supplementary ingress map failed (err:%d).",
-			      err);
-		return 1;
+	int counter = (int)(sizeof(ipcidr) / sizeof(*ipcidr));
+	for (int i = 0; i < counter; i++)
+	{
+		int err = bpf_map_update_elem(md->ing_vsip_supp_map_fd, ipcidr, bitmap, 0);
+		if (err) {
+			TRN_LOG_ERROR("Store Supplementary ingress map failed (err:%d).",
+				err);
+			return 1;
+		}
+		ipcidr++;
+		bitmap++;
 	}
 	return 0;
 }
 
 int trn_update_transit_network_policy_except_map(struct user_metadata_t *md,
 						 struct vsip_cidr_t *ipcidr,
-						 __u64 bitmap)
+						 __u64 *bitmap)
 {
-	int err = bpf_map_update_elem(md->ing_vsip_except_map_fd, ipcidr, &bitmap, 0);
-	if (err) {
-		TRN_LOG_ERROR("Store Except ingress map failed (err:%d).",
-			      err);
-		return 1;
+	int counter = (int)(sizeof(ipcidr) / sizeof(*ipcidr));
+	for (int i = 0; i < counter; i++)
+	{
+		int err = bpf_map_update_elem(md->ing_vsip_except_map_fd, ipcidr, bitmap, 0);
+		if (err) {
+			TRN_LOG_ERROR("Store Except ingress map failed (err:%d).",
+				err);
+			return 1;
+		}
+		ipcidr++;
+		bitmap++;
 	}
 	return 0;
 }

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -641,7 +641,7 @@ int trn_update_transit_network_policy_primary_map(struct user_metadata_t *md,
 						  struct vsip_cidr_t *ipcidr,
 						  __u64 *bitmap)
 {
-	int counter = (int)(sizeof(ipcidr) / sizeof(*ipcidr));
+	int counter = (int)(sizeof(ipcidr) / sizeof(struct vsip_cidr_t));
 	for (int i = 0; i < counter; i++)
 	{
 		int err = bpf_map_update_elem(md->ing_vsip_prim_map_fd, ipcidr, bitmap, 0);
@@ -661,7 +661,7 @@ int trn_update_transit_network_policy_supplementary_map(struct user_metadata_t *
 							struct vsip_cidr_t *ipcidr,
 							__u64 *bitmap)
 {
-	int counter = (int)(sizeof(ipcidr) / sizeof(*ipcidr));
+	int counter = (int)(sizeof(ipcidr) / sizeof(struct vsip_cidr_t));
 	for (int i = 0; i < counter; i++)
 	{
 		int err = bpf_map_update_elem(md->ing_vsip_supp_map_fd, ipcidr, bitmap, 0);
@@ -680,7 +680,7 @@ int trn_update_transit_network_policy_except_map(struct user_metadata_t *md,
 						 struct vsip_cidr_t *ipcidr,
 						 __u64 *bitmap)
 {
-	int counter = (int)(sizeof(ipcidr) / sizeof(*ipcidr));
+	int counter = (int)(sizeof(ipcidr) / sizeof(struct vsip_cidr_t));
 	for (int i = 0; i < counter; i++)
 	{
 		int err = bpf_map_update_elem(md->ing_vsip_except_map_fd, ipcidr, bitmap, 0);

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -639,9 +639,9 @@ uint32_t trn_get_interface_ipv4(int itf_idx)
 
 int trn_update_transit_network_policy_primary_map(struct user_metadata_t *md,
 						  struct vsip_cidr_t *ipcidr,
-						  __u64 *bitmap)
+						  __u64 *bitmap,
+						  int counter)
 {
-	int counter = (int)(sizeof(ipcidr) / sizeof(struct vsip_cidr_t));
 	for (int i = 0; i < counter; i++)
 	{
 		int err = bpf_map_update_elem(md->ing_vsip_prim_map_fd, ipcidr, bitmap, 0);
@@ -659,9 +659,9 @@ int trn_update_transit_network_policy_primary_map(struct user_metadata_t *md,
 
 int trn_update_transit_network_policy_supplementary_map(struct user_metadata_t *md,
 							struct vsip_cidr_t *ipcidr,
-							__u64 *bitmap)
+							__u64 *bitmap,
+							int counter)
 {
-	int counter = (int)(sizeof(ipcidr) / sizeof(struct vsip_cidr_t));
 	for (int i = 0; i < counter; i++)
 	{
 		int err = bpf_map_update_elem(md->ing_vsip_supp_map_fd, ipcidr, bitmap, 0);
@@ -678,9 +678,9 @@ int trn_update_transit_network_policy_supplementary_map(struct user_metadata_t *
 
 int trn_update_transit_network_policy_except_map(struct user_metadata_t *md,
 						 struct vsip_cidr_t *ipcidr,
-						 __u64 *bitmap)
+						 __u64 *bitmap,
+						 int counter)
 {
-	int counter = (int)(sizeof(ipcidr) / sizeof(struct vsip_cidr_t));
 	for (int i = 0; i < counter; i++)
 	{
 		int err = bpf_map_update_elem(md->ing_vsip_except_map_fd, ipcidr, bitmap, 0);

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -214,15 +214,15 @@ int trn_remove_prog(struct user_metadata_t *md, unsigned int prog_idx);
 
 int trn_update_transit_network_policy_primary_map(struct user_metadata_t *md,
 						  struct vsip_cidr_t *cidr,
-						  __u64 bitmap);
+						  __u64 *bitmap);
 
 int trn_update_transit_network_policy_supplementary_map(struct user_metadata_t *md,
 							struct vsip_cidr_t *cidr,
-							__u64 bitmap);
+							__u64 *bitmap);
 
 int trn_update_transit_network_policy_except_map(struct user_metadata_t *md,
 						 struct vsip_cidr_t *cidr,
-						 __u64 bitmap);
+						 __u64 *bitmap);
 
 int trn_delete_transit_network_policy_primary_map(struct user_metadata_t *md,
 						  struct vsip_cidr_t *cidr);

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -214,15 +214,18 @@ int trn_remove_prog(struct user_metadata_t *md, unsigned int prog_idx);
 
 int trn_update_transit_network_policy_primary_map(struct user_metadata_t *md,
 						  struct vsip_cidr_t *cidr,
-						  __u64 *bitmap);
+						  __u64 *bitmap,
+						  int counter);
 
 int trn_update_transit_network_policy_supplementary_map(struct user_metadata_t *md,
 							struct vsip_cidr_t *cidr,
-							__u64 *bitmap);
+							__u64 *bitmap,
+							int counter);
 
 int trn_update_transit_network_policy_except_map(struct user_metadata_t *md,
 						 struct vsip_cidr_t *cidr,
-						 __u64 *bitmap);
+						 __u64 *bitmap,
+						 int counter);
 
 int trn_delete_transit_network_policy_primary_map(struct user_metadata_t *md,
 						  struct vsip_cidr_t *cidr);

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -169,6 +169,7 @@ struct rpc_trn_vsip_cidr_t {
        uint32_t cidr_prefixlen;
        int cidr_type;
        uint64_t bit_val;
+       int count;
 };
 
 /* Defines a network policy table key */


### PR DESCRIPTION
This partially resolves #294 

For network policy cidr updates, we were doing one by one bpf map update previously. To increase efficiency, we now switch to batch update