### PR TITLE
Batch delete transit network policy cidr

### DIFF
--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -2214,30 +2214,29 @@ static void test_trn_cli_delete_transit_network_policy_subcmd(void **state)
 				  "cidr_prefixlen": "16",
 				  "cidr_ip": "172.0.0.9",
 				  "cidr_type": "1"
-			  }) };
+			  },
+			  {
+				  "tunnel_id": "1",
+				  "local_ip": "10.0.0.1",
+				  "cidr_prefixlen": "17",
+				  "cidr_ip": "172.0.0.6",
+				  "cidr_type": "2"
+			  }]) };
 
 	char *argv2[] = { "delete-network-policy-ingress", "-i", "eth0", "-j", QUOTE({
-				  "tunnel_id": 3,
-				  "local_ip": "10.0.0.3",
-				  "cidr_prefixlen": "16",
-				  "cidr_ip": "172.0.0.9",
-				  "cidr_type": "1"
-			  }) };
-
-	char *argv3[] = { "delete-network-policy-ingress", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": "3",
 				  "local_ip": 10.0.0.3,
 				  "cidr_prefixlen": "16",
 				  "cidr_ip": "172.0.0.9",
 				  "cidr_type": "1"
-			  }) };
-
-	char *argv4[] = { "delete-network-policy-ingress", "-i", "eth0", "-j", QUOTE({
-				  "tunnel_id": "3",
-				  "cidr_prefixlen": "16",
-				  "cidr_ip": "172.0.0.9",
-				  "cidr_type": "1"
-			  }) };
+			  },
+			  {
+				  "tunnel_id": "1",
+				  "local_ip": 10.0.0.1,
+				  "cidr_prefixlen": "17",
+				  "cidr_ip": "172.0.0.6",
+				  "cidr_type": "2"
+			  }]) };
 
 	struct rpc_trn_vsip_cidr_key_t exp_policy_key = {
 		.interface = itf,
@@ -2258,18 +2257,9 @@ static void test_trn_cli_delete_transit_network_policy_subcmd(void **state)
 	rc = trn_cli_delete_transit_network_policy_subcmd(NULL, argc, argv1);
 	assert_int_equal(rc, 0);
 
-	/* Test parse network policy input error*/
-	TEST_CASE("delete-network-policy-ingress is not called with non-string field");
-	rc = trn_cli_delete_transit_network_policy_subcmd(NULL, argc, argv2);
-	assert_int_equal(rc, -EINVAL);
-
 	/* Test parse network policy input error 2*/
 	TEST_CASE("delete-network-policy-ingress is not called malformed json");
-	rc = trn_cli_delete_transit_network_policy_subcmd(NULL, argc, argv3);
-	assert_int_equal(rc, -EINVAL);
-
-	TEST_CASE("delete-network-policy-ingress is not called with missing required field");
-	rc = trn_cli_delete_transit_network_policy_subcmd(NULL, argc, argv4);
+	rc = trn_cli_delete_transit_network_policy_subcmd(NULL, argc, argv2);
 	assert_int_equal(rc, -EINVAL);
 
 	/* Test call delete_transit_network_policy_1 return error*/

--- a/src/cli/trn_cli_network_policy.c
+++ b/src/cli/trn_cli_network_policy.c
@@ -102,7 +102,7 @@ int trn_cli_delete_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *a
 	int counter = cJSON_GetArraySize(json_str); 
 
 	int *rc;
-	struct rpc_trn_vsip_cidr_key_t cidrkey_list[counter];
+	struct rpc_trn_vsip_cidr_key_t cidrkeys[counter];
 	char rpc[] = "delete_transit_network_policy_1";
 
 	for (int i = 0; i < counter; i++)
@@ -117,11 +117,11 @@ int trn_cli_delete_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *a
 			print_err("Error: parsing network policy config.\n");
 			return -EINVAL;
 		}
-		cidrkey_list[i] = cidrkey;
+		cidrkeys[i] = cidrkey;
 	}
 	cJSON_Delete(json_str);
 
-	rc = delete_transit_network_policy_1(cidrkey_list, clnt);
+	rc = delete_transit_network_policy_1(cidrkeys, clnt);
 	if (rc == (int *)NULL) {
 		print_err("RPC Error: client call failed: delete_transit_network_policy_1.\n");
 		return -EINVAL;

--- a/src/cli/trn_cli_network_policy.c
+++ b/src/cli/trn_cli_network_policy.c
@@ -36,11 +36,11 @@ int trn_cli_update_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *a
 
 	char *buf = conf.conf_str;
 	json_str = trn_cli_parse_json(buf);
-	int counter = cJSON_GetArraySize(json_str); 
-
 	if (json_str == NULL) {
 		return -EINVAL;
 	}
+	int counter = cJSON_GetArraySize(json_str); 
+
 	int *rc;
 	struct rpc_trn_vsip_cidr_t cidr_list[counter];
 	char rpc[] = "update_transit_network_policy_1";
@@ -96,25 +96,32 @@ int trn_cli_delete_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *a
 
 	char *buf = conf.conf_str;
 	json_str = trn_cli_parse_json(buf);
-
 	if (json_str == NULL) {
 		return -EINVAL;
 	}
+	int counter = cJSON_GetArraySize(json_str); 
 
 	int *rc;
-	struct rpc_trn_vsip_cidr_key_t cidrkey;
+	struct rpc_trn_vsip_cidr_key_t cidrkey_list[counter];
 	char rpc[] = "delete_transit_network_policy_1";
-	cidrkey.interface = conf.intf;
 
-	int err = trn_cli_parse_network_policy_cidr_key(json_str, &cidrkey);
+	for (int i = 0; i < counter; i++)
+	{
+		struct rpc_trn_vsip_cidr_key_t cidrkey;
+		cidrkey.interface = conf.intf;
+		cidrkey.count = counter;
+		cJSON *policy = cJSON_GetArrayItem(json_str, i);
+		int err = trn_cli_parse_network_policy_cidr_key(json_str, &cidrkey);
+
+		if (err != 0) {
+			print_err("Error: parsing network policy config.\n");
+			return -EINVAL;
+		}
+		cidrkey_list[i] = cidrkey;
+	}
 	cJSON_Delete(json_str);
 
-	if (err != 0) {
-		print_err("Error: parsing network policy config.\n");
-		return -EINVAL;
-	}
-
-	rc = delete_transit_network_policy_1(&cidrkey, clnt);
+	rc = delete_transit_network_policy_1(cidrkey_list, clnt);
 	if (rc == (int *)NULL) {
 		print_err("RPC Error: client call failed: delete_transit_network_policy_1.\n");
 		return -EINVAL;
@@ -127,8 +134,7 @@ int trn_cli_delete_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *a
 		return -EINVAL;
 	}
 
-	print_msg("delete_transit_network_policy_1 successfully deleted network policy cidr: 0x%x / %d, for interface %s\n",
-				cidrkey.cidr_ip, cidrkey.cidr_prefixlen, cidrkey.interface);
+	print_msg("delete_transit_network_policy_1 successfully deleted network policy cidr.\n");
 
 	return 0;
 }

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -620,31 +620,43 @@ static void test_delete_transit_network_policy_1_svc(void **state)
 {
 	UNUSED(state);
 	char itf[] = "lo";
-	struct rpc_trn_vsip_cidr_key_t policy_key = {
+	struct rpc_trn_vsip_cidr_key_t policy_keys[2] = {{
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x100000a,
 		.cidr_prefixlen = 16,
 		.cidr_ip = 0xac00012,
-		.cidr_type = 1
-	};
+		.cidr_type = 1,
+		.count = 2
+	},
+	{
+		.interface = itf,
+		.tunid = 1,
+		.local_ip = 0x900000a,
+		.cidr_prefixlen = 16,
+		.cidr_ip = 0xac00012,
+		.cidr_type = 1,
+		.count = 2
+	}};
 	int *rc;
 
 	/* Test delete_transit_network_policy_1 with valid vp_ckey */
 	will_return(__wrap_bpf_map_delete_elem, TRUE);
+	will_return(__wrap_bpf_map_delete_elem, TRUE);
 	expect_function_call(__wrap_bpf_map_delete_elem);
-	rc = delete_transit_network_policy_1_svc(&policy_key, NULL);
+	expect_function_call(__wrap_bpf_map_delete_elem);
+	rc = delete_transit_network_policy_1_svc(policy_keys, NULL);
 	assert_int_equal(*rc, 0);
 
 	/* Test delete_transit_network_policy_1 with invalid vpc_key */
 	will_return(__wrap_bpf_map_delete_elem, FALSE);
 	expect_function_call(__wrap_bpf_map_delete_elem);
-	rc = delete_transit_network_policy_1_svc(&policy_key, NULL);
+	rc = delete_transit_network_policy_1_svc(policy_keys, NULL);
 	assert_int_equal(*rc, RPC_TRN_FATAL);
 
 	/* Test delete_transit_network_policy_1 with invalid interface*/
-	policy_key.interface = "";
-	rc = delete_transit_network_policy_1_svc(&policy_key, NULL);
+	policy_keys[0].interface = "";
+	rc = delete_transit_network_policy_1_svc(policy_keys, NULL);
 	assert_int_equal(*rc, RPC_TRN_ERROR);
 }
 

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1335,9 +1335,9 @@ int *delete_transit_network_policy_1_svc(rpc_trn_vsip_cidr_key_t *policy_key, st
 	UNUSED(rqstp);
 	static int result;
 	int rc;
-	char *itf = policy_key[0].interface;
-	int type = policy_key[0].cidr_type;
-	int counter = policy_key[0].count;
+	char *itf = policy_key->interface;
+	int type = policy_key->cidr_type;
+	int counter = policy_key->count;
 
 	if (counter == 0){
 		TRN_LOG_INFO("policy list has length of 0. Nothing to do");
@@ -1357,14 +1357,13 @@ int *delete_transit_network_policy_1_svc(rpc_trn_vsip_cidr_key_t *policy_key, st
 
 	for (int i = 0; i < counter; i++)
 	{
-		cidr[i].tunnel_id = policy_key->tunid;
+		cidr[i].tunnel_id = policy_key[i].tunid;
 		// cidr-related maps have tunnel-id(64 bits),
 		// local-ip(32 bits) prior to destination cidr;
 		// hence the final prefix length is 64+32+{cidr prefix}
-		cidr[i].prefixlen = policy_key->cidr_prefixlen + 96;
-		cidr[i].local_ip = policy_key->local_ip;
-		cidr[i].remote_ip = policy_key->cidr_ip;
-		policy_key++;
+		cidr[i].prefixlen = policy_key[i].cidr_prefixlen + 96;
+		cidr[i].local_ip = policy_key[i].local_ip;
+		cidr[i].remote_ip = policy_key[i].cidr_ip;
 	}
 
 	switch (type) {

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1292,7 +1292,9 @@ int *update_transit_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc
 	for (int i = 0; i < counter; i++)
 	{
 		cidr[i].tunnel_id = policy->tunid;
-		// Add explaination here for magic number 96
+		// cidr-related maps have tunnel-id(64 bits),
+		// local-ip(32 bits) prior to destination cidr;
+		// hence the final prefix length is 64+32+{cidr prefix}
 		cidr[i].prefixlen = policy->cidr_prefixlen + 96;
 		cidr[i].local_ip = policy->local_ip;
 		cidr[i].remote_ip = policy->cidr_ip;
@@ -1333,8 +1335,16 @@ int *delete_transit_network_policy_1_svc(rpc_trn_vsip_cidr_key_t *policy_key, st
 	UNUSED(rqstp);
 	static int result;
 	int rc;
-	char *itf = policy_key->interface;
-	struct vsip_cidr_t cidr;
+	char *itf = policy_key[0].interface;
+	int type = policy_key[0].cidr_type;
+	int counter = policy_key[0].count;
+
+	if (counter == 0){
+		TRN_LOG_INFO("policy list has length of 0. Nothing to do");
+		result = 0;
+		return &result;
+	}
+	struct vsip_cidr_t cidr[counter];
 
 	TRN_LOG_INFO("delete_transit_network_policy_1_svc service");
 
@@ -1345,24 +1355,27 @@ int *delete_transit_network_policy_1_svc(rpc_trn_vsip_cidr_key_t *policy_key, st
 		goto error;
 	}
 
-	cidr.tunnel_id = policy_key->tunid;
+	for (int i = 0; i < counter; i++)
+	{
+		cidr[i].tunnel_id = policy_key->tunid;
+		// cidr-related maps have tunnel-id(64 bits),
+		// local-ip(32 bits) prior to destination cidr;
+		// hence the final prefix length is 64+32+{cidr prefix}
+		cidr[i].prefixlen = policy_key->cidr_prefixlen + 96;
+		cidr[i].local_ip = policy_key->local_ip;
+		cidr[i].remote_ip = policy_key->cidr_ip;
+		policy_key++;
+	}
 
-	// cidr-related maps have tunnel-id(64 bits),
-	// local-ip(32 bits) prior to destination cidr;
-	// hence the final prefix length is 64+32+{cidr prefix}
-	cidr.prefixlen = policy_key->cidr_prefixlen + 96;
-	cidr.local_ip = policy_key->local_ip;
-	cidr.remote_ip = policy_key->cidr_ip;
-
-	switch (policy_key->cidr_type) {
+	switch (type) {
 	case PRIMARY:
-		rc = trn_delete_transit_network_policy_primary_map(md, &cidr);
+		rc = trn_delete_transit_network_policy_primary_map(md, cidr, counter);
 		break;
 	case SUPPLEMENTARY:
-		rc = trn_delete_transit_network_policy_supplementary_map(md, &cidr);
+		rc = trn_delete_transit_network_policy_supplementary_map(md, cidr, counter);
 		break;
 	case EXCEPTION:
-		rc = trn_delete_transit_network_policy_except_map(md, &cidr);
+		rc = trn_delete_transit_network_policy_except_map(md, cidr, counter);
 		break;
 	default:
 		result = RPC_TRN_FATAL;
@@ -1370,8 +1383,7 @@ int *delete_transit_network_policy_1_svc(rpc_trn_vsip_cidr_key_t *policy_key, st
 	}
 
 	if (rc != 0) {
-		TRN_LOG_ERROR("Failure deleting transit network policy map cidr: 0x%x / %d, for interface %s",
-					policy_key->cidr_ip, policy_key->cidr_prefixlen, policy_key->interface);
+		TRN_LOG_ERROR("Failure deleting transit network policy map cidr");
 		result = RPC_TRN_FATAL;
 		goto error;
 	}

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -696,37 +696,52 @@ int trn_update_transit_network_policy_except_map(struct user_metadata_t *md,
 }
 
 int trn_delete_transit_network_policy_primary_map(struct user_metadata_t *md,
-						  struct vsip_cidr_t *cidr)
+						  struct vsip_cidr_t *cidr,
+						  int counter)
 {
-	int err = bpf_map_delete_elem(md->ing_vsip_prim_map_fd, cidr);
-	if (err) {
-		TRN_LOG_ERROR("Delete Primary ingress map failed (err:%d).",
-			      err);
-		return 1;
+	for (int i = 0; i < counter; i++)
+	{
+		int err = bpf_map_delete_elem(md->ing_vsip_prim_map_fd, cidr);
+		if (err) {
+			TRN_LOG_ERROR("Delete Primary ingress map failed (err:%d).",
+				err);
+			return 1;
+		}
+		cidr++;
 	}
 	return 0;
 }
 
 int trn_delete_transit_network_policy_supplementary_map(struct user_metadata_t *md,
-							struct vsip_cidr_t *cidr)
+							struct vsip_cidr_t *cidr,
+							int counter)
 {
-	int err = bpf_map_delete_elem(md->ing_vsip_supp_map_fd, cidr);
-	if (err) {
-		TRN_LOG_ERROR("Delete Supplementary ingress map failed (err:%d).",
-			      err);
-		return 1;
+	for (int i = 0; i < counter; i++)
+	{
+		int err = bpf_map_delete_elem(md->ing_vsip_supp_map_fd, cidr);
+		if (err) {
+			TRN_LOG_ERROR("Delete Supplementary ingress map failed (err:%d).",
+				err);
+			return 1;
+		}
+		cidr++;
 	}
 	return 0;
 }
 
 int trn_delete_transit_network_policy_except_map(struct user_metadata_t *md,
-						 struct vsip_cidr_t *cidr)
+						 struct vsip_cidr_t *cidr,
+						 int counter)
 {
-	int err = bpf_map_delete_elem(md->ing_vsip_except_map_fd, cidr);
-	if (err) {
-		TRN_LOG_ERROR("Delete Except ingress map failed (err:%d).",
-			      err);
-		return 1;
+	for (int i = 0; i < counter; i++)
+	{
+		int err = bpf_map_delete_elem(md->ing_vsip_except_map_fd, cidr);
+		if (err) {
+			TRN_LOG_ERROR("Delete Except ingress map failed (err:%d).",
+				err);
+			return 1;
+		}
+		cidr++;
 	}
 	return 0;
 }

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -228,13 +228,16 @@ int trn_update_transit_network_policy_except_map(struct user_metadata_t *md,
 						 int counter);
 
 int trn_delete_transit_network_policy_primary_map(struct user_metadata_t *md,
-						  struct vsip_cidr_t *cidr);
+						  struct vsip_cidr_t *cidr,
+						  int counter);
 
 int trn_delete_transit_network_policy_supplementary_map(struct user_metadata_t *md,
-							struct vsip_cidr_t *cidr);
+							struct vsip_cidr_t *cidr,
+							int counter);
 
 int trn_delete_transit_network_policy_except_map(struct user_metadata_t *md,
-						 struct vsip_cidr_t *cidr);
+						 struct vsip_cidr_t *cidr,
+						 int counter);
 
 int trn_update_transit_network_policy_enforcement_map(struct user_metadata_t *md,
 						      struct vsip_enforce_t *local,

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -180,6 +180,7 @@ struct rpc_trn_vsip_cidr_key_t {
        uint32_t cidr_ip;
        uint32_t cidr_prefixlen;
        int cidr_type;
+       int count;
 };
 
 /* Defines a network policy enforcement table key */


### PR DESCRIPTION
This partially resolves #294

For network policy cidr deletes, we were doing one by one bpf map delete previously. To increase efficiency, we now switch to batch delete