### PR TITLE
conn_track: set connection state for traffic denied by policy instead of simple removal 

### DIFF
--- a/src/include/trn_datamodel.h
+++ b/src/include/trn_datamodel.h
@@ -172,3 +172,9 @@ struct ipv4_ct_tuple_t {
 	struct vpc_key_t vpc;
 	struct ipv4_tuple_t tuple;
 } __attribute__((packed));
+
+enum conn_status {
+	TRFFIC_DENIED	= 1 << 0,	// traffic is denied (1) or default allowed (0)
+	UNI_DIRECTION 	= 1 << 1,	// traffic is uni-direction only, or bi-direction
+	FLAG_REEVAL 	= 1 << 2,	// need to re-evaluate allow/deny traffic
+};

--- a/src/include/trn_datamodel.h
+++ b/src/include/trn_datamodel.h
@@ -175,6 +175,6 @@ struct ipv4_ct_tuple_t {
 
 enum conn_status {
 	TRFFIC_DENIED	= 1 << 0,	// traffic is denied (1) or default allowed (0)
-	UNI_DIRECTION 	= 1 << 1,	// traffic is uni-direction only, or bi-direction
+	UNI_DIRECTION 	= 1 << 1,	// reserved; traffic is uni-direction only, or bi-direction
 	FLAG_REEVAL 	= 1 << 2,	// need to re-evaluate allow/deny traffic
 };

--- a/src/xdp/conntrack_common.h
+++ b/src/xdp/conntrack_common.h
@@ -26,15 +26,14 @@
 #include "trn_kern.h"
 
 __ALWAYS_INLINE__
-static inline int conntrack_insert_tcpudp_conn(void *conntracks, __u64 tunnel_id, const struct ipv4_tuple_t *tuple)
+static inline int conntrack_insert_tcpudp_conn(void *conntracks, __u64 tunnel_id, const struct ipv4_tuple_t *tuple, __u8 state)
 {
 	struct ipv4_ct_tuple_t conn = {
 		.vpc.tunnel_id = tunnel_id,
 		.tuple = *tuple,
 	};
-	__u8 value = 1;
 	return (tuple->protocol == IPPROTO_TCP || tuple->protocol == IPPROTO_UDP) ?
-		bpf_map_update_elem(conntracks, &conn, &value, 0) : 0;
+		bpf_map_update_elem(conntracks, &conn, &state, 0) : 0;
 }
 
 __ALWAYS_INLINE__
@@ -49,19 +48,19 @@ static inline int conntrack_remove_tcpudp_conn(void *conntracks, __u64 tunnel_id
 }
 
 __ALWAYS_INLINE__
-static inline int conntrack_is_reply_of_tracked_conn(void *conntracks, __u64 tunnel_id, const struct ipv4_tuple_t *tuple)
+static inline __u8* get_originated_conn_state(void *conntracks, __u64 tunnel_id, const struct ipv4_tuple_t *reply_tuple)
 {
 	struct ipv4_ct_tuple_t rev_conn = {
 		.vpc.tunnel_id = tunnel_id,
 		.tuple = {
-			.protocol = tuple->protocol,
-			.saddr = tuple->daddr,
-			.daddr = tuple->saddr,
-			.sport = tuple->dport,
-			.dport = tuple->sport,
+			.protocol = reply_tuple->protocol,
+			.saddr = reply_tuple->daddr,
+			.daddr = reply_tuple->saddr,
+			.sport = reply_tuple->dport,
+			.dport = reply_tuple->sport,
 		},
 	};
-	return NULL != bpf_map_lookup_elem(conntracks, &rev_conn);
+	return bpf_map_lookup_elem(conntracks, &rev_conn);
 }
 
 /*
@@ -222,4 +221,50 @@ static inline int egress_policy_check(__u64 tunnel_id, const struct ipv4_tuple_t
 		return 0;
 
 	return enforce_egress_policy(tunnel_id, ipv4_tuple);
+}
+
+/*
+   egress_reply_packet_check checks whether the outgoing (egress) reply packet of the specific tunnel id and connection tuple
+     should be allowed or denied, based on the tracked originated conn state, and the derived policy if applicable
+   return value:
+     0: allows this packet; no error (by either open policy or an allowing egress policy)
+    -1: denies this packet; ingress policy denial error
+*/
+__ALWAYS_INLINE__
+static inline int egress_reply_packet_check(__u64 tunnel_id, const struct ipv4_tuple_t *ipv4_tuple, __u8 originated_conn_state)
+{
+	if (!(originated_conn_state & FLAG_REEVAL))
+		return originated_conn_state & TRFFIC_DENIED;
+
+	struct ipv4_tuple_t originated_tuple = {
+		.protocol = ipv4_tuple->protocol,
+		.saddr = ipv4_tuple->daddr,
+		.daddr = ipv4_tuple->saddr,
+		.sport = ipv4_tuple->dport,
+		.dport = ipv4_tuple->sport,
+	};
+	return ingress_policy_check(tunnel_id, &originated_tuple);
+}
+
+/*
+   ingress_reply_packet_check checks whether the incoming (ingress) reply packet of the specific tunnel id and connection tuple
+     should be allowed or denied, based on the tracked originated conn state, and the derived policy if applicable
+   return value:
+     0: allows this packet; no error (by either open policy or an allowing egress policy)
+    -1: denies this packet; ingress policy denial error
+*/
+__ALWAYS_INLINE__
+static inline int ingress_reply_packet_check(__u64 tunnel_id, const struct ipv4_tuple_t *ipv4_tuple, __u8 originated_conn_state)
+{
+	if (!(originated_conn_state & FLAG_REEVAL))
+		return originated_conn_state & TRFFIC_DENIED;
+
+	struct ipv4_tuple_t originated_tuple = {
+		.protocol = ipv4_tuple->protocol,
+		.saddr = ipv4_tuple->daddr,
+		.daddr = ipv4_tuple->saddr,
+		.sport = ipv4_tuple->dport,
+		.dport = ipv4_tuple->sport,
+	};
+	return egress_policy_check(tunnel_id, &originated_tuple);
 }

--- a/src/xdp/conntrack_common.h
+++ b/src/xdp/conntrack_common.h
@@ -251,7 +251,7 @@ static inline int egress_reply_packet_check(__u64 tunnel_id, const struct ipv4_t
      should be allowed or denied, based on the tracked originated conn state, and the derived policy if applicable
    return value:
      0: allows this packet; no error (by either open policy or an allowing egress policy)
-    -1: denies this packet; ingress policy denial error
+     non-0: denies this packet; ingress policy denial error
 */
 __ALWAYS_INLINE__
 static inline int ingress_reply_packet_check(__u64 tunnel_id, const struct ipv4_tuple_t *ipv4_tuple, __u8 originated_conn_state)

--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -335,10 +335,11 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 
 	if (pkt->inner_ipv4_tuple.protocol == IPPROTO_TCP || pkt->inner_ipv4_tuple.protocol == IPPROTO_UDP) {
 		__u8 *tracked_state = get_originated_conn_state(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple);
+		// todo: only check for bi-directional connections
 		if (NULL != tracked_state){
 			if (0 != egress_reply_packet_check(pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple, *tracked_state))
 			{
-				bpf_debug("[Agent:%ld.0x%x] ABORTED: packet to 0x%x egress policy denied, reply of a denied UDP conn\n",
+				bpf_debug("[Agent:%ld.0x%x] ABORTED: packet to 0x%x egress policy denied, reply of a denied conn\n",
 					pkt->agent_ep_tunid,
 					bpf_ntohl(pkt->agent_ep_ipv4),
 					bpf_ntohl(pkt->inner_ip->daddr));

--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -333,29 +333,18 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 		pkt->inner_ipv4_tuple.dport = pkt->inner_udp->dest;
 	}
 
-	// todo: add conn_track related logic properly
 	if (pkt->inner_ipv4_tuple.protocol == IPPROTO_TCP || pkt->inner_ipv4_tuple.protocol == IPPROTO_UDP) {
-		// todo: handle udp reply even when the originated connection is marked as denied;
-		// this is necessary to check the derived policy rules as policy might have been updated to allow;
-		// the impl will be after the conn_track has connection states.
-		if (conntrack_is_reply_of_tracked_conn(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple)){
-			if (pkt->inner_ipv4_tuple.protocol == IPPROTO_UDP) {
-				struct ipv4_tuple_t originated_tuple = {
-					.protocol = IPPROTO_UDP,
-					.saddr = pkt->inner_ipv4_tuple.daddr,
-					.daddr = pkt->inner_ipv4_tuple.saddr,
-					.sport = pkt->inner_ipv4_tuple.dport,
-					.dport = pkt->inner_ipv4_tuple.sport,
-				};
-				if (0 != ingress_policy_check(pkt->agent_ep_tunid, &originated_tuple)){
-					bpf_debug("[Agent:%ld.0x%x] ABORTED: packet to 0x%x egress policy denied, reply of a denied UDP conn\n",
-						pkt->agent_ep_tunid,
-						bpf_ntohl(pkt->agent_ep_ipv4),
-						bpf_ntohl(pkt->inner_ip->daddr));
-					conntrack_remove_tcpudp_conn(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple);
-					return XDP_ABORTED;
-				}
+		__u8 *tracked_state = get_originated_conn_state(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple);
+		if (NULL != tracked_state){
+			if (0 != egress_reply_packet_check(pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple, *tracked_state))
+			{
+				bpf_debug("[Agent:%ld.0x%x] ABORTED: packet to 0x%x egress policy denied, reply of a denied UDP conn\n",
+					pkt->agent_ep_tunid,
+					bpf_ntohl(pkt->agent_ep_ipv4),
+					bpf_ntohl(pkt->inner_ip->daddr));
+				return XDP_ABORTED;
 			}
+
 			// todo: get rid of goto
 			goto xdp_continue;
 		}
@@ -366,14 +355,16 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 					pkt->agent_ep_tunid,
 					bpf_ntohl(pkt->agent_ep_ipv4),
 					bpf_ntohl(pkt->inner_ip->daddr));
-				conntrack_remove_tcpudp_conn(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple);
+				__u8 conn_state = (pkt->inner_ipv4_tuple.protocol == IPPROTO_UDP) ? FLAG_REEVAL | TRFFIC_DENIED : TRFFIC_DENIED;
+				conntrack_insert_tcpudp_conn(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple, conn_state);
 				return XDP_ABORTED;
 			}
 		}
 	}
 
 	// todo: consider to handle error in case it happens
-	conntrack_insert_tcpudp_conn(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple);
+	__u8 conn_state = (pkt->inner_ipv4_tuple.protocol == IPPROTO_UDP) ? FLAG_REEVAL : 0;
+	conntrack_insert_tcpudp_conn(&conn_track_cache, pkt->agent_ep_tunid, &pkt->inner_ipv4_tuple, conn_state);
 
 	/* Check if we need to apply a forward flow update */
 

--- a/src/xdp/trn_transit_xdp.c
+++ b/src/xdp/trn_transit_xdp.c
@@ -448,10 +448,11 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 
 	if (pkt->inner_ipv4_tuple.protocol == IPPROTO_TCP || pkt->inner_ipv4_tuple.protocol == IPPROTO_UDP) {
 		__u8 *tracked_state = get_originated_conn_state(&conn_track_cache, tunnel_id, &pkt->inner_ipv4_tuple);
-		if (NULL != tracked_state){
+		// todo: only check for bi-directional connections
+		if (NULL != tracked_state) {
 			if (0 != ingress_reply_packet_check(tunnel_id, &pkt->inner_ipv4_tuple, *tracked_state))
 			{
-				bpf_debug("[Transit:vpc 0x%lx] ABORTED: packet to 0x%x from 0x%x ingress denied, reply of a denied UDP conn\n",
+				bpf_debug("[Transit:vpc 0x%lx] ABORTED: packet to 0x%x from 0x%x ingress denied, reply of a denied conn\n",
 					tunnel_id,
 					bpf_ntohl(pkt->inner_ipv4_tuple.daddr),
 					bpf_ntohl(pkt->inner_ipv4_tuple.saddr));


### PR DESCRIPTION
This fixes #312.

The new design of connection track requires the conn has status
| bit value | Description |
| ----------- | ----------- |
| 0x01      | traffic is denied or open (allowed)  |
| 0x04      | need to re-evaluate applicable policy, or simply base on decision already made before  |

When traffic is denied by policy enforcement, its tracked connection will have state 0x01 (for tcp), or 0x05 (udp); if allowed, 0x00(tcp) or 0x04(udp), respectively.

When xdp prog is making decision for the reply flow, for packets that are reply of a tracked connection, it will re-evaluate with the _derived_ policy - if the state indicates so (which applies to udp flows).

This PR changes the xdp prog with update to the conn state, particularly with the re-eval flag. 