### PR TITLE
Change to batch update for transit enforcement map updates

### DIFF
--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -2208,7 +2208,7 @@ static void test_trn_cli_delete_transit_network_policy_subcmd(void **state)
 	int delete_transit_network_policy_1_ret_val;
 
 	/* Test cases */
-	char *argv1[] = { "delete-network-policy-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv1[] = { "delete-network-policy-ingress", "-i", "eth0", "-j", QUOTE([{
 				  "tunnel_id": "3",
 				  "local_ip": "10.0.0.3",
 				  "cidr_prefixlen": "16",
@@ -2223,7 +2223,7 @@ static void test_trn_cli_delete_transit_network_policy_subcmd(void **state)
 				  "cidr_type": "2"
 			  }]) };
 
-	char *argv2[] = { "delete-network-policy-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv2[] = { "delete-network-policy-ingress", "-i", "eth0", "-j", QUOTE([{
 				  "tunnel_id": "3",
 				  "local_ip": 10.0.0.3,
 				  "cidr_prefixlen": "16",
@@ -2238,21 +2238,29 @@ static void test_trn_cli_delete_transit_network_policy_subcmd(void **state)
 				  "cidr_type": "2"
 			  }]) };
 
-	struct rpc_trn_vsip_cidr_key_t exp_policy_key = {
+	struct rpc_trn_vsip_cidr_key_t exp_policy_key[2] = {{
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.cidr_prefixlen = 16,
 		.cidr_ip = 0x90000ac,
 		.cidr_type = 1
-	};
+	},
+	{
+		.interface = itf,
+		.tunid = 1,
+		.local_ip = 0x100000a,
+		.cidr_prefixlen = 17,
+		.cidr_ip = 0x60000ac,
+		.cidr_type = 2
+	}};
 
 	/* Test call delete_transit_network_policy successfully */
 	TEST_CASE("delete-network-policy-ingress succeed with well formed policy json input");
 	delete_transit_network_policy_1_ret_val = 0;
 	expect_function_call(__wrap_delete_transit_network_policy_1);
 	will_return(__wrap_delete_transit_network_policy_1, &delete_transit_network_policy_1_ret_val);
-	expect_check(__wrap_delete_transit_network_policy_1, policy, check_policy_key_equal, &exp_policy_key);
+	expect_check(__wrap_delete_transit_network_policy_1, policy, check_policy_key_equal, exp_policy_key);
 	expect_any(__wrap_delete_transit_network_policy_1, clnt);
 	rc = trn_cli_delete_transit_network_policy_subcmd(NULL, argc, argv1);
 	assert_int_equal(rc, 0);
@@ -2290,46 +2298,49 @@ static void test_trn_cli_update_transit_network_policy_enforcement_subcmd(void *
 	int update_transit_network_policy_enforcement_1_ret_val = 0;
 
 	/* Test cases */
-	char *argv1[] = { "update-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv1[] = { "update-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE([{
 				  "tunnel_id": "3",
 				  "ip": "10.0.0.3"
-			  }) };
-
-	char *argv2[] = { "update-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE({
-				  "tunnel_id": 3,
+			  },
+			  {
+				  "tunnel_id": "3",
 				  "ip": "10.0.0.3"
-			  }) };
+			  }]) };
 
-	char *argv3[] = { "update-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv2[] = { "update-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE([{
 				  "tunnel_id": "3",
 				  "ip": 10.0.0.3
-			  }) };
+			  },
+			  {
+				  "tunnel_id": "3",
+				  "ip": 10.0.0.3
+			  }]) };
 	char itf[] = "eth0";
 
-	struct rpc_trn_vsip_enforce_t exp_enforce = {
+	struct rpc_trn_vsip_enforce_t exp_enforce[2] = {{
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x300000a
-	};
+	},
+	{
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x300000a
+	}};
 
 	/* Test call update_transit_network_policy_enforcement successfully */
 	TEST_CASE("update-network-policy-enforcement-ingress succeed with well formed policy json input");
 	update_transit_network_policy_enforcement_1_ret_val = 0;
 	expect_function_call(__wrap_update_transit_network_policy_enforcement_1);
 	will_return(__wrap_update_transit_network_policy_enforcement_1, &update_transit_network_policy_enforcement_1_ret_val);
-	expect_check(__wrap_update_transit_network_policy_enforcement_1, enforce, check_policy_enforcement_equal, &exp_enforce);
+	expect_check(__wrap_update_transit_network_policy_enforcement_1, enforce, check_policy_enforcement_equal, exp_enforce);
 	expect_any(__wrap_update_transit_network_policy_enforcement_1, clnt);
 	rc = trn_cli_update_transit_network_policy_enforcement_subcmd(NULL, argc, argv1);
 	assert_int_equal(rc, 0);
 
-	/* Test parse network policy input error*/
-	TEST_CASE("update-network-policy-enforcement-ingress is not called with non-string field");
-	rc = trn_cli_update_transit_network_policy_enforcement_subcmd(NULL, argc, argv2);
-	assert_int_equal(rc, -EINVAL);
-
 	/* Test parse network policy input error 2*/
 	TEST_CASE("update-network-policy-enforcement-ingress is not called malformed json");
-	rc = trn_cli_update_transit_network_policy_enforcement_subcmd(NULL, argc, argv3);
+	rc = trn_cli_update_transit_network_policy_enforcement_subcmd(NULL, argc, argv2);
 	assert_int_equal(rc, -EINVAL);
 
 	/* Test call update_transit_network_policy_enforcement_1 return error*/

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -665,15 +665,22 @@ static void test_update_transit_network_policy_enforcement_1_svc(void **state)
 	UNUSED(state);
 	char itf[] = "lo";
 
-	struct rpc_trn_vsip_enforce_t enforce1 = {
+	struct rpc_trn_vsip_enforce_t enforce1[2] = {{
 		.interface = itf,
 		.tunid = 3,
-		.local_ip = 0x100000a
-	};
+		.local_ip = 0x100000a,
+		.count = 2
+	},
+	{
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x100000a,
+		.count = 2
+	}};
 
 	int *rc;
-	expect_function_call(__wrap_bpf_map_update_elem);
-	rc = update_transit_network_policy_enforcement_1_svc(&enforce1, NULL);
+	expect_function_calls(__wrap_bpf_map_update_elem, 2);
+	rc = update_transit_network_policy_enforcement_1_svc(enforce1, NULL);
 	assert_int_equal(*rc, 0);
 }
 

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1266,10 +1266,10 @@ int *update_transit_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc
 	UNUSED(rqstp);
 	static int result;
 	int rc;
-	char *itf = policy[0].interface;
-	int type = policy[0].cidr_type;
+	char *itf = policy->interface;
+	int type = policy->cidr_type;
 
-	int counter = policy[0].count;
+	int counter = policy->count;
 	if (counter == 0)
 	{
 		TRN_LOG_INFO("policy has length of 0. Nothing to do");
@@ -1394,14 +1394,23 @@ error:
 	return &result;
 }
 
-int *update_transit_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *enforce, struct svc_req *rqstp)
+int *update_transit_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *policy, struct svc_req *rqstp)
 {
 	UNUSED(rqstp);
 	static int result;
 	int rc;
-	char *itf = enforce->interface;
-	struct vsip_enforce_t enf;
-	__u8 val;
+	char *itf = policy->interface;
+
+	int counter = policy->count;
+	if (counter == 0)
+	{
+		TRN_LOG_INFO("policy has length of 0. Nothing to do");
+		result = 0;
+		return &result;
+	}
+
+	struct vsip_enforce_t enforces[counter];
+	__u8 val[counter];
 
 	TRN_LOG_INFO("update_transit_network_policy_enforcement_1_svc service");
 
@@ -1412,15 +1421,17 @@ int *update_transit_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *enf
 		goto error;
 	}
 
-	enf.tunnel_id = enforce->tunid;
-	enf.local_ip = enforce->local_ip;
-	val = 1;
+	for (int i = 0; i < counter; i++)
+	{
+		enforces[i].tunnel_id = policy[i].tunid;
+		enforces[i].local_ip = policy[i].local_ip;
+		val[i] = 1;
+	}
 
-	rc = trn_update_transit_network_policy_enforcement_map(md, &enf, val);
+	rc = trn_update_transit_network_policy_enforcement_map(md, enforces, val, counter);
 
 	if (rc != 0) {
-		TRN_LOG_ERROR("Failure updating transit network policy enforcement map ip address: 0x%x, for interface %s",
-					enforce->local_ip, enforce->interface);
+		TRN_LOG_ERROR("Failure updating transit network policy enforcement map \n");
 		result = RPC_TRN_FATAL;
 		goto error;
 	}

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -748,15 +748,20 @@ int trn_delete_transit_network_policy_except_map(struct user_metadata_t *md,
 
 int trn_update_transit_network_policy_enforcement_map(struct user_metadata_t *md,
 						      struct vsip_enforce_t *local,
-						      __u8 isenforce)
+						      __u8 *isenforce,
+						      int counter)
 {
-	int err = bpf_map_update_elem(md->ing_vsip_enforce_map_fd, local, &isenforce, 0);
+	for (int i = 0; i < counter; i++)
+	{
+		int err = bpf_map_update_elem(md->ing_vsip_enforce_map_fd, &local[i], &isenforce[i], 0);
 
-	if (err) {
-		TRN_LOG_ERROR("Update Enforcement ingress map failed (err:%d).",
-				err);
-		return 1;
+		if (err) {
+			TRN_LOG_ERROR("Update Enforcement ingress map failed (err:%d).",
+					err);
+			return 1;
+		}
 	}
+
 	return 0;
 }
 

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -241,7 +241,8 @@ int trn_delete_transit_network_policy_except_map(struct user_metadata_t *md,
 
 int trn_update_transit_network_policy_enforcement_map(struct user_metadata_t *md,
 						      struct vsip_enforce_t *local,
-						      __u8 isenforce);
+						      __u8 *isenforce,
+						      int counter);
 
 int trn_delete_transit_network_policy_enforcement_map(struct user_metadata_t *md,
 						      struct vsip_enforce_t *local);

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -188,6 +188,7 @@ struct rpc_trn_vsip_enforce_t {
        string interface<20>;
        uint64_t tunid;
        uint32_t local_ip;
+       int count;
 };
 
 /* Defines a network policy protocol port table entry */


### PR DESCRIPTION
This partially resolves #294

For network policy enforcement maps updates, we were doing one by one bpf map delete previously. To increase efficiency, we now switch to batch update