### PR TITLE
Add agent enforcement map update

### DIFF
--- a/src/cli/test/module.mk
+++ b/src/cli/test/module.mk
@@ -16,6 +16,7 @@ CLI_MOCKS += -Wl,--wrap=update_agent_md_1
 CLI_MOCKS += -Wl,--wrap=update_transit_network_policy_1
 CLI_MOCKS += -Wl,--wrap=update_agent_network_policy_1
 CLI_MOCKS += -Wl,--wrap=update_transit_network_policy_enforcement_1
+CLI_MOCKS += -Wl,--wrap=update_agent_network_policy_enforcement_1
 CLI_MOCKS += -Wl,--wrap=update_transit_network_policy_protocol_port_1
 CLI_MOCKS += -Wl,--wrap=load_transit_xdp_1
 CLI_MOCKS += -Wl,--wrap=unload_transit_xdp_1

--- a/src/cli/trn_cli.c
+++ b/src/cli/trn_cli.c
@@ -57,6 +57,7 @@ static const struct cmd {
 	{ "delete-network-policy-ingress", trn_cli_delete_transit_network_policy_subcmd },
 	{ "delete-network-policy-egress", trn_cli_delete_agent_network_policy_subcmd },
 	{ "update-network-policy-enforcement-ingress", trn_cli_update_transit_network_policy_enforcement_subcmd },
+	{ "update-network-policy-enforcement-egress", trn_cli_update_agent_network_policy_enforcement_subcmd },
 	{ "delete-network-policy-enforcement-ingress", trn_cli_delete_transit_network_policy_enforcement_subcmd },
 	{ "update-network-policy-protocol-port-ingress", trn_cli_update_transit_network_policy_protocol_port_subcmd },
 	{ "delete-network-policy-protocol-port-ingress", trn_cli_delete_transit_network_policy_protocol_port_subcmd },

--- a/src/cli/trn_cli.h
+++ b/src/cli/trn_cli.h
@@ -115,6 +115,7 @@ int trn_cli_update_agent_network_policy_subcmd(CLIENT *clnt, int argc, char *arg
 int trn_cli_delete_transit_network_policy_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_delete_agent_network_policy_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_update_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int argc, char *argv[]);
+int trn_cli_update_agent_network_policy_enforcement_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_delete_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_update_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_delete_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int argc, char *argv[]);

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -760,6 +760,30 @@ static void test_update_transit_network_policy_enforcement_1_svc(void **state)
 	assert_int_equal(*rc, 0);
 }
 
+static void test_update_agent_network_policy_enforcement_1_svc(void **state)
+{
+	UNUSED(state);
+	char itf[] = "lo";
+
+	struct rpc_trn_vsip_enforce_t enforce1[2] = {{
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x100000a,
+		.count = 2
+	},
+	{
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x100000a,
+		.count = 2
+	}};
+
+	int *rc;
+	expect_function_calls(__wrap_bpf_map_update_elem, 2);
+	rc = update_agent_network_policy_enforcement_1_svc(enforce1, NULL);
+	assert_int_equal(*rc, 0);
+}
+
 static void test_delete_transit_network_policy_enforcement_1_svc(void **state)
 {
 	UNUSED(state);
@@ -1441,6 +1465,7 @@ int main()
 		cmocka_unit_test(test_delete_transit_network_policy_1_svc),
 		cmocka_unit_test(test_delete_agent_network_policy_1_svc),
 		cmocka_unit_test(test_update_transit_network_policy_enforcement_1_svc),
+		cmocka_unit_test(test_update_agent_network_policy_enforcement_1_svc),
 		cmocka_unit_test(test_delete_transit_network_policy_enforcement_1_svc),
 		cmocka_unit_test(test_update_transit_network_policy_protocol_port_1_svc),
 		cmocka_unit_test(test_delete_transit_network_policy_protocol_port_1_svc)

--- a/src/dmn/trn_agent_xdp_usr.c
+++ b/src/dmn/trn_agent_xdp_usr.c
@@ -602,3 +602,23 @@ int trn_delete_agent_network_policy_map(int fd,
 	}
 	return 0;
 }
+
+
+int trn_update_agent_network_policy_enforcement_map(struct agent_user_metadata_t *md,
+						      struct vsip_enforce_t *local,
+						      __u8 *isenforce,
+						      int counter)
+{
+	for (int i = 0; i < counter; i++)
+	{
+		int err = bpf_map_update_elem(md->ing_vsip_enforce_map_fd, &local[i], &isenforce[i], 0);
+
+		if (err) {
+			TRN_LOG_ERROR("Update Enforcement ingress map failed (err:%d).",
+					err);
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/src/dmn/trn_agent_xdp_usr.h
+++ b/src/dmn/trn_agent_xdp_usr.h
@@ -147,3 +147,8 @@ int trn_update_agent_network_policy_map(int fd,
 int trn_delete_agent_network_policy_map(int fd,
 					 struct vsip_cidr_t *ipcidr,
 					 int counter);
+
+int trn_update_agent_network_policy_enforcement_map(struct agent_user_metadata_t *md,
+						      struct vsip_enforce_t *local,
+						      __u8 *isenforce,
+						      int counter);

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1567,6 +1567,55 @@ error:
 	return &result;
 }
 
+int *update_agent_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *policy, struct svc_req *rqstp)
+{
+	UNUSED(rqstp);
+	static int result = -1;
+	int rc;
+	char *itf = policy->interface;
+
+	int counter = policy->count;
+	if (counter == 0)
+	{
+		TRN_LOG_INFO("policy has length of 0. Nothing to do");
+		result = 0;
+		return &result;
+	}
+
+	struct vsip_enforce_t enforces[counter];
+	__u8 val[counter];
+
+	TRN_LOG_INFO("update_agent_network_policy_enforcement_1_svc service");
+
+	struct agent_user_metadata_t *md = trn_vif_table_find(itf);
+	if (!md) {
+		TRN_LOG_ERROR("Cannot find interface metadata for %s", itf);
+		result = RPC_TRN_ERROR;
+		goto error;
+	}
+
+	for (int i = 0; i < counter; i++)
+	{
+		enforces[i].tunnel_id = policy[i].tunid;
+		enforces[i].local_ip = policy[i].local_ip;
+		val[i] = 1;
+	}
+
+	rc = trn_update_agent_network_policy_enforcement_map(md, enforces, val, counter);
+
+	if (rc != 0) {
+		TRN_LOG_ERROR("Failure updating agent network policy enforcement map \n");
+		result = RPC_TRN_FATAL;
+		goto error;
+	}
+
+	result = 0;
+	return &result;
+
+error:
+	return &result;
+}
+
 int *delete_transit_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *enforce, struct svc_req *rqstp)
 {
 	UNUSED(rqstp);

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -250,6 +250,7 @@ program RPC_TRANSIT_REMOTE_PROTOCOL {
                 int DELETE_TRANSIT_NETWORK_POLICY_PROTOCOL_PORT(rpc_trn_vsip_ppo_key_t) = 28;
                 int UPDATE_AGENT_NETWORK_POLICY(rpc_trn_vsip_cidr_t) = 29;
                 int DELETE_AGENT_NETWORK_POLICY(rpc_trn_vsip_cidr_key_t) = 30;
+                int UPDATE_AGENT_NETWORK_POLICY_ENFORCEMENT(rpc_trn_vsip_enforce_t) = 31;
 
           } = 1;
 


### PR DESCRIPTION
This PR partially resolves issue #270

It gets cli command input and trigger RPC call, then updates BPF map for network policy enforcement maps on the agent side.