### PR TITLE
Batch update for enforcement map delete

### DIFF
--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -2584,17 +2584,8 @@ static void test_trn_cli_delete_transit_network_policy_enforcement_subcmd(void *
 			  }) };
 
 	char *argv2[] = { "delete-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE({
-				  "tunnel_id": 3,
-				  "ip": "10.0.0.3"
-			  }) };
-
-	char *argv3[] = { "delete-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": "3",
 				  "ip": 10.0.0.3
-			  }) };
-
-	char *argv4[] = { "delete-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE({
-				  "tunnel_id": "3"
 			  }) };
 
 	struct rpc_trn_vsip_enforce_t exp_enforce = {
@@ -2613,18 +2604,9 @@ static void test_trn_cli_delete_transit_network_policy_enforcement_subcmd(void *
 	rc = trn_cli_delete_transit_network_policy_enforcement_subcmd(NULL, argc, argv1);
 	assert_int_equal(rc, 0);
 
-	/* Test parse network policy input error*/
-	TEST_CASE("delete-network-policy-enforcement-ingress is not called with non-string field");
-	rc = trn_cli_delete_transit_network_policy_enforcement_subcmd(NULL, argc, argv2);
-	assert_int_equal(rc, -EINVAL);
-
 	/* Test parse network policy input error 2*/
 	TEST_CASE("delete-network-policy-enforcement-ingress is not called malformed json");
-	rc = trn_cli_delete_transit_network_policy_enforcement_subcmd(NULL, argc, argv3);
-	assert_int_equal(rc, -EINVAL);
-
-	TEST_CASE("delete-network-policy-enforcement-ingress is not called with missing required field");
-	rc = trn_cli_delete_transit_network_policy_enforcement_subcmd(NULL, argc, argv4);
+	rc = trn_cli_delete_transit_network_policy_enforcement_subcmd(NULL, argc, argv2);
 	assert_int_equal(rc, -EINVAL);
 
 	/* Test call delete_transit_network_policy_enforcement_1 return error*/

--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -2578,28 +2578,41 @@ static void test_trn_cli_delete_transit_network_policy_enforcement_subcmd(void *
 	int delete_transit_network_policy_enforcement_1_ret_val;
 
 	/* Test cases */
-	char *argv1[] = { "delete-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv1[] = { "delete-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE([{
 				  "tunnel_id": "3",
 				  "ip": "10.0.0.3"
-			  }) };
+			  },
+			  {
+				  "tunnel_id": "3",
+				  "ip": "10.0.0.3"
+			  }]) };
 
-	char *argv2[] = { "delete-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv2[] = { "delete-network-policy-enforcement-ingress", "-i", "eth0", "-j", QUOTE([{
 				  "tunnel_id": "3",
 				  "ip": 10.0.0.3
-			  }) };
+			  },
+			  {
+				  "tunnel_id": "3",
+				  "ip": 10.0.0.3
+			  }]) };
 
-	struct rpc_trn_vsip_enforce_t exp_enforce = {
+	struct rpc_trn_vsip_enforce_t exp_enforce[2] = {{
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x300000a
-	};
+	},
+	{
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x300000a
+	}};
 
 	/* Test call delete_transit_network_policy_enforcement successfully */
 	TEST_CASE("delete-network-policy-enforcement-ingress succeed with well formed policy json input");
 	delete_transit_network_policy_enforcement_1_ret_val = 0;
 	expect_function_call(__wrap_delete_transit_network_policy_enforcement_1);
 	will_return(__wrap_delete_transit_network_policy_enforcement_1, &delete_transit_network_policy_enforcement_1_ret_val);
-	expect_check(__wrap_delete_transit_network_policy_enforcement_1, enforce, check_policy_enforcement_equal, &exp_enforce);
+	expect_check(__wrap_delete_transit_network_policy_enforcement_1, enforce, check_policy_enforcement_equal, exp_enforce);
 	expect_any(__wrap_delete_transit_network_policy_enforcement_1, clnt);
 	rc = trn_cli_delete_transit_network_policy_enforcement_subcmd(NULL, argc, argv1);
 	assert_int_equal(rc, 0);

--- a/src/cli/trn_cli_network_policy.c
+++ b/src/cli/trn_cli_network_policy.c
@@ -350,8 +350,8 @@ int trn_cli_delete_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int a
 		enforce.interface = conf.intf;
 		enforce.count = counter;
 		cJSON *policy = cJSON_GetArrayItem(json_str, i);
-		int err = trn_cli_parse_network_policy_enforcement(json_str, &enforce);
 
+		int err = trn_cli_parse_network_policy_enforcement(policy, &enforce);
 		if (err != 0) {
 			print_err("Error: parsing network policy enforcement config.\n");
 			return -EINVAL;

--- a/src/cli/trn_cli_network_policy.c
+++ b/src/cli/trn_cli_network_policy.c
@@ -338,23 +338,31 @@ int trn_cli_delete_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int a
 		return -EINVAL;
 	}
 
-	int *rc;
-	struct rpc_trn_vsip_enforce_t enforce;
-	char rpc[] = "delete_transit_network_policy_enforcement_1";
-	enforce.interface = conf.intf;
+	int counter = cJSON_GetArraySize(json_str);
 
-	int err = trn_cli_parse_network_policy_enforcement(json_str, &enforce);
+	int *rc;
+	struct rpc_trn_vsip_enforce_t enforces[counter];
+	char rpc[] = "delete_transit_network_policy_enforcement_1";
+
+	for (int i = 0; i < counter; i++)
+	{
+		struct rpc_trn_vsip_enforce_t enforce;
+		enforce.interface = conf.intf;
+		enforce.count = counter;
+		cJSON *policy = cJSON_GetArrayItem(json_str, i);
+		int err = trn_cli_parse_network_policy_enforcement(json_str, &enforce);
+
+		if (err != 0) {
+			print_err("Error: parsing network policy enforcement config.\n");
+			return -EINVAL;
+		}
+		enforces[i] = enforce;
+	}
 	cJSON_Delete(json_str);
 
-	if (err != 0) {
-		print_err("Error: parsing network policy enforcement config.\n");
-		return -EINVAL;
-	}
-
-	rc = delete_transit_network_policy_enforcement_1(&enforce, clnt);
+	rc = delete_transit_network_policy_enforcement_1(enforces, clnt);
 	if (rc == (int *)NULL) {
-		print_err("RPC Error: client call failed: delete_transit_network_policy_enforcement_1 for local ip: 0x%x.\n",
-					enforce.local_ip);
+		print_err("RPC Error: client call failed: delete_transit_network_policy_enforcement_1\n");
 		return -EINVAL;
 	}
 
@@ -365,9 +373,7 @@ int trn_cli_delete_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int a
 		return -EINVAL;
 	}
 
-	dump_enforced_policy(&enforce);
-	print_msg("delete_transit_network_policy_enforcement_1 successfully deleted network policy for local ip: 0x%x for interface %s\n",
-					enforce.local_ip, enforce.interface);
+	print_msg("delete_transit_network_policy_enforcement_1 successfully deleted network policy \n");
 
 	return 0;
 }

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -765,29 +765,39 @@ static void test_delete_transit_network_policy_enforcement_1_svc(void **state)
 	UNUSED(state);
 	char itf[] = "lo";
 
-	struct rpc_trn_vsip_enforce_t enforce_key = {
+	struct rpc_trn_vsip_enforce_t enforce_keys[2] = {{
 		.interface = itf,
 		.tunid = 3,
-		.local_ip = 0x100000a
-	};
+		.local_ip = 0x100000a,
+		.count = 2
+	},
+	{
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x100000a,
+		.count = 2
+	}};
 
 	int *rc;
 
 	/* Test delete_transit_network_policy_enforcement_1 with valid enforce_key */
 	will_return(__wrap_bpf_map_delete_elem, TRUE);
+	will_return(__wrap_bpf_map_delete_elem, TRUE);
 	expect_function_call(__wrap_bpf_map_delete_elem);
-	rc = delete_transit_network_policy_enforcement_1_svc(&enforce_key, NULL);
+	expect_function_call(__wrap_bpf_map_delete_elem);
+	rc = delete_transit_network_policy_enforcement_1_svc(enforce_keys, NULL);
 	assert_int_equal(*rc, 0);
 
 	/* Test delete_transit_network_policy_enforcement_1 with invalid enforce_key */
 	will_return(__wrap_bpf_map_delete_elem, FALSE);
 	expect_function_call(__wrap_bpf_map_delete_elem);
-	rc = delete_transit_network_policy_enforcement_1_svc(&enforce_key, NULL);
+	rc = delete_transit_network_policy_enforcement_1_svc(enforce_keys, NULL);
 	assert_int_equal(*rc, RPC_TRN_FATAL);
 
 	/* Test delete_transit_network_policy_enforcement_1 with invalid interface*/
-	enforce_key.interface = "";
-	rc = delete_transit_network_policy_enforcement_1_svc(&enforce_key, NULL);
+	enforce_keys[0].interface = "";
+	enforce_keys[1].interface = "";
+	rc = delete_transit_network_policy_enforcement_1_svc(enforce_keys, NULL);
 	assert_int_equal(*rc, RPC_TRN_ERROR);
 }
 

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1573,9 +1573,16 @@ int *delete_transit_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *enf
 	static int result = -1;
 	int rc;
 	char *itf = enforce->interface;
-	struct vsip_enforce_t enf;
+	int counter = enforce->count;
 
 	TRN_LOG_INFO("delete_transit_network_policy_enforcement_1_svc service");
+
+	if (counter == 0){
+		TRN_LOG_INFO("policy list has length of 0. Nothing to do");
+		result = 0;
+		return &result;
+	}
+	struct vsip_enforce_t enfs[counter];
 
 	struct user_metadata_t *md = trn_itf_table_find(itf);
 	if (!md) {
@@ -1584,14 +1591,16 @@ int *delete_transit_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *enf
 		goto error;
 	}
 
-	enf.tunnel_id = enforce->tunid;
-	enf.local_ip = enforce->local_ip;
+	for (int i = 0; i < counter; i++)
+	{
+		enfs[i].tunnel_id = enforce[i].tunid;
+		enfs[i].local_ip = enforce[i].local_ip;
+	}
 
-	rc = trn_delete_transit_network_policy_enforcement_map(md, &enf);
+	rc = trn_delete_transit_network_policy_enforcement_map(md, enfs, counter);
 
 	if (rc != 0) {
-		TRN_LOG_ERROR("Failure deleting transit network policy enforcement map ip address: 0x%x, for interface %s",
-					enforce->local_ip, enforce->interface);
+		TRN_LOG_ERROR("Failure deleting transit network policy enforcement map \n");
 		result = RPC_TRN_FATAL;
 		goto error;
 	}

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -761,19 +761,22 @@ int trn_update_transit_network_policy_enforcement_map(struct user_metadata_t *md
 			return 1;
 		}
 	}
-
 	return 0;
 }
 
 int trn_delete_transit_network_policy_enforcement_map(struct user_metadata_t *md,
-						      struct vsip_enforce_t *local)
+						      struct vsip_enforce_t *local,
+						      int counter)
 {
-	int err = bpf_map_delete_elem(md->ing_vsip_enforce_map_fd, local);
+	for (int i = 0; i < counter; i++)
+	{
+		int err = bpf_map_delete_elem(md->ing_vsip_enforce_map_fd, &local[i]);
 
-	if (err) {
-		TRN_LOG_ERROR("Delete Enforcement ingress map failed (err:%d).",
-				err);
-		return 1;
+		if (err) {
+			TRN_LOG_ERROR("Delete Enforcement ingress map failed (err:%d).",
+					err);
+			return 1;
+		}
 	}
 	return 0;
 }

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -245,7 +245,8 @@ int trn_update_transit_network_policy_enforcement_map(struct user_metadata_t *md
 						      int counter);
 
 int trn_delete_transit_network_policy_enforcement_map(struct user_metadata_t *md,
-						      struct vsip_enforce_t *local);
+						      struct vsip_enforce_t *local,
+						      int counter);
 
 int trn_update_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
 						        struct vsip_ppo_t *policy,


### PR DESCRIPTION
This partially resolves #294

For network policy enforcement maps deletes, we were doing one by one bpf map delete previously. To increase efficiency, we now switch to batch delete