### PR TITLE
batch update for protocol-port network policy on the transit side

### DIFF
--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -2721,58 +2721,67 @@ static void test_trn_cli_update_transit_network_policy_protocol_port_subcmd(void
 	int update_transit_network_policy_proto_port_1_ret_val = 0;
 
 	/* Test cases */
-	char *argv1[] = { "update-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv1[] = { "update-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE([{
 				  "tunnel_id": "3",
 				  "local_ip": "10.0.0.3",
 				  "protocol": "6",
 				  "port": "6379",
 				  "bit_value": "10"
-			  }) };
-
-	char *argv2[] = { "update-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE({
-				  "tunnel_id": 3,
+			  },
+			  {
+				  "tunnel_id": "3",
 				  "local_ip": "10.0.0.3",
 				  "protocol": "6",
 				  "port": "6379",
 				  "bit_value": "10"
-			  }) };
+			  }]) };
 
-	char *argv3[] = { "update-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv2[] = { "update-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE([{
 				  "tunnel_id": "3",
 				  "local_ip": 10.0.0.3,
 				  "protocol": "6",
 				  "port": "6379",
 				  "bit_value": "10"
-			  }) };
+			  },
+			  {
+				  "tunnel_id": "3",
+				  "local_ip": 10.0.0.3,
+				  "protocol": "6",
+				  "port": "6379",
+				  "bit_value": "10"
+			  }]) };
 	char itf[] = "eth0";
 
-	struct rpc_trn_vsip_ppo_t exp_ppo = {
+	struct rpc_trn_vsip_ppo_t exp_ppo[2] = {{
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
 		.port = 6379,
 		.bit_val = 10
-	};
+	},
+	{
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x300000a,
+		.proto = 6,
+		.port = 6379,
+		.bit_val = 10
+	}};
 
 	/* Test call update_transit_network_policy_protocol_port successfully */
 	TEST_CASE("update_transit_network_policy_protocol_port succeed with well formed policy json input");
 	update_transit_network_policy_proto_port_1_ret_val = 0;
 	expect_function_call(__wrap_update_transit_network_policy_protocol_port_1);
 	will_return(__wrap_update_transit_network_policy_protocol_port_1, &update_transit_network_policy_proto_port_1_ret_val);
-	expect_check(__wrap_update_transit_network_policy_protocol_port_1, ppo, check_policy_protocol_port_equal, &exp_ppo);
+	expect_check(__wrap_update_transit_network_policy_protocol_port_1, ppo, check_policy_protocol_port_equal, exp_ppo);
 	expect_any(__wrap_update_transit_network_policy_protocol_port_1, clnt);
 	rc = trn_cli_update_transit_network_policy_protocol_port_subcmd(NULL, argc, argv1);
 	assert_int_equal(rc, 0);
 
-	/* Test parse network policy input error*/
-	TEST_CASE("update_transit_network_policy_protocol_port is not called with non-string field");
-	rc = trn_cli_update_transit_network_policy_protocol_port_subcmd(NULL, argc, argv2);
-	assert_int_equal(rc, -EINVAL);
-
 	/* Test parse network policy input error 2*/
 	TEST_CASE("update_transit_network_policy_protocol_port is not called malformed json");
-	rc = trn_cli_update_transit_network_policy_protocol_port_subcmd(NULL, argc, argv3);
+	rc = trn_cli_update_transit_network_policy_protocol_port_subcmd(NULL, argc, argv2);
 	assert_int_equal(rc, -EINVAL);
 
 	/* Test call update_transit_network_policy_1 return error*/

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -830,18 +830,28 @@ static void test_update_transit_network_policy_protocol_port_1_svc(void **state)
 	UNUSED(state);
 	char itf[] = "lo";
 
-	struct rpc_trn_vsip_ppo_t ppo1 = {
+	struct rpc_trn_vsip_ppo_t ppo1[2] = {{
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
 		.port = 6379,
-		.bit_val = 10
-	};
+		.bit_val = 10,
+		.count = 2
+	},
+	{
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x300000a,
+		.proto = 6,
+		.port = 6379,
+		.bit_val = 10,
+		.count = 2
+	}};
 
 	int *rc;
-	expect_function_call(__wrap_bpf_map_update_elem);
-	rc = update_transit_network_policy_protocol_port_1_svc(&ppo1, NULL);
+	expect_function_calls(__wrap_bpf_map_update_elem, 2);
+	rc = update_transit_network_policy_protocol_port_1_svc(ppo1, NULL);
 	assert_int_equal(*rc, 0);
 }
 

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1667,9 +1667,16 @@ int *update_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_t *ppo, 
 	static int result = -1;
 	int rc;
 	char *itf = ppo->interface;
-	struct vsip_ppo_t policy;
-
+	int counter = ppo->count;
+	
 	TRN_LOG_INFO("update_transit_network_policy_protocol_port_1_svc service");
+	if (counter == 0){
+		TRN_LOG_INFO("policy list has length of 0. Nothing to do");
+		result = 0;
+		return &result;
+	}
+	struct vsip_ppo_t policies[counter];
+	__u64 bitmap[counter];
 
 	struct user_metadata_t *md = trn_itf_table_find(itf);
 	if (!md) {
@@ -1678,16 +1685,19 @@ int *update_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_t *ppo, 
 		goto error;
 	}
 
-	policy.tunnel_id = ppo->tunid;
-	policy.local_ip = ppo->local_ip;
-	policy.proto = ppo->proto;
-	policy.port = ppo->port;
+	for (int i = 0; i < counter; i++)
+	{
+		policies[i].tunnel_id = ppo[i].tunid;
+		policies[i].local_ip = ppo[i].local_ip;
+		policies[i].proto = ppo[i].proto;
+		policies[i].port = ppo[i].port;
+		bitmap[i] = ppo[i].bit_val;
+	}
 
-	rc = trn_update_transit_network_policy_protocol_port_map(md, &policy, ppo->bit_val);
+	rc = trn_update_transit_network_policy_protocol_port_map(md, policies, bitmap, counter);
 
 	if (rc != 0) {
-		TRN_LOG_ERROR("Failure updating transit network policy enforcement map ip address: 0x%x, for interface %s",
-					ppo->local_ip, ppo->interface);
+		TRN_LOG_ERROR("Failure updating transit network policy enforcement map\n");
 		result = RPC_TRN_FATAL;
 		goto error;
 	}

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -783,14 +783,18 @@ int trn_delete_transit_network_policy_enforcement_map(struct user_metadata_t *md
 
 int trn_update_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
 						        struct vsip_ppo_t *policy,
-						        __u64 bitmap)
+						        __u64 *bitmap,
+							int counter)
 {
-	int err = bpf_map_update_elem(md->ing_vsip_ppo_map_fd, policy, &bitmap, 0);
+	for (int i = 0; i < counter; i++)
+	{
+		int err = bpf_map_update_elem(md->ing_vsip_ppo_map_fd, &policy[i], &bitmap[i], 0);
 
-	if (err) {
-		TRN_LOG_ERROR("Update Protocol-Port ingress map failed (err:%d).",
-				err);
-		return 1;
+		if (err) {
+			TRN_LOG_ERROR("Update Protocol-Port ingress map failed (err:%d).",
+					err);
+			return 1;
+		}
 	}
 	return 0;
 }

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -791,8 +791,8 @@ int trn_update_transit_network_policy_protocol_port_map(struct user_metadata_t *
 		int err = bpf_map_update_elem(md->ing_vsip_ppo_map_fd, &policy[i], &bitmap[i], 0);
 
 		if (err) {
-			TRN_LOG_ERROR("Update Protocol-Port ingress map failed (err:%d).",
-					err);
+			TRN_LOG_ERROR("Update Protocol-Port ingress map failed (err:%d) for ip address 0x%x with protocol %d and port %d. \n",
+					err, policy[i].local_ip, policy[i].proto, policy[i].port);
 			return 1;
 		}
 	}

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -250,7 +250,8 @@ int trn_delete_transit_network_policy_enforcement_map(struct user_metadata_t *md
 
 int trn_update_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
 						        struct vsip_ppo_t *policy,
-						        __u64 bitmap);
+						        __u64 *bitmap,
+							int counter);
 
 int trn_delete_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
 						        struct vsip_ppo_t *policy);

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -199,6 +199,7 @@ struct rpc_trn_vsip_ppo_t {
        uint8_t proto;
        uint16_t port;
        uint64_t bit_val;
+       int count;
 };
 
 /* Defines a network policy protocol port table key */


### PR DESCRIPTION
This partially resolves #294

For network policy protocol-port maps updates, we were doing one by one bpf map update previously. To increase efficiency, we now switch to batch update