### PR TITLE
Change to batch delete for transit protocol-port maps

### DIFF
--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -2813,63 +2813,60 @@ static void test_trn_cli_delete_transit_network_policy_protocol_port_subcmd(void
 	int delete_transit_network_policy_protocol_port_1_ret_val;
 
 	/* Test cases */
-	char *argv1[] = { "delete-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv1[] = { "delete-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE([{
 				  "tunnel_id": "3",
 				  "local_ip": "10.0.0.3",
 				  "protocol": "6",
 				  "port": "6379"
-			  }) };
-
-	char *argv2[] = { "delete-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE({
-				  "tunnel_id": 3,
-				  "local_ip": "10.0.0.3",
+			  },
+			  {
+				  "tunnel_id": "2",
+				  "local_ip": "10.0.0.2",
 				  "protocol": "6",
 				  "port": "6379"
-			  }) };
+			  }]) };
 
-	char *argv3[] = { "delete-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE({
+	char *argv2[] = { "delete-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE([{
 				  "tunnel_id": "3",
 				  "local_ip": 10.0.0.3,
 				  "protocol": "6",
 				  "port": "6379"
-			  }) };
-
-	char *argv4[] = { "delete-network-policy-protocol-port-ingress", "-i", "eth0", "-j", QUOTE({
-				  "tunnel_id": "3",
+			  },
+			  {
+				  "tunnel_id": "2",
+				  "local_ip": 10.0.0.2,
 				  "protocol": "6",
 				  "port": "6379"
-			  }) };
+			  }]) };
 
-	struct rpc_trn_vsip_ppo_t exp_ppo = {
+	struct rpc_trn_vsip_ppo_t exp_ppo[2] = {{
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
 		.port = 6379
-	};
+	},
+	{
+		.interface = itf,
+		.tunid = 2,
+		.local_ip = 0x200000a,
+		.proto = 6,
+		.port = 6379
+	}};
 
 	/* Test call delete_transit_network_policy_protocol_port successfully */
 	TEST_CASE("delete-network-policy-protocol-port-ingress succeed with well formed policy json input");
 	delete_transit_network_policy_protocol_port_1_ret_val = 0;
 	expect_function_call(__wrap_delete_transit_network_policy_protocol_port_1);
 	will_return(__wrap_delete_transit_network_policy_protocol_port_1, &delete_transit_network_policy_protocol_port_1_ret_val);
-	expect_check(__wrap_delete_transit_network_policy_protocol_port_1, ppo, check_policy_protocol_port_key_equal, &exp_ppo);
+	expect_check(__wrap_delete_transit_network_policy_protocol_port_1, ppo, check_policy_protocol_port_key_equal, exp_ppo);
 	expect_any(__wrap_delete_transit_network_policy_protocol_port_1, clnt);
 	rc = trn_cli_delete_transit_network_policy_protocol_port_subcmd(NULL, argc, argv1);
 	assert_int_equal(rc, 0);
 
-	/* Test parse network policy input error*/
-	TEST_CASE("delete-network-policy-protocol-port-ingress is not called with non-string field");
-	rc = trn_cli_delete_transit_network_policy_protocol_port_subcmd(NULL, argc, argv2);
-	assert_int_equal(rc, -EINVAL);
-
 	/* Test parse network policy input error 2*/
 	TEST_CASE("delete-network-policy-protocol-port-ingress is not called malformed json");
-	rc = trn_cli_delete_transit_network_policy_protocol_port_subcmd(NULL, argc, argv3);
-	assert_int_equal(rc, -EINVAL);
-
-	TEST_CASE("delete-network-policy-protocol-port-ingress is not called with missing required field");
-	rc = trn_cli_delete_transit_network_policy_protocol_port_subcmd(NULL, argc, argv4);
+	rc = trn_cli_delete_transit_network_policy_protocol_port_subcmd(NULL, argc, argv2);
 	assert_int_equal(rc, -EINVAL);
 
 	/* Test call delete_transit_network_policy_protocol_port_1 return error*/

--- a/src/cli/trn_cli_network_policy.c
+++ b/src/cli/trn_cli_network_policy.c
@@ -537,8 +537,13 @@ int trn_cli_delete_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int
 		return -EINVAL;
 	}
 
-	int counter = cJSON_GetArraySize(json_str);
 	int *rc;
+	int counter = cJSON_GetArraySize(json_str);
+	if (counter <= 0) {
+		print_err("Input policy size is less than or equal to zero. Please check your input. \n");
+		return -EINVAL;
+	}
+
 	struct rpc_trn_vsip_ppo_key_t ppo_keys[counter];
 	char rpc[] = "delete_transit_network_policy_protocol_port_1";
 

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -860,30 +860,42 @@ static void test_delete_transit_network_policy_protocol_port_1_svc(void **state)
 	UNUSED(state);
 	char itf[] = "lo";
 
-	struct rpc_trn_vsip_ppo_key_t ppo_key = {
+	struct rpc_trn_vsip_ppo_key_t ppo_keys[2] = {{
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
-		.port = 6379
-	};
+		.port = 6379,
+		.count = 2
+	},
+	{
+		.interface = itf,
+		.tunid = 2,
+		.local_ip = 0x200000a,
+		.proto = 6,
+		.port = 6379,
+		.count = 2
+	}};
 
 	int *rc;
-	/* Test delete_transit_network_policy_protocol_port_1 with valid ppo_key */
+	/* Test delete_transit_network_policy_protocol_port_1 with valid ppo_keys */
 	will_return(__wrap_bpf_map_delete_elem, TRUE);
 	expect_function_call(__wrap_bpf_map_delete_elem);
-	rc = delete_transit_network_policy_protocol_port_1_svc(&ppo_key, NULL);
+	will_return(__wrap_bpf_map_delete_elem, TRUE);
+	expect_function_call(__wrap_bpf_map_delete_elem);
+	rc = delete_transit_network_policy_protocol_port_1_svc(ppo_keys, NULL);
 	assert_int_equal(*rc, 0);
 
-	/* Test delete_transit_network_policy_protocol_port_1 with invalid ppo_key */
+	/* Test delete_transit_network_policy_protocol_port_1 with invalid ppo_keys */
 	will_return(__wrap_bpf_map_delete_elem, FALSE);
 	expect_function_call(__wrap_bpf_map_delete_elem);
-	rc = delete_transit_network_policy_protocol_port_1_svc(&ppo_key, NULL);
+	rc = delete_transit_network_policy_protocol_port_1_svc(ppo_keys, NULL);
 	assert_int_equal(*rc, RPC_TRN_FATAL);
 
 	/* Test delete_transit_network_policy_protocol_port_1 with invalid interface*/
-	ppo_key.interface = "";
-	rc = delete_transit_network_policy_protocol_port_1_svc(&ppo_key, NULL);
+	ppo_keys[0].interface = "";
+	ppo_keys[1].interface = "";
+	rc = delete_transit_network_policy_protocol_port_1_svc(ppo_keys, NULL);
 	assert_int_equal(*rc, RPC_TRN_ERROR);
 }
 

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1715,9 +1715,16 @@ int *delete_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_key_t *p
 	static int result = -1;
 	int rc;
 	char *itf = ppo_key->interface;
-	struct vsip_ppo_t policy;
+	int counter = ppo_key->count;
 
 	TRN_LOG_INFO("delete_transit_network_policy_protocol_port_1 service");
+
+	if (counter == 0){
+		TRN_LOG_INFO("policy list has length of 0. Nothing to do");
+		result = 0;
+		return &result;
+	}
+	struct vsip_ppo_t policies[counter];
 
 	struct user_metadata_t *md = trn_itf_table_find(itf);
 	if (!md) {
@@ -1726,16 +1733,17 @@ int *delete_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_key_t *p
 		goto error;
 	}
 
-	policy.tunnel_id = ppo_key->tunid;
-	policy.local_ip = ppo_key->local_ip;
-	policy.proto = ppo_key->proto;
-	policy.port = ppo_key->port;
+	for (int i = 0; i < counter; i++){
+		policies[i].tunnel_id = ppo_key[i].tunid;
+		policies[i].local_ip = ppo_key[i].local_ip;
+		policies[i].proto = ppo_key[i].proto;
+		policies[i].port = ppo_key[i].port;
+	}
 
-	rc = trn_delete_transit_network_policy_protocol_port_map(md, &policy);
+	rc = trn_delete_transit_network_policy_protocol_port_map(md, policies, counter);
 
 	if (rc != 0) {
-		TRN_LOG_ERROR("Failure updating transit network policy enforcement map ip address: 0x%x, for interface %s",
-					ppo_key->local_ip, ppo_key->interface);
+		TRN_LOG_ERROR("Failure updating transit network policy enforcement map \n");
 		result = RPC_TRN_FATAL;
 		goto error;
 	}

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1265,6 +1265,7 @@ int *update_transit_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc
 {
 	UNUSED(rqstp);
 	static int result = -1;
+	int map_fd = -1;
 	int rc;
 	char *itf = policy->interface;
 	int type = policy->cidr_type;
@@ -1302,20 +1303,19 @@ int *update_transit_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc
 		policy++;
 	}
 
-	switch (type) {
-	case PRIMARY:
-		rc = trn_update_transit_network_policy_primary_map(md, cidr, bitmap, counter);
-		break;
-	case SUPPLEMENTARY:
-		rc = trn_update_transit_network_policy_supplementary_map(md, cidr, bitmap, counter);
-		break;
-	case EXCEPTION:
-		rc = trn_update_transit_network_policy_except_map(md, cidr, bitmap, counter);
-		break;
-	default:
-		result = RPC_TRN_FATAL;
+	if (type == PRIMARY) {
+		map_fd = md->ing_vsip_prim_map_fd;
+	}else if (type == SUPPLEMENTARY){
+		map_fd = md->ing_vsip_supp_map_fd;
+	}else if (type == EXCEPTION){
+		map_fd = md->ing_vsip_except_map_fd;
+	}else {
+		TRN_LOG_ERROR("Wrong network policy CIDR type. \n");
+		result = RPC_TRN_ERROR;
 		goto error;
 	}
+
+	rc = trn_update_transit_network_policy_map(map_fd, cidr, bitmap, counter);
 
 	if (rc != 0) {
 		TRN_LOG_ERROR("Failure updating transit network policy map cidr.");
@@ -1335,7 +1335,7 @@ int *update_agent_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc_r
 	UNUSED(rqstp);
 	static int result = -1;
 	int rc;
-	int map_fd;
+	int map_fd = -1;
 	char *itf = policy[0].interface;
 	int type = policy[0].cidr_type;
 
@@ -1376,8 +1376,12 @@ int *update_agent_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc_r
 		map_fd = md->eg_vsip_prim_map_fd;
 	}else if (type == SUPPLEMENTARY){
 		map_fd = md->eg_vsip_supp_map_fd;
-	}else{
+	}else if (type == EXCEPTION){
 		map_fd = md->eg_vsip_except_map_fd;
+	}else {
+		TRN_LOG_ERROR("Wrong network policy CIDR type. \n");
+		result = RPC_TRN_ERROR;
+		goto error;
 	}
 
 	rc = trn_update_agent_network_policy_map(map_fd, cidr, bitmap, counter);
@@ -1399,6 +1403,7 @@ int *delete_transit_network_policy_1_svc(rpc_trn_vsip_cidr_key_t *policy_key, st
 	UNUSED(rqstp);
 	static int result = -1;
 	int rc;
+	int map_fd = -1;
 	char *itf = policy_key->interface;
 	int type = policy_key->cidr_type;
 	int counter = policy_key->count;
@@ -1430,20 +1435,19 @@ int *delete_transit_network_policy_1_svc(rpc_trn_vsip_cidr_key_t *policy_key, st
 		cidr[i].remote_ip = policy_key[i].cidr_ip;
 	}
 
-	switch (type) {
-	case PRIMARY:
-		rc = trn_delete_transit_network_policy_primary_map(md, cidr, counter);
-		break;
-	case SUPPLEMENTARY:
-		rc = trn_delete_transit_network_policy_supplementary_map(md, cidr, counter);
-		break;
-	case EXCEPTION:
-		rc = trn_delete_transit_network_policy_except_map(md, cidr, counter);
-		break;
-	default:
-		result = RPC_TRN_FATAL;
+	if (type == PRIMARY) {
+		map_fd = md->ing_vsip_prim_map_fd;
+	}else if (type == SUPPLEMENTARY){
+		map_fd = md->ing_vsip_supp_map_fd;
+	}else if (type == EXCEPTION){
+		map_fd = md->ing_vsip_except_map_fd;
+	}else {
+		TRN_LOG_ERROR("Wrong network policy CIDR type. \n");
+		result = RPC_TRN_ERROR;
 		goto error;
 	}
+
+	rc = trn_delete_transit_network_policy_map(map_fd, cidr, counter);
 
 	if (rc != 0) {
 		TRN_LOG_ERROR("Failure deleting transit network policy map cidr");
@@ -1499,8 +1503,12 @@ int *delete_agent_network_policy_1_svc(rpc_trn_vsip_cidr_key_t *policy_key, stru
 		map_fd = md->eg_vsip_prim_map_fd;
 	}else if (type == SUPPLEMENTARY){
 		map_fd = md->eg_vsip_supp_map_fd;
-	}else{
+	}else if (type == EXCEPTION){
 		map_fd = md->eg_vsip_except_map_fd;
+	}else {
+		TRN_LOG_ERROR("Wrong network policy CIDR type. \n");
+		result = RPC_TRN_ERROR;
+		goto error;
 	}
 
 	rc = trn_delete_agent_network_policy_map(map_fd, cidr, counter);

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -800,14 +800,18 @@ int trn_update_transit_network_policy_protocol_port_map(struct user_metadata_t *
 }
 
 int trn_delete_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
-						        struct vsip_ppo_t *policy)
+						        struct vsip_ppo_t *policy,
+							int counter)
 {
-	int err = bpf_map_delete_elem(md->ing_vsip_ppo_map_fd, policy);
+	for (int i = 0; i < counter; i++)
+	{
+		int err = bpf_map_delete_elem(md->ing_vsip_ppo_map_fd, &policy[i]);
 
-	if (err) {
-		TRN_LOG_ERROR("Delete Protocol-Port ingress map failed (err:%d).",
-				err);
-		return 1;
+		if (err) {
+			TRN_LOG_ERROR("Delete Protocol-Port ingress map failed (err:%d).for ip address 0x%x with protocol %d and port %d. \n",
+					err, policy[i].local_ip, policy[i].proto, policy[i].port);
+			return 1;
+		}
 	}
 	return 0;
 }

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -212,32 +212,14 @@ int trn_add_prog(struct user_metadata_t *md, unsigned int prog_idx,
 
 int trn_remove_prog(struct user_metadata_t *md, unsigned int prog_idx);
 
-int trn_update_transit_network_policy_primary_map(struct user_metadata_t *md,
-						  struct vsip_cidr_t *cidr,
-						  __u64 *bitmap,
-						  int counter);
+int trn_update_transit_network_policy_map(int fd,
+					   struct vsip_cidr_t *ipcidr,
+					   __u64 *bitmap,
+					   int counter);
 
-int trn_update_transit_network_policy_supplementary_map(struct user_metadata_t *md,
-							struct vsip_cidr_t *cidr,
-							__u64 *bitmap,
-							int counter);
-
-int trn_update_transit_network_policy_except_map(struct user_metadata_t *md,
-						 struct vsip_cidr_t *cidr,
-						 __u64 *bitmap,
-						 int counter);
-
-int trn_delete_transit_network_policy_primary_map(struct user_metadata_t *md,
-						  struct vsip_cidr_t *cidr,
-						  int counter);
-
-int trn_delete_transit_network_policy_supplementary_map(struct user_metadata_t *md,
-							struct vsip_cidr_t *cidr,
-							int counter);
-
-int trn_delete_transit_network_policy_except_map(struct user_metadata_t *md,
-						 struct vsip_cidr_t *cidr,
-						 int counter);
+int trn_delete_transit_network_policy_map(int fd,
+					   struct vsip_cidr_t *ipcidr,
+					   int counter);
 
 int trn_update_transit_network_policy_enforcement_map(struct user_metadata_t *md,
 						      struct vsip_enforce_t *local,

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -254,4 +254,5 @@ int trn_update_transit_network_policy_protocol_port_map(struct user_metadata_t *
 							int counter);
 
 int trn_delete_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
-						        struct vsip_ppo_t *policy);
+						        struct vsip_ppo_t *policy,
+							int counter);

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -209,6 +209,7 @@ struct rpc_trn_vsip_ppo_key_t {
        uint32_t local_ip;
        uint8_t proto;
        uint16_t port;
+       int count;
 };
 
 /*----- Protocol. -----*/


### PR DESCRIPTION
This partially resolves #294

For network policy protocol-port maps deletes, we were doing one by one bpf map delete previously. To increase efficiency, we now switch to batch delete