### PR TITLE
Add Agent enforcement map delete

### DIFF
--- a/src/cli/test/module.mk
+++ b/src/cli/test/module.mk
@@ -35,6 +35,7 @@ CLI_MOCKS += -Wl,--wrap=delete_agent_md_1
 CLI_MOCKS += -Wl,--wrap=delete_transit_network_policy_1
 CLI_MOCKS += -Wl,--wrap=delete_agent_network_policy_1
 CLI_MOCKS += -Wl,--wrap=delete_transit_network_policy_enforcement_1
+CLI_MOCKS += -Wl,--wrap=delete_agent_network_policy_enforcement_1
 CLI_MOCKS += -Wl,--wrap=delete_transit_network_policy_protocol_port_1
 CLI_MOCKS += -Wl,--wrap=setrlimit
 

--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -170,6 +170,15 @@ int *__wrap_delete_transit_network_policy_enforcement_1(rpc_trn_vsip_enforce_t *
 	return retval;
 }
 
+int *__wrap_delete_agent_network_policy_enforcement_1(rpc_trn_vsip_enforce_t *enforce, CLIENT *clnt)
+{
+	check_expected_ptr(enforce);
+	check_expected_ptr(clnt);
+	int *retval = mock_ptr_type(int *);
+	function_called();
+	return retval;
+}
+
 int *__wrap_update_transit_network_policy_protocol_port_1(rpc_trn_vsip_ppo_t *ppo, CLIENT *clnt)
 {
 	check_expected_ptr(ppo);
@@ -2713,6 +2722,79 @@ static void test_trn_cli_delete_transit_network_policy_enforcement_subcmd(void *
 	assert_int_equal(rc, -EINVAL);
 }
 
+static void test_trn_cli_delete_agent_network_policy_enforcement_subcmd(void **state)
+{
+	UNUSED(state);
+	int rc;
+	int argc = 5;
+	char itf[] = "eth0";
+	int delete_agent_network_policy_enforcement_1_ret_val;
+
+	/* Test cases */
+	char *argv1[] = { "delete-network-policy-enforcement-egress", "-i", "eth0", "-j", QUOTE([{
+				  "tunnel_id": "3",
+				  "ip": "10.0.0.3"
+			  },
+			  {
+				  "tunnel_id": "3",
+				  "ip": "10.0.0.3"
+			  }]) };
+
+	char *argv2[] = { "delete-network-policy-enforcement-egress", "-i", "eth0", "-j", QUOTE([{
+				  "tunnel_id": "3",
+				  "ip": 10.0.0.3
+			  },
+			  {
+				  "tunnel_id": "3",
+				  "ip": 10.0.0.3
+			  }]) };
+
+	struct rpc_trn_vsip_enforce_t exp_enforce[2] = {{
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x300000a
+	},
+	{
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x300000a
+	}};
+
+	/* Test call delete_agent_network_policy_enforcement successfully */
+	TEST_CASE("delete-network-policy-enforcement-egress succeed with well formed policy json input");
+	delete_agent_network_policy_enforcement_1_ret_val = 0;
+	expect_function_call(__wrap_delete_agent_network_policy_enforcement_1);
+	will_return(__wrap_delete_agent_network_policy_enforcement_1, &delete_agent_network_policy_enforcement_1_ret_val);
+	expect_check(__wrap_delete_agent_network_policy_enforcement_1, enforce, check_policy_enforcement_equal, exp_enforce);
+	expect_any(__wrap_delete_agent_network_policy_enforcement_1, clnt);
+	rc = trn_cli_delete_agent_network_policy_enforcement_subcmd(NULL, argc, argv1);
+	assert_int_equal(rc, 0);
+
+	/* Test parse network policy input error 2*/
+	TEST_CASE("delete-network-policy-enforcement-egress is not called malformed json");
+	rc = trn_cli_delete_agent_network_policy_enforcement_subcmd(NULL, argc, argv2);
+	assert_int_equal(rc, -EINVAL);
+
+	/* Test call delete_agent_network_policy_enforcement_1 return error*/
+	TEST_CASE("delete-network-policy-enforcement-egress subcommand fails if delete_agent_network_policy_enforcement_1 returns error");
+	delete_agent_network_policy_enforcement_1_ret_val = -EINVAL;
+	expect_function_call(__wrap_delete_agent_network_policy_enforcement_1);
+	will_return(__wrap_delete_agent_network_policy_enforcement_1, &delete_agent_network_policy_enforcement_1_ret_val);
+	expect_any(__wrap_delete_agent_network_policy_enforcement_1, enforce);
+	expect_any(__wrap_delete_agent_network_policy_enforcement_1, clnt);
+	rc = trn_cli_delete_agent_network_policy_enforcement_subcmd(NULL, argc, argv1);
+	assert_int_equal(rc, -EINVAL);
+
+	/* Test call delete_agent_network_policy_enforcement_1 return NULL*/
+	TEST_CASE("delete-network-policy-enforcement-egress subcommand fails if delete_agent_network_policy_enforcement_1 returns NULL");
+	expect_function_call(__wrap_delete_agent_network_policy_enforcement_1);
+	will_return(__wrap_delete_agent_network_policy_enforcement_1, NULL);
+	expect_any(__wrap_delete_agent_network_policy_enforcement_1, enforce);
+	expect_any(__wrap_delete_agent_network_policy_enforcement_1, clnt);
+	rc = trn_cli_delete_agent_network_policy_enforcement_subcmd(NULL, argc, argv1);
+	assert_int_equal(rc, -EINVAL);
+}
+
 static void test_trn_cli_update_transit_network_policy_protocol_port_subcmd(void **state)
 {
 	UNUSED(state);
@@ -2921,6 +3003,7 @@ int main()
 		cmocka_unit_test(test_trn_cli_update_transit_network_policy_enforcement_subcmd),
 		cmocka_unit_test(test_trn_cli_update_agent_network_policy_enforcement_subcmd),
 		cmocka_unit_test(test_trn_cli_delete_transit_network_policy_enforcement_subcmd),
+		cmocka_unit_test(test_trn_cli_delete_agent_network_policy_enforcement_subcmd),
 		cmocka_unit_test(test_trn_cli_update_transit_network_policy_protocol_port_subcmd),
 		cmocka_unit_test(test_trn_cli_delete_transit_network_policy_protocol_port_subcmd)
 	};

--- a/src/cli/trn_cli.c
+++ b/src/cli/trn_cli.c
@@ -59,6 +59,7 @@ static const struct cmd {
 	{ "update-network-policy-enforcement-ingress", trn_cli_update_transit_network_policy_enforcement_subcmd },
 	{ "update-network-policy-enforcement-egress", trn_cli_update_agent_network_policy_enforcement_subcmd },
 	{ "delete-network-policy-enforcement-ingress", trn_cli_delete_transit_network_policy_enforcement_subcmd },
+	{ "delete-network-policy-enforcement-egress", trn_cli_delete_agent_network_policy_enforcement_subcmd },
 	{ "update-network-policy-protocol-port-ingress", trn_cli_update_transit_network_policy_protocol_port_subcmd },
 	{ "delete-network-policy-protocol-port-ingress", trn_cli_delete_transit_network_policy_protocol_port_subcmd },
 	{ 0 },

--- a/src/cli/trn_cli.h
+++ b/src/cli/trn_cli.h
@@ -117,6 +117,7 @@ int trn_cli_delete_agent_network_policy_subcmd(CLIENT *clnt, int argc, char *arg
 int trn_cli_update_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_update_agent_network_policy_enforcement_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_delete_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int argc, char *argv[]);
+int trn_cli_delete_agent_network_policy_enforcement_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_update_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_delete_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int argc, char *argv[]);
 

--- a/src/cli/trn_cli_network_policy.c
+++ b/src/cli/trn_cli_network_policy.c
@@ -454,6 +454,63 @@ int trn_cli_delete_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int a
 	return 0;
 }
 
+int trn_cli_delete_agent_network_policy_enforcement_subcmd(CLIENT *clnt, int argc, char *argv[])
+{
+	ketopt_t om = KETOPT_INIT;
+	struct cli_conf_data_t conf;
+	cJSON *json_str = NULL;
+
+	if (trn_cli_read_conf_str(&om, argc, argv, &conf)) {
+		return -EINVAL;
+	}
+
+	char *buf = conf.conf_str;
+	json_str = trn_cli_parse_json(buf);
+
+	if (json_str == NULL) {
+		return -EINVAL;
+	}
+
+	int counter = cJSON_GetArraySize(json_str);
+
+	int *rc;
+	struct rpc_trn_vsip_enforce_t enforces[counter];
+	char rpc[] = "delete_agent_network_policy_enforcement_1";
+
+	for (int i = 0; i < counter; i++)
+	{
+		struct rpc_trn_vsip_enforce_t enforce;
+		enforce.interface = conf.intf;
+		enforce.count = counter;
+		cJSON *policy = cJSON_GetArrayItem(json_str, i);
+
+		int err = trn_cli_parse_network_policy_enforcement(policy, &enforce);
+		if (err != 0) {
+			print_err("Error: parsing network policy enforcement config.\n");
+			return -EINVAL;
+		}
+		enforces[i] = enforce;
+	}
+	cJSON_Delete(json_str);
+
+	rc = delete_agent_network_policy_enforcement_1(enforces, clnt);
+	if (rc == (int *)NULL) {
+		print_err("RPC Error: client call failed: delete_agent_network_policy_enforcement_1\n");
+		return -EINVAL;
+	}
+
+	if (*rc != 0) {
+		print_err(
+			"Error: %s fatal daemon error, see transitd logs for details.\n",
+			rpc);
+		return -EINVAL;
+	}
+
+	print_msg("delete_agent_network_policy_enforcement_1 successfully deleted network policy \n");
+
+	return 0;
+}
+
 int trn_cli_update_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int argc, char *argv[])
 {
 	ketopt_t om = KETOPT_INIT;

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -825,6 +825,47 @@ static void test_delete_transit_network_policy_enforcement_1_svc(void **state)
 	assert_int_equal(*rc, RPC_TRN_ERROR);
 }
 
+static void test_delete_agent_network_policy_enforcement_1_svc(void **state)
+{
+	UNUSED(state);
+	char itf[] = "lo";
+
+	struct rpc_trn_vsip_enforce_t enforce_keys[2] = {{
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x100000a,
+		.count = 2
+	},
+	{
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x100000a,
+		.count = 2
+	}};
+
+	int *rc;
+
+	/* Test delete_transit_network_policy_enforcement_1 with valid enforce_key */
+	will_return(__wrap_bpf_map_delete_elem, TRUE);
+	will_return(__wrap_bpf_map_delete_elem, TRUE);
+	expect_function_call(__wrap_bpf_map_delete_elem);
+	expect_function_call(__wrap_bpf_map_delete_elem);
+	rc = delete_agent_network_policy_enforcement_1_svc(enforce_keys, NULL);
+	assert_int_equal(*rc, 0);
+
+	/* Test delete_transit_network_policy_enforcement_1 with invalid enforce_key */
+	will_return(__wrap_bpf_map_delete_elem, FALSE);
+	expect_function_call(__wrap_bpf_map_delete_elem);
+	rc = delete_agent_network_policy_enforcement_1_svc(enforce_keys, NULL);
+	assert_int_equal(*rc, RPC_TRN_FATAL);
+
+	/* Test delete_transit_network_policy_enforcement_1 with invalid interface*/
+	enforce_keys[0].interface = "";
+	enforce_keys[1].interface = "";
+	rc = delete_agent_network_policy_enforcement_1_svc(enforce_keys, NULL);
+	assert_int_equal(*rc, RPC_TRN_ERROR);
+}
+
 static void test_update_transit_network_policy_protocol_port_1_svc(void **state)
 {
 	UNUSED(state);
@@ -1487,6 +1528,7 @@ int main()
 		cmocka_unit_test(test_update_transit_network_policy_enforcement_1_svc),
 		cmocka_unit_test(test_update_agent_network_policy_enforcement_1_svc),
 		cmocka_unit_test(test_delete_transit_network_policy_enforcement_1_svc),
+		cmocka_unit_test(test_delete_agent_network_policy_enforcement_1_svc),
 		cmocka_unit_test(test_update_transit_network_policy_protocol_port_1_svc),
 		cmocka_unit_test(test_delete_transit_network_policy_protocol_port_1_svc)
 	};

--- a/src/dmn/trn_agent_xdp_usr.c
+++ b/src/dmn/trn_agent_xdp_usr.c
@@ -574,14 +574,12 @@ int trn_update_agent_network_policy_map(int fd,
 {
 	for (int i = 0; i < counter; i++)
 	{
-		int err = bpf_map_update_elem(fd, ipcidr, bitmap, 0);
+		int err = bpf_map_update_elem(fd, &ipcidr[i], &bitmap[i], 0);
 		if (err) {
-			TRN_LOG_ERROR("Store Primary ingress map failed (err:%d).",
-				err);
+			TRN_LOG_ERROR("Store Primary egress map failed (err:%d) for ip address 0x%x wit remote cidr 0x%x / %d ",
+				err, ipcidr[i].local_ip, ipcidr[i].remote_ip, ipcidr[i].prefixlen);
 			return 1;
 		}
-		ipcidr++;
-		bitmap++;
 	}
 	return 0;
 }
@@ -592,13 +590,12 @@ int trn_delete_agent_network_policy_map(int fd,
 {
 	for (int i = 0; i < counter; i++)
 	{
-		int err = bpf_map_delete_elem(fd, ipcidr);
+		int err = bpf_map_delete_elem(fd, &ipcidr[i]);
 		if (err) {
-			TRN_LOG_ERROR("Store Primary ingress map failed (err:%d).",
-				err);
+			TRN_LOG_ERROR("Store Primary egress map failed (err:%d) for ip address 0x%x wit remote cidr 0x%x / %d ",
+				err, ipcidr[i].local_ip, ipcidr[i].remote_ip, ipcidr[i].prefixlen);
 			return 1;
 		}
-		ipcidr++;
 	}
 	return 0;
 }
@@ -614,8 +611,8 @@ int trn_update_agent_network_policy_enforcement_map(struct agent_user_metadata_t
 		int err = bpf_map_update_elem(md->eg_vsip_enforce_map_fd, &local[i], &isenforce[i], 0);
 
 		if (err) {
-			TRN_LOG_ERROR("Update Enforcement ingress map failed (err:%d).",
-					err);
+			TRN_LOG_ERROR("Update Enforcement egress map failed (err:%d) for ip address 0x%x. \n",
+					err, local[i].local_ip);
 			return 1;
 		}
 	}
@@ -632,8 +629,8 @@ int trn_delete_agent_network_policy_enforcement_map(struct agent_user_metadata_t
 		int err = bpf_map_delete_elem(md->eg_vsip_enforce_map_fd, &local[i]);
 
 		if (err) {
-			TRN_LOG_ERROR("Delete Enforcement ingress map failed (err:%d).",
-					err);
+			TRN_LOG_ERROR("Delete Enforcement egress map failed (err:%d) for ip address 0x%x. ",
+					err, local[i].local_ip);
 			return 1;
 		}
 	}

--- a/src/dmn/trn_agent_xdp_usr.c
+++ b/src/dmn/trn_agent_xdp_usr.c
@@ -611,7 +611,7 @@ int trn_update_agent_network_policy_enforcement_map(struct agent_user_metadata_t
 {
 	for (int i = 0; i < counter; i++)
 	{
-		int err = bpf_map_update_elem(md->ing_vsip_enforce_map_fd, &local[i], &isenforce[i], 0);
+		int err = bpf_map_update_elem(md->eg_vsip_enforce_map_fd, &local[i], &isenforce[i], 0);
 
 		if (err) {
 			TRN_LOG_ERROR("Update Enforcement ingress map failed (err:%d).",
@@ -620,5 +620,22 @@ int trn_update_agent_network_policy_enforcement_map(struct agent_user_metadata_t
 		}
 	}
 
+	return 0;
+}
+
+int trn_delete_agent_network_policy_enforcement_map(struct agent_user_metadata_t *md,
+						      struct vsip_enforce_t *local,
+						      int counter)
+{
+	for (int i = 0; i < counter; i++)
+	{
+		int err = bpf_map_delete_elem(md->eg_vsip_enforce_map_fd, &local[i]);
+
+		if (err) {
+			TRN_LOG_ERROR("Delete Enforcement ingress map failed (err:%d).",
+					err);
+			return 1;
+		}
+	}
 	return 0;
 }

--- a/src/dmn/trn_agent_xdp_usr.c
+++ b/src/dmn/trn_agent_xdp_usr.c
@@ -576,7 +576,7 @@ int trn_update_agent_network_policy_map(int fd,
 	{
 		int err = bpf_map_update_elem(fd, &ipcidr[i], &bitmap[i], 0);
 		if (err) {
-			TRN_LOG_ERROR("Store Primary egress map failed (err:%d) for ip address 0x%x wit remote cidr 0x%x / %d ",
+			TRN_LOG_ERROR("Store network policy egress CIDR map failed (err:%d) for ip address 0x%x wit remote cidr 0x%x / %d ",
 				err, ipcidr[i].local_ip, ipcidr[i].remote_ip, ipcidr[i].prefixlen);
 			return 1;
 		}
@@ -592,7 +592,7 @@ int trn_delete_agent_network_policy_map(int fd,
 	{
 		int err = bpf_map_delete_elem(fd, &ipcidr[i]);
 		if (err) {
-			TRN_LOG_ERROR("Store Primary egress map failed (err:%d) for ip address 0x%x wit remote cidr 0x%x / %d ",
+			TRN_LOG_ERROR("Delete network policy egress CIDR map failed (err:%d) for ip address 0x%x wit remote cidr 0x%x / %d ",
 				err, ipcidr[i].local_ip, ipcidr[i].remote_ip, ipcidr[i].prefixlen);
 			return 1;
 		}

--- a/src/dmn/trn_agent_xdp_usr.h
+++ b/src/dmn/trn_agent_xdp_usr.h
@@ -152,3 +152,7 @@ int trn_update_agent_network_policy_enforcement_map(struct agent_user_metadata_t
 						      struct vsip_enforce_t *local,
 						      __u8 *isenforce,
 						      int counter);
+
+int trn_delete_agent_network_policy_enforcement_map(struct agent_user_metadata_t *md,
+						      struct vsip_enforce_t *local,
+						      int counter);

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1661,6 +1661,51 @@ error:
 	return &result;
 }
 
+int *delete_agent_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *enforce, struct svc_req *rqstp)
+{
+	UNUSED(rqstp);
+	static int result = -1;
+	int rc;
+	char *itf = enforce->interface;
+	int counter = enforce->count;
+
+	TRN_LOG_INFO("delete_agent_network_policy_enforcement_1_svc service");
+
+	if (counter == 0){
+		TRN_LOG_INFO("policy list has length of 0. Nothing to do");
+		result = 0;
+		return &result;
+	}
+	struct vsip_enforce_t enfs[counter];
+
+	struct agent_user_metadata_t *md = trn_vif_table_find(itf);
+	if (!md) {
+		TRN_LOG_ERROR("Cannot find interface metadata for %s", itf);
+		result = RPC_TRN_ERROR;
+		goto error;
+	}
+
+	for (int i = 0; i < counter; i++)
+	{
+		enfs[i].tunnel_id = enforce[i].tunid;
+		enfs[i].local_ip = enforce[i].local_ip;
+	}
+
+	rc = trn_delete_agent_network_policy_enforcement_map(md, enfs, counter);
+
+	if (rc != 0) {
+		TRN_LOG_ERROR("Failure deleting agent network policy enforcement map \n");
+		result = RPC_TRN_FATAL;
+		goto error;
+	}
+
+	result = 0;
+	return &result;
+
+error:
+	return &result;
+}
+
 int *update_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_t *ppo, struct svc_req *rqstp)
 {
 	UNUSED(rqstp);

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -252,6 +252,7 @@ program RPC_TRANSIT_REMOTE_PROTOCOL {
                 int UPDATE_AGENT_NETWORK_POLICY(rpc_trn_vsip_cidr_t) = 29;
                 int DELETE_AGENT_NETWORK_POLICY(rpc_trn_vsip_cidr_key_t) = 30;
                 int UPDATE_AGENT_NETWORK_POLICY_ENFORCEMENT(rpc_trn_vsip_enforce_t) = 31;
+                int DELETE_AGENT_NETWORK_POLICY_ENFORCEMENT(rpc_trn_vsip_enforce_t) = 32;
 
           } = 1;
 


### PR DESCRIPTION
This PR partially resolves issue #270

It gets cli command input and trigger RPC call, then delete from BPF map for network policy enforcement map on the agent side.