### PR TITLE
Adding Protocol Port maps deletes on the agent side

### DIFF
--- a/src/cli/test/module.mk
+++ b/src/cli/test/module.mk
@@ -38,6 +38,7 @@ CLI_MOCKS += -Wl,--wrap=delete_agent_network_policy_1
 CLI_MOCKS += -Wl,--wrap=delete_transit_network_policy_enforcement_1
 CLI_MOCKS += -Wl,--wrap=delete_agent_network_policy_enforcement_1
 CLI_MOCKS += -Wl,--wrap=delete_transit_network_policy_protocol_port_1
+CLI_MOCKS += -Wl,--wrap=delete_agent_network_policy_protocol_port_1
 CLI_MOCKS += -Wl,--wrap=setrlimit
 
 unittest:: test_cli

--- a/src/cli/trn_cli.c
+++ b/src/cli/trn_cli.c
@@ -63,6 +63,7 @@ static const struct cmd {
 	{ "update-network-policy-protocol-port-ingress", trn_cli_update_transit_network_policy_protocol_port_subcmd },
 	{ "update-network-policy-protocol-port-egress", trn_cli_update_agent_network_policy_protocol_port_subcmd },
 	{ "delete-network-policy-protocol-port-ingress", trn_cli_delete_transit_network_policy_protocol_port_subcmd },
+	{ "delete-network-policy-protocol-port-egress", trn_cli_delete_agent_network_policy_protocol_port_subcmd },
 	{ 0 },
 };
 

--- a/src/cli/trn_cli.h
+++ b/src/cli/trn_cli.h
@@ -121,6 +121,7 @@ int trn_cli_delete_agent_network_policy_enforcement_subcmd(CLIENT *clnt, int arg
 int trn_cli_update_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_update_agent_network_policy_protocol_port_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_delete_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int argc, char *argv[]);
+int trn_cli_delete_agent_network_policy_protocol_port_subcmd(CLIENT *clnt, int argc, char *argv[]);
 
 void dump_vpc(struct rpc_trn_vpc_t *vpc);
 void dump_net(struct rpc_trn_network_t *net);

--- a/src/cli/trn_cli_network_policy.c
+++ b/src/cli/trn_cli_network_policy.c
@@ -758,6 +758,67 @@ int trn_cli_delete_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int
 	return 0;
 }
 
+int trn_cli_delete_agent_network_policy_protocol_port_subcmd(CLIENT *clnt, int argc, char *argv[])
+{
+	ketopt_t om = KETOPT_INIT;
+	struct cli_conf_data_t conf;
+	cJSON *json_str = NULL;
+
+	if (trn_cli_read_conf_str(&om, argc, argv, &conf)) {
+		return -EINVAL;
+	}
+
+	char *buf = conf.conf_str;
+	json_str = trn_cli_parse_json(buf);
+
+	if (json_str == NULL) {
+		return -EINVAL;
+	}
+
+	int *rc;
+
+	int counter = cJSON_GetArraySize(json_str); 
+	if (counter <= 0) {
+		print_err("Input policy size is less than or equal to zero. Please check your input. \n");
+		return -EINVAL;
+	}
+
+	struct rpc_trn_vsip_ppo_key_t ppo_keys[counter];
+	char rpc[] = "delete_agent_network_policy_protocol_port_1";
+
+	for (int i = 0; i < counter; i++)
+	{
+		struct rpc_trn_vsip_ppo_key_t ppo_key;
+		ppo_key.interface = conf.intf;
+		ppo_key.count = counter;
+		cJSON *policy = cJSON_GetArrayItem(json_str, i);
+		int err = trn_cli_parse_network_policy_protocol_port_key(policy, &ppo_key);
+		if (err != 0) {
+			print_err("Error: parsing network policy protocol port config.\n");
+			return -EINVAL;
+		}
+		ppo_keys[i] = ppo_key;
+	}
+	cJSON_Delete(json_str);
+
+	rc = delete_agent_network_policy_protocol_port_1(ppo_keys, clnt);
+	if (rc == (int *)NULL) {
+		print_err("RPC Error: client call failed: delete_agent_network_policy_protocol_port_1 \n");
+		return -EINVAL;
+	}
+
+	if (*rc != 0) {
+		print_err(
+			"Error: %s fatal daemon error, see transitd logs for details.\n",
+			rpc);
+		return -EINVAL;
+	}
+
+	print_msg("delete_agent_network_policy_protocol_port_1 successfully deleted network policy \n");
+
+	return 0;
+}
+
 void dump_network_policy(struct rpc_trn_vsip_cidr_t *policy)
 {
 	print_msg("Interface: %s\n", policy->interface);

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -970,6 +970,50 @@ static void test_delete_transit_network_policy_protocol_port_1_svc(void **state)
 	assert_int_equal(*rc, RPC_TRN_ERROR);
 }
 
+static void test_delete_agent_network_policy_protocol_port_1_svc(void **state)
+{
+	UNUSED(state);
+	char itf[] = "lo";
+
+	struct rpc_trn_vsip_ppo_key_t ppo_keys[2] = {{
+		.interface = itf,
+		.tunid = 3,
+		.local_ip = 0x300000a,
+		.proto = 6,
+		.port = 6379,
+		.count = 2
+	},
+	{
+		.interface = itf,
+		.tunid = 2,
+		.local_ip = 0x200000a,
+		.proto = 6,
+		.port = 6379,
+		.count = 2
+	}};
+
+	int *rc;
+	/* Test delete_agent_network_policy_protocol_port_1 with valid ppo_keys */
+	will_return(__wrap_bpf_map_delete_elem, TRUE);
+	expect_function_call(__wrap_bpf_map_delete_elem);
+	will_return(__wrap_bpf_map_delete_elem, TRUE);
+	expect_function_call(__wrap_bpf_map_delete_elem);
+	rc = delete_agent_network_policy_protocol_port_1_svc(ppo_keys, NULL);
+	assert_int_equal(*rc, 0);
+
+	/* Test delete_agent_network_policy_protocol_port_1 with invalid ppo_keys */
+	will_return(__wrap_bpf_map_delete_elem, FALSE);
+	expect_function_call(__wrap_bpf_map_delete_elem);
+	rc = delete_agent_network_policy_protocol_port_1_svc(ppo_keys, NULL);
+	assert_int_equal(*rc, RPC_TRN_FATAL);
+
+	/* Test delete_agent_network_policy_protocol_port_1 with invalid interface*/
+	ppo_keys[0].interface = "";
+	ppo_keys[1].interface = "";
+	rc = delete_agent_network_policy_protocol_port_1_svc(ppo_keys, NULL);
+	assert_int_equal(*rc, RPC_TRN_ERROR);
+}
+
 static void test_get_vpc_1_svc(void **state)
 {
 	UNUSED(state);
@@ -1573,7 +1617,8 @@ int main()
 		cmocka_unit_test(test_delete_agent_network_policy_enforcement_1_svc),
 		cmocka_unit_test(test_update_transit_network_policy_protocol_port_1_svc),
 		cmocka_unit_test(test_update_agent_network_policy_protocol_port_1_svc),
-		cmocka_unit_test(test_delete_transit_network_policy_protocol_port_1_svc)
+		cmocka_unit_test(test_delete_transit_network_policy_protocol_port_1_svc),
+		cmocka_unit_test(test_delete_agent_network_policy_protocol_port_1_svc)
 	};
 
 	int result = cmocka_run_group_tests(tests, groupSetup, groupTeardown);

--- a/src/dmn/trn_agent_xdp_usr.c
+++ b/src/dmn/trn_agent_xdp_usr.c
@@ -654,3 +654,20 @@ int trn_update_agent_network_policy_protocol_port_map(struct agent_user_metadata
 	}
 	return 0;
 }
+
+int trn_delete_agent_network_policy_protocol_port_map(struct agent_user_metadata_t *md,
+						        struct vsip_ppo_t *policy,
+							int counter)
+{
+	for (int i = 0; i < counter; i++)
+	{
+		int err = bpf_map_delete_elem(md->ing_vsip_ppo_map_fd, &policy[i]);
+
+		if (err) {
+			TRN_LOG_ERROR("Delete Protocol-Port egress map failed (err:%d).for ip address 0x%x with protocol %d and port %d. \n",
+					err, policy[i].local_ip, policy[i].proto, policy[i].port);
+			return 1;
+		}
+	}
+	return 0;
+}

--- a/src/dmn/trn_agent_xdp_usr.h
+++ b/src/dmn/trn_agent_xdp_usr.h
@@ -161,3 +161,7 @@ int trn_update_agent_network_policy_protocol_port_map(struct agent_user_metadata
 						        struct vsip_ppo_t *policy,
 						        __u64 *bitmap,
 							int counter);
+
+int trn_delete_agent_network_policy_protocol_port_map(struct agent_user_metadata_t *md,
+						        struct vsip_ppo_t *policy,
+							int counter);

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -255,6 +255,7 @@ program RPC_TRANSIT_REMOTE_PROTOCOL {
                 int UPDATE_AGENT_NETWORK_POLICY_ENFORCEMENT(rpc_trn_vsip_enforce_t) = 31;
                 int DELETE_AGENT_NETWORK_POLICY_ENFORCEMENT(rpc_trn_vsip_enforce_t) = 32;
                 int UPDATE_AGENT_NETWORK_POLICY_PROTOCOL_PORT(rpc_trn_vsip_ppo_t) = 33;
+                int DELETE_AGENT_NETWORK_POLICY_PROTOCOL_PORT(rpc_trn_vsip_ppo_key_t) = 34;
 
           } = 1;
 


### PR DESCRIPTION
This PR partially resolves issue #270

It gets cli command input and trigger RPC call, then deletes BPF map for network policy protocol port maps on the agent side.