### PR TITLE
Add size limit to cli command update_network_policy_ingress

### DIFF
--- a/mizar/common/common.py
+++ b/mizar/common/common.py
@@ -44,6 +44,12 @@ def run_cmd(cmd):
     returncode = result.returncode
     return (returncode, text)
 
+def count_characters(self, a_dict):
+    count = 0
+    for key, value in a_dict.items():
+        count += len(key)
+        count += len(str(value))
+    return count
 
 def get_iface_index(name, iproute):
     intfs = iproute.link_lookup(ifname=name)

--- a/mizar/common/common.py
+++ b/mizar/common/common.py
@@ -44,12 +44,6 @@ def run_cmd(cmd):
     returncode = result.returncode
     return (returncode, text)
 
-def count_characters(self, a_dict):
-    count = 0
-    for key, value in a_dict.items():
-        count += len(key)
-        count += len(str(value))
-    return count
 
 def get_iface_index(name, iproute):
     intfs = iproute.link_lookup(ifname=name)

--- a/mizar/common/constants.py
+++ b/mizar/common/constants.py
@@ -36,7 +36,7 @@ class CONSTANTS:
     ON_XDP_SCALED_EP = "ON_XDP_SCALED_EP"
     IPPROTO_TCP = "6"
     IPROTO_UDP = "17"
-
+    MAX_CLI_CHAR_LENGTH = 2000
 
 class OBJ_STATUS:
     obj_init = 'Init'

--- a/mizar/common/rpc.py
+++ b/mizar/common/rpc.py
@@ -21,7 +21,7 @@
 
 import logging
 import json
-from mizar.common.common import run_cmd, count_characters
+from mizar.common.common import run_cmd
 from mizar.common.constants import *
 
 logger = logging.getLogger()
@@ -319,7 +319,7 @@ class TrnRpc:
         if len(cidr_networkpolicy_list) == 0:
             return
         conf_list = []
-        counter = 0
+
         for cidr_networkpolicy in cidr_networkpolicy_list:
             conf = {
                 "tunnel_id": cidr_networkpolicy.vni,
@@ -329,14 +329,13 @@ class TrnRpc:
                 "cidr_type": cidr_networkpolicy.get_cidr_type_int(),
                 "bit_value": str(cidr_networkpolicy.policy_bit_value),
             }
-            item_len = count_characters(conf)
-            counter += item_len
+            item_len = len(json.dumps(conf)) + 1
+            counter = len(json.dumps(conf_list)) + item_len
             if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
                 conf_list.append(conf)
             if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
                 self.run_cli_update_network_policy_ingress(conf_list)
                 conf_list = []
-                counter = 0
         self.run_cli_update_network_policy_ingress(conf_list)
 
     def run_cli_update_network_policy_ingress(self, conf_list):

--- a/mizar/obj/endpoint.py
+++ b/mizar/obj/endpoint.py
@@ -377,6 +377,9 @@ class Endpoint:
         self.rpc.delete_agent_substrate_ep(ep, bouncer.ip)
 
     def update_networkpolicy_per_endpoint(self, data):
+        self.update_network_policy_ingress("except", data["ingress"]["cidr_table_except"])
+        self.update_network_policy_egress("except", data["egress"]["cidr_table_except"])
+
         if len(data["old"]) > 0:
             self.delete_network_policy_ingress("no_except", data["old"]["ingress"]["cidr_table_no_except"])
             self.delete_network_policy_ingress("with_except", data["old"]["ingress"]["cidr_table_with_except"])
@@ -384,17 +387,13 @@ class Endpoint:
             self.delete_network_policy_egress("no_except", data["old"]["egress"]["cidr_table_no_except"])
             self.delete_network_policy_egress("with_except", data["old"]["egress"]["cidr_table_with_except"])
             self.delete_network_policy_egress("except", data["old"]["egress"]["cidr_table_except"])
-
             self.delete_network_policy_protocol_port_ingress(data["old"]["ingress"]["port_table"])
             self.delete_network_policy_protocol_port_egress(data["old"]["egress"]["port_table"])
 
         self.update_network_policy_ingress("no_except", data["ingress"]["cidr_table_no_except"])
         self.update_network_policy_ingress("with_except", data["ingress"]["cidr_table_with_except"])
-        self.update_network_policy_ingress("except", data["ingress"]["cidr_table_except"])
         self.update_network_policy_egress("no_except", data["egress"]["cidr_table_no_except"])
         self.update_network_policy_egress("with_except", data["egress"]["cidr_table_with_except"])
-        self.update_network_policy_egress("except", data["egress"]["cidr_table_except"])
-
         self.update_network_policy_protocol_port_ingress(data["ingress"]["port_table"])
         self.update_network_policy_protocol_port_egress(data["egress"]["port_table"])
 


### PR DESCRIPTION
When doing batch update, the cli command has a limit of 2047. 
This PR is to break down the batch size so that it does not exceeds 2047 each update