### PR TITLE
Check size limit for network policy related map updates and deletes

### DIFF
--- a/mizar/common/common.py
+++ b/mizar/common/common.py
@@ -25,6 +25,7 @@ import logging
 import luigi
 import kopf
 import datetime
+import json
 import dateutil.parser
 from kubernetes import watch, client
 from ctypes.util import find_library
@@ -382,3 +383,11 @@ def reset_param(param):
     param.extra = None
     param.return_message = None
     return param
+
+def network_policy_rpc_helper(conf, conf_list):
+    # +1 is for comma that will get added during json conversion
+    item_len = len(json.dumps(conf)) + 1
+    counter = len(json.dumps(conf_list)) + item_len
+    if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+        return True
+    return False

--- a/mizar/common/common.py
+++ b/mizar/common/common.py
@@ -384,7 +384,7 @@ def reset_param(param):
     param.return_message = None
     return param
 
-def network_policy_rpc_helper(conf, conf_list):
+def conf_list_has_max_elements(conf, conf_list):
     # +1 is for comma that will get added during json conversion
     item_len = len(json.dumps(conf)) + 1
     counter = len(json.dumps(conf_list)) + item_len

--- a/mizar/common/rpc.py
+++ b/mizar/common/rpc.py
@@ -21,7 +21,7 @@
 
 import logging
 import json
-from mizar.common.common import run_cmd
+from mizar.common.common import run_cmd, network_policy_rpc_helper
 from mizar.common.constants import *
 
 logger = logging.getLogger()
@@ -328,12 +328,8 @@ class TrnRpc:
                 "cidr_type": cidr_networkpolicy.get_cidr_type_int(),
                 "bit_value": str(cidr_networkpolicy.policy_bit_value),
             }
-            # +1 is for comma that will get added during json conversion
-            item_len = len(json.dumps(conf)) + 1
-            counter = len(json.dumps(conf_list)) + item_len
-            if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
-                conf_list.append(conf)
-            if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+            conf_list.append(conf)
+            if (network_policy_rpc_helper(conf, conf_list)):
                 self.run_cli_update_network_policy_ingress(conf_list)
                 conf_list = []
         self.run_cli_update_network_policy_ingress(conf_list)
@@ -344,7 +340,6 @@ class TrnRpc:
         logger.info("update_network_policy_ingress: {}".format(cmd))
         returncode, text = run_cmd(cmd)
         logger.info("update_network_policy_ingress returns {} {}".format(returncode, text))
-    #### TODO: to shorten cli commands from line 51 to 62 to reduce size of the cli cmd
 
     def update_network_policy_egress(self, ep, cidr_networkpolicy_list):
         if len(cidr_networkpolicy_list) == 0:
@@ -360,12 +355,8 @@ class TrnRpc:
                 "cidr_type": cidr_networkpolicy.get_cidr_type_int(),
                 "bit_value": str(cidr_networkpolicy.policy_bit_value),
             }
-            # +1 is for comma that will get added during json conversion
-            item_len = len(json.dumps(conf)) + 1
-            counter = len(json.dumps(conf_list)) + item_len
-            if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
-                conf_list.append(conf)
-            if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+            conf_list.append(conf)
+            if (network_policy_rpc_helper(conf, conf_list)):
                 self.run_cli_update_network_policy_egress(conf_list, itf)
                 conf_list = []
         self.run_cli_update_network_policy_egress(conf_list, itf)
@@ -390,12 +381,8 @@ class TrnRpc:
                 "cidr_type": cidr_networkpolicy.get_cidr_type_int(),
                 "bit_value": str(cidr_networkpolicy.policy_bit_value),
             }
-            # +1 is for comma that will get added during json conversion
-            item_len = len(json.dumps(conf)) + 1
-            counter = len(json.dumps(conf_list)) + item_len
-            if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
-                conf_list.append(conf)
-            if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+            conf_list.append(conf)
+            if (network_policy_rpc_helper(conf, conf_list)):
                 self.run_cli_delete_network_policy_ingress(conf_list)
                 conf_list = []
         self.run_cli_delete_network_policy_ingress(conf_list)
@@ -421,15 +408,11 @@ class TrnRpc:
                 "cidr_type": cidr_networkpolicy.get_cidr_type_int(),
                 "bit_value": str(cidr_networkpolicy.policy_bit_value),
             }
-            # +1 is for comma that will get added during json conversion
-            item_len = len(json.dumps(conf)) + 1
-            counter = len(json.dumps(conf_list)) + item_len
-            if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
-                conf_list.append(conf)
-            if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+            conf_list.append(conf)
+            if (network_policy_rpc_helper(conf, conf_list)):
                 self.run_cli_delete_network_policy_egress(conf_list, itf)
                 conf_list = []
-            self.run_cli_delete_network_policy_egress(conf_list, itf)
+        self.run_cli_delete_network_policy_egress(conf_list, itf)
 
     def run_cli_delete_network_policy_egress(self, conf_list, itf):
         jsonconf = json.dumps(conf_list)
@@ -450,15 +433,11 @@ class TrnRpc:
                 "port": port_networkpolicy.port,
                 "bit_value": str(port_networkpolicy.policy_bit_value),
             }
-            # +1 is for comma that will get added during json conversion
-            item_len = len(json.dumps(conf)) + 1
-            counter = len(json.dumps(conf_list)) + item_len
-            if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
-                conf_list.append(conf)
-            if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+            conf_list.append(conf)
+            if (network_policy_rpc_helper(conf, conf_list)):
                 self.run_cli_update_network_policy_protocol_port_ingress(conf_list)
                 conf_list = []
-            self.run_cli_update_network_policy_protocol_port_ingress(conf_list)
+        self.run_cli_update_network_policy_protocol_port_ingress(conf_list)
 
     def run_cli_update_network_policy_protocol_port_ingress(self, conf_list):
         jsonconf = json.dumps(conf_list)
@@ -480,15 +459,11 @@ class TrnRpc:
                 "port": port_networkpolicy.port,
                 "bit_value": str(port_networkpolicy.policy_bit_value),
             }
-            # +1 is for comma that will get added during json conversion
-            item_len = len(json.dumps(conf)) + 1
-            counter = len(json.dumps(conf_list)) + item_len
-            if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
-                conf_list.append(conf)
-            if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+            conf_list.append(conf)
+            if (network_policy_rpc_helper(conf, conf_list)):
                 self.run_cli_update_network_policy_protocol_port_egress(conf_list, itf)
                 conf_list = []
-            self.run_cli_update_network_policy_protocol_port_egress(conf_list, itf)
+        self.run_cli_update_network_policy_protocol_port_egress(conf_list, itf)
 
     def run_cli_update_network_policy_protocol_port_egress(self, conf_list, itf):
         jsonconf = json.dumps(conf_list)
@@ -509,15 +484,11 @@ class TrnRpc:
                 "port": port_networkpolicy.port,
                 "bit_value": str(port_networkpolicy.policy_bit_value),
             }
-            # +1 is for comma that will get added during json conversion
-            item_len = len(json.dumps(conf)) + 1
-            counter = len(json.dumps(conf_list)) + item_len
-            if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
-                conf_list.append(conf)
-            if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+            conf_list.append(conf)
+            if (network_policy_rpc_helper(conf, conf_list)):
                 self.run_cli_delete_network_policy_protocol_port_ingress(conf_list)
                 conf_list = []
-            self.run_cli_delete_network_policy_protocol_port_ingress(conf_list)
+        self.run_cli_delete_network_policy_protocol_port_ingress(conf_list)
 
     def run_cli_delete_network_policy_protocol_port_ingress(self, conf_list):
         jsonconf = json.dumps(conf_list)
@@ -539,15 +510,11 @@ class TrnRpc:
                 "port": port_networkpolicy.port,
                 "bit_value": str(port_networkpolicy.policy_bit_value),
             }
-            # +1 is for comma that will get added during json conversion
-            item_len = len(json.dumps(conf)) + 1
-            counter = len(json.dumps(conf_list)) + item_len
-            if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
-                conf_list.append(conf)
-            if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+            conf_list.append(conf)
+            if (network_policy_rpc_helper(conf, conf_list)):
                 self.run_cli_delete_network_policy_protocol_port_egress(conf_list, itf)
                 conf_list = []
-            self.run_cli_delete_network_policy_protocol_port_egress(conf_list, itf)
+        self.run_cli_delete_network_policy_protocol_port_egress(conf_list, itf)
 
     def run_cli_delete_network_policy_protocol_port_egress(self, conf_list, itf):
         jsonconf = json.dumps(conf_list)

--- a/mizar/common/rpc.py
+++ b/mizar/common/rpc.py
@@ -319,7 +319,6 @@ class TrnRpc:
         if len(cidr_networkpolicy_list) == 0:
             return
         conf_list = []
-
         for cidr_networkpolicy in cidr_networkpolicy_list:
             conf = {
                 "tunnel_id": cidr_networkpolicy.vni,
@@ -329,6 +328,7 @@ class TrnRpc:
                 "cidr_type": cidr_networkpolicy.get_cidr_type_int(),
                 "bit_value": str(cidr_networkpolicy.policy_bit_value),
             }
+            # +1 is for comma that will get added during json conversion
             item_len = len(json.dumps(conf)) + 1
             counter = len(json.dumps(conf_list)) + item_len
             if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
@@ -360,7 +360,17 @@ class TrnRpc:
                 "cidr_type": cidr_networkpolicy.get_cidr_type_int(),
                 "bit_value": str(cidr_networkpolicy.policy_bit_value),
             }
-            conf_list.append(conf)
+            # +1 is for comma that will get added during json conversion
+            item_len = len(json.dumps(conf)) + 1
+            counter = len(json.dumps(conf_list)) + item_len
+            if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
+                conf_list.append(conf)
+            if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+                self.run_cli_update_network_policy_egress(conf_list, itf)
+                conf_list = []
+        self.run_cli_update_network_policy_egress(conf_list, itf)
+
+    def run_cli_update_network_policy_egress(self, conf_list, itf):
         jsonconf = json.dumps(conf_list)
         cmd = f'''{self.trn_cli_update_network_policy_egress} \'{jsonconf}\' -i \'{itf}\''''
         logger.info("update_network_policy_egress: {}".format(cmd))
@@ -380,7 +390,17 @@ class TrnRpc:
                 "cidr_type": cidr_networkpolicy.get_cidr_type_int(),
                 "bit_value": str(cidr_networkpolicy.policy_bit_value),
             }
-            conf_list.append(conf)
+            # +1 is for comma that will get added during json conversion
+            item_len = len(json.dumps(conf)) + 1
+            counter = len(json.dumps(conf_list)) + item_len
+            if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
+                conf_list.append(conf)
+            if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+                self.run_cli_delete_network_policy_ingress(conf_list)
+                conf_list = []
+        self.run_cli_delete_network_policy_ingress(conf_list)
+
+    def run_cli_delete_network_policy_ingress(self, conf_list):
         jsonconf = json.dumps(conf_list)
         cmd = f'''{self.trn_cli_delete_network_policy_ingress} \'{jsonconf}\''''
         logger.info("delete_network_policy_ingress: {}".format(cmd))
@@ -401,7 +421,17 @@ class TrnRpc:
                 "cidr_type": cidr_networkpolicy.get_cidr_type_int(),
                 "bit_value": str(cidr_networkpolicy.policy_bit_value),
             }
-            conf_list.append(conf)
+            # +1 is for comma that will get added during json conversion
+            item_len = len(json.dumps(conf)) + 1
+            counter = len(json.dumps(conf_list)) + item_len
+            if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
+                conf_list.append(conf)
+            if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+                self.run_cli_delete_network_policy_egress(conf_list, itf)
+                conf_list = []
+            self.run_cli_delete_network_policy_egress(conf_list, itf)
+
+    def run_cli_delete_network_policy_egress(self, conf_list, itf):
         jsonconf = json.dumps(conf_list)
         cmd = f'''{self.trn_cli_delete_network_policy_egress} \'{jsonconf}\' -i \'{itf}\''''
         logger.info("delete_network_policy_egress: {}".format(cmd))
@@ -420,7 +450,17 @@ class TrnRpc:
                 "port": port_networkpolicy.port,
                 "bit_value": str(port_networkpolicy.policy_bit_value),
             }
-            conf_list.append(conf)
+            # +1 is for comma that will get added during json conversion
+            item_len = len(json.dumps(conf)) + 1
+            counter = len(json.dumps(conf_list)) + item_len
+            if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
+                conf_list.append(conf)
+            if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+                self.run_cli_update_network_policy_protocol_port_ingress(conf_list)
+                conf_list = []
+            self.run_cli_update_network_policy_protocol_port_ingress(conf_list)
+
+    def run_cli_update_network_policy_protocol_port_ingress(self, conf_list):
         jsonconf = json.dumps(conf_list)
         cmd = f'''{self.trn_cli_update_network_policy_protocol_port_ingress} \'{jsonconf}\''''
         logger.info("update_network_policy_protocol_port_ingress: {}".format(cmd))
@@ -440,7 +480,17 @@ class TrnRpc:
                 "port": port_networkpolicy.port,
                 "bit_value": str(port_networkpolicy.policy_bit_value),
             }
-            conf_list.append(conf)
+            # +1 is for comma that will get added during json conversion
+            item_len = len(json.dumps(conf)) + 1
+            counter = len(json.dumps(conf_list)) + item_len
+            if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
+                conf_list.append(conf)
+            if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+                self.run_cli_update_network_policy_protocol_port_egress(conf_list, itf)
+                conf_list = []
+            self.run_cli_update_network_policy_protocol_port_egress(conf_list, itf)
+
+    def run_cli_update_network_policy_protocol_port_egress(self, conf_list, itf):
         jsonconf = json.dumps(conf_list)
         cmd = f'''{self.trn_cli_update_network_policy_protocol_port_egress} \'{jsonconf}\' -i \'{itf}\''''
         logger.info("update_network_policy_protocol_port_egress: {}".format(cmd))
@@ -459,7 +509,17 @@ class TrnRpc:
                 "port": port_networkpolicy.port,
                 "bit_value": str(port_networkpolicy.policy_bit_value),
             }
-            conf_list.append(conf)
+            # +1 is for comma that will get added during json conversion
+            item_len = len(json.dumps(conf)) + 1
+            counter = len(json.dumps(conf_list)) + item_len
+            if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
+                conf_list.append(conf)
+            if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+                self.run_cli_delete_network_policy_protocol_port_ingress(conf_list)
+                conf_list = []
+            self.run_cli_delete_network_policy_protocol_port_ingress(conf_list)
+
+    def run_cli_delete_network_policy_protocol_port_ingress(self, conf_list):
         jsonconf = json.dumps(conf_list)
         cmd = f'''{self.trn_cli_delete_network_policy_protocol_port_ingress} \'{jsonconf}\''''
         logger.info("delete_network_policy_protocol_port_ingress: {}".format(cmd))
@@ -479,7 +539,17 @@ class TrnRpc:
                 "port": port_networkpolicy.port,
                 "bit_value": str(port_networkpolicy.policy_bit_value),
             }
-            conf_list.append(conf)
+            # +1 is for comma that will get added during json conversion
+            item_len = len(json.dumps(conf)) + 1
+            counter = len(json.dumps(conf_list)) + item_len
+            if (counter < CONSTANTS.MAX_CLI_CHAR_LENGTH):
+                conf_list.append(conf)
+            if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
+                self.run_cli_delete_network_policy_protocol_port_egress(conf_list, itf)
+                conf_list = []
+            self.run_cli_delete_network_policy_protocol_port_egress(conf_list, itf)
+
+    def run_cli_delete_network_policy_protocol_port_egress(self, conf_list, itf):
         jsonconf = json.dumps(conf_list)
         cmd = f'''{self.trn_cli_delete_network_policy_protocol_port_egress} \'{jsonconf}\' -i \'{itf}\''''
         logger.info("delete_network_policy_protocol_port_egress: {}".format(cmd))


### PR DESCRIPTION
When doing batch updates and deletes, the cli command has a limit of 2047.
This PR is to break down the batch size so that it does not exceeds 2047 each update and delete