### PR TITLE
When deleting a networkpolicy, make sure all its references in all related maps are deleted

### DIFF
--- a/mizar/networkpolicy/networkpolicy_util.py
+++ b/mizar/networkpolicy/networkpolicy_util.py
@@ -94,6 +94,7 @@ class NetworkPolicyUtil:
 
     def add_networkpolicy_for_endpoint(self, policy_name, policy_types):
         if policy_types is None:
+            self.remove_networkpolicy_from_endpoint(policy_name)
             return
 
         has_ingress = "Ingress" in policy_types
@@ -110,10 +111,21 @@ class NetworkPolicyUtil:
             if ep is None:
                 logger.warn("In operator store, found endpoint {} in networkpolicy_endpoints_store but cannot retrieve it from eps_store.".format(endpoint_name))
             else:
-                if has_ingress and policy_name not in ep.ingress_networkpolicies:
+                if has_ingress:
                     ep.add_ingress_networkpolicy(policy_name)
-                if has_egress and policy_name not in ep.egress_networkpolicies:
+                if has_egress:
                     ep.add_egress_networkpolicy(policy_name)
+
+    def remove_networkpolicy_from_endpoint(self, policy_name):
+        if policy_name not in networkpolicy_opr.store.networkpolicy_endpoints_store:
+            return
+        for endpoint_name in networkpolicy_opr.store.networkpolicy_endpoints_store[policy_name]:
+            ep = networkpolicy_opr.store.get_ep(endpoint_name)
+            if ep is None:
+                logger.warn("In operator store, found endpoint {} in networkpolicy_endpoints_store but cannot retrieve it from eps_store.".format(endpoint_name))
+            else:
+                ep.remove_ingress_networkpolicy(policy_name)
+                ep.remove_egress_networkpolicy(policy_name)
 
     def handle_networkpolicy_update_delete(self, endpoint_name_list):
         for endpoint_name in endpoint_name_list:

--- a/mizar/store/operator_store.py
+++ b/mizar/store/operator_store.py
@@ -205,6 +205,22 @@ class OprStore(object):
     def delete_networkpolicy(self, name):
         if name in self.networkpolicies_store:
             del self.networkpolicies_store[name]
+        self.delete_networkpolicy_in_label_policy_store(self.label_networkpolicies_store, name)
+        self.delete_networkpolicy_in_label_policy_store(self.label_networkpolicies_ingress_store, name)
+        self.delete_networkpolicy_in_label_policy_store(self.label_networkpolicies_egress_store, name)
+        self.delete_networkpolicy_in_label_policy_store(self.namespace_label_networkpolicies_ingress_store, name)
+        self.delete_networkpolicy_in_label_policy_store(self.namespace_label_networkpolicies_egress_store, name)
+
+    def delete_networkpolicy_in_label_policy_store(self, label_policy_store, policy_name):
+        label_list = set()
+        for label in label_policy_store:
+            if policy_name in label_policy_store[label]:
+                label_policy_store[label].remove(policy_name)
+                if len(label_policy_store[label]) == 0:
+                    label_list.add(label)
+
+        for label in label_list:
+            label_policy_store.pop(label)
 
     def get_networkpolicies_by_label(self, label):
         if label in self.label_networkpolicies_store:


### PR DESCRIPTION
Implementation:
1. When deleting a network policy, delete label_policy_store as well.
2. When deleting a network policy, remove the policy from label-policy mapping.