### PR TITLE
Change enforcement map update and delete from batches to singles

### DIFF
--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -2540,44 +2540,29 @@ static void test_trn_cli_update_transit_network_policy_enforcement_subcmd(void *
 	int update_transit_network_policy_enforcement_1_ret_val = 0;
 
 	/* Test cases */
-	char *argv1[] = { "update-net-policy-enforce-in", "-i", "eth0", "-j", QUOTE([{
+	char *argv1[] = { "update-net-policy-enforce-in", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": "3",
 				  "ip": "10.0.0.3"
-			  },
-			  {
-				  "tunnel_id": "3",
-				  "ip": "10.0.0.3"
-			  }]) };
+			  }) };
 
-	char *argv2[] = { "update-net-policy-enforce-in", "-i", "eth0", "-j", QUOTE([{
+	char *argv2[] = { "update-net-policy-enforce-in", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": "3",
 				  "ip": 10.0.0.3
-			  },
-			  {
-				  "tunnel_id": "3",
-				  "ip": 10.0.0.3
-			  }]) };
+			  }) };
 	char itf[] = "eth0";
 
-	struct rpc_trn_vsip_enforce_t exp_enforce[2] = {{
+	struct rpc_trn_vsip_enforce_t exp_enforce = {
 		.interface = itf,
 		.tunid = 3,
-		.local_ip = 0x300000a,
-		.count = 2
-	},
-	{
-		.interface = itf,
-		.tunid = 3,
-		.local_ip = 0x300000a,
-		.count = 2
-	}};
+		.local_ip = 0x300000a
+	};
 
 	/* Test call update_transit_network_policy_enforcement successfully */
 	TEST_CASE("update-net-policy-enforce-in succeed with well formed policy json input");
 	update_transit_network_policy_enforcement_1_ret_val = 0;
 	expect_function_call(__wrap_update_transit_network_policy_enforcement_1);
 	will_return(__wrap_update_transit_network_policy_enforcement_1, &update_transit_network_policy_enforcement_1_ret_val);
-	expect_check(__wrap_update_transit_network_policy_enforcement_1, enforce, check_policy_enforcement_equal, exp_enforce);
+	expect_check(__wrap_update_transit_network_policy_enforcement_1, enforce, check_policy_enforcement_equal, &exp_enforce);
 	expect_any(__wrap_update_transit_network_policy_enforcement_1, clnt);
 	rc = trn_cli_update_transit_network_policy_enforcement_subcmd(NULL, argc, argv1);
 	assert_int_equal(rc, 0);
@@ -2615,29 +2600,29 @@ static void test_trn_cli_update_agent_network_policy_enforcement_subcmd(void **s
 	int update_agent_network_policy_enforcement_1_ret_val = 0;
 
 	/* Test cases */
-	char *argv1[] = { "update-net-policy-enforce-out", "-i", "eth0", "-j", QUOTE([{
+	char *argv1[] = { "update-net-policy-enforce-out", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": "3",
 				  "ip": "10.0.0.3"
-			  }]) };
+			  }) };
 
-	char *argv2[] = { "update-net-policy-enforce-out", "-i", "eth0", "-j", QUOTE([{
+	char *argv2[] = { "update-net-policy-enforce-out", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": "3",
 				  "ip": 10.0.0.3
-			  }]) };
+			  }) };
 	char itf[] = "eth0";
 
-	struct rpc_trn_vsip_enforce_t exp_enforce[1] = {{
+	struct rpc_trn_vsip_enforce_t exp_enforce = {
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x300000a
-	}};
+	};
 
 	/* Test call update_agent_network_policy_enforcement successfully */
 	TEST_CASE("update-net-policy-enforce-out succeed with well formed policy json input");
 	update_agent_network_policy_enforcement_1_ret_val = 0;
 	expect_function_call(__wrap_update_agent_network_policy_enforcement_1);
 	will_return(__wrap_update_agent_network_policy_enforcement_1, &update_agent_network_policy_enforcement_1_ret_val);
-	expect_check(__wrap_update_agent_network_policy_enforcement_1, enforce, check_policy_enforcement_equal, exp_enforce);
+	expect_check(__wrap_update_agent_network_policy_enforcement_1, enforce, check_policy_enforcement_equal, &exp_enforce);
 	expect_any(__wrap_update_agent_network_policy_enforcement_1, clnt);
 	rc = trn_cli_update_agent_network_policy_enforcement_subcmd(NULL, argc, argv1);
 	assert_int_equal(rc, 0);
@@ -2676,41 +2661,28 @@ static void test_trn_cli_delete_transit_network_policy_enforcement_subcmd(void *
 	int delete_transit_network_policy_enforcement_1_ret_val;
 
 	/* Test cases */
-	char *argv1[] = { "delete-net-policy-enforce-in", "-i", "eth0", "-j", QUOTE([{
+	char *argv1[] = { "delete-net-policy-enforce-in", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": "3",
 				  "ip": "10.0.0.3"
-			  },
-			  {
-				  "tunnel_id": "3",
-				  "ip": "10.0.0.3"
-			  }]) };
+			  }) };
 
-	char *argv2[] = { "delete-net-policy-enforce-in", "-i", "eth0", "-j", QUOTE([{
+	char *argv2[] = { "delete-net-policy-enforce-in", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": "3",
 				  "ip": 10.0.0.3
-			  },
-			  {
-				  "tunnel_id": "3",
-				  "ip": 10.0.0.3
-			  }]) };
+			  }) };
 
-	struct rpc_trn_vsip_enforce_t exp_enforce[2] = {{
+	struct rpc_trn_vsip_enforce_t exp_enforce = {
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x300000a
-	},
-	{
-		.interface = itf,
-		.tunid = 3,
-		.local_ip = 0x300000a
-	}};
+	};
 
 	/* Test call delete_transit_network_policy_enforcement successfully */
 	TEST_CASE("delete-net-policy-enforce-in succeed with well formed policy json input");
 	delete_transit_network_policy_enforcement_1_ret_val = 0;
 	expect_function_call(__wrap_delete_transit_network_policy_enforcement_1);
 	will_return(__wrap_delete_transit_network_policy_enforcement_1, &delete_transit_network_policy_enforcement_1_ret_val);
-	expect_check(__wrap_delete_transit_network_policy_enforcement_1, enforce, check_policy_enforcement_equal, exp_enforce);
+	expect_check(__wrap_delete_transit_network_policy_enforcement_1, enforce, check_policy_enforcement_equal, &exp_enforce);
 	expect_any(__wrap_delete_transit_network_policy_enforcement_1, clnt);
 	rc = trn_cli_delete_transit_network_policy_enforcement_subcmd(NULL, argc, argv1);
 	assert_int_equal(rc, 0);
@@ -2749,41 +2721,28 @@ static void test_trn_cli_delete_agent_network_policy_enforcement_subcmd(void **s
 	int delete_agent_network_policy_enforcement_1_ret_val;
 
 	/* Test cases */
-	char *argv1[] = { "delete-net-policy-enforce-out", "-i", "eth0", "-j", QUOTE([{
+	char *argv1[] = { "delete-net-policy-enforce-out", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": "3",
 				  "ip": "10.0.0.3"
-			  },
-			  {
-				  "tunnel_id": "3",
-				  "ip": "10.0.0.3"
-			  }]) };
+			  }) };
 
-	char *argv2[] = { "delete-net-policy-enforce-out", "-i", "eth0", "-j", QUOTE([{
+	char *argv2[] = { "delete-net-policy-enforce-out", "-i", "eth0", "-j", QUOTE({
 				  "tunnel_id": "3",
 				  "ip": 10.0.0.3
-			  },
-			  {
-				  "tunnel_id": "3",
-				  "ip": 10.0.0.3
-			  }]) };
+			  }) };
 
-	struct rpc_trn_vsip_enforce_t exp_enforce[2] = {{
+	struct rpc_trn_vsip_enforce_t exp_enforce = {
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x300000a
-	},
-	{
-		.interface = itf,
-		.tunid = 3,
-		.local_ip = 0x300000a
-	}};
+	};
 
 	/* Test call delete_agent_network_policy_enforcement successfully */
 	TEST_CASE("delete-net-policy-enforce-out succeed with well formed policy json input");
 	delete_agent_network_policy_enforcement_1_ret_val = 0;
 	expect_function_call(__wrap_delete_agent_network_policy_enforcement_1);
 	will_return(__wrap_delete_agent_network_policy_enforcement_1, &delete_agent_network_policy_enforcement_1_ret_val);
-	expect_check(__wrap_delete_agent_network_policy_enforcement_1, enforce, check_policy_enforcement_equal, exp_enforce);
+	expect_check(__wrap_delete_agent_network_policy_enforcement_1, enforce, check_policy_enforcement_equal, &exp_enforce);
 	expect_any(__wrap_delete_agent_network_policy_enforcement_1, clnt);
 	rc = trn_cli_delete_agent_network_policy_enforcement_subcmd(NULL, argc, argv1);
 	assert_int_equal(rc, 0);

--- a/src/cli/trn_cli_common.c
+++ b/src/cli/trn_cli_common.c
@@ -742,7 +742,7 @@ int trn_cli_parse_network_policy_enforcement(const cJSON *jsonobj,
 	if (ip != NULL && cJSON_IsString(ip)) {
 		enforce->local_ip = parse_ip_address(ip);
 	} else {
-		print_err("Error: Network policy enforcement local IP is missing or non-string\n");
+		print_err("Error: Network policy enforcement IP is missing or non-string\n");
 		return -EINVAL;
 	}
 

--- a/src/cli/trn_cli_network_policy.c
+++ b/src/cli/trn_cli_network_policy.c
@@ -300,40 +300,28 @@ int trn_cli_update_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int a
 
 	char *buf = conf.conf_str;
 	json_str = trn_cli_parse_json(buf);
+
 	if (json_str == NULL) {
 		return -EINVAL;
 	}
 
 	int *rc;
+	struct rpc_trn_vsip_enforce_t enforce;
+	char rpc[] = "update_transit_network_policy_enforcement_1";
+	enforce.interface = conf.intf;
 
-	int counter = cJSON_GetArraySize(json_str); 
-	if (counter <= 0) {
-		print_err("Input policy size is less than or equal to zero. Please check your input. \n");
+	int err = trn_cli_parse_network_policy_enforcement(json_str, &enforce);
+	cJSON_Delete(json_str);
+
+	if (err != 0) {
+		print_err("Error: parsing network policy enforcement config.\n");
 		return -EINVAL;
 	}
 
-	struct rpc_trn_vsip_enforce_t enforces[counter];
-	char rpc[] = "update_transit_network_policy_enforcement_1";
-
-	for (int i = 0; i < counter; i++)
-	{
-		struct rpc_trn_vsip_enforce_t enforce;
-		enforce.interface = conf.intf;
-		enforce.count = counter;
-		cJSON *policy = cJSON_GetArrayItem(json_str, i);
-
-		int err = trn_cli_parse_network_policy_enforcement(policy, &enforce);
-		if (err != 0) {
-			print_err("Error: parsing network policy enforcement config.\n");
-			return -EINVAL;
-		}
-		enforces[i] = enforce;
-	}
-	cJSON_Delete(json_str);
-
-	rc = update_transit_network_policy_enforcement_1(enforces, clnt);
+	rc = update_transit_network_policy_enforcement_1(&enforce, clnt);
 	if (rc == (int *)NULL) {
-		print_err("RPC Error: client call failed: update_transit_network_policy_enforcement_1\n");
+		print_err("RPC Error: client call failed: update_transit_network_policy_enforcement_1 for local ip: 0x%x .\n",
+					enforce.local_ip);
 		return -EINVAL;
 	}
 
@@ -344,17 +332,9 @@ int trn_cli_update_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int a
 		return -EINVAL;
 	}
 
-	for (int k = 0; k < counter; k++)
-	{
-		if (&enforces[k] == NULL){
-			print_err("update_transit_network_policy_enforcement_1 Expected %d elements to be updated into network policy map, but only has %d elements. \n",
-					counter, k-1);
-			return -EINVAL; 
-		}
-		dump_enforced_policy(&enforces[k]);
-	}
-	
-	print_msg("update_transit_network_policy_enforcement_1 successfully updated network policy enforcement maps\n");
+	dump_enforced_policy(&enforce);
+	print_msg("update_transit_network_policy_enforcement_1 successfully updated network policy for local ip: 0x%x for interface %s \n",
+				enforce.local_ip, enforce.interface);
 
 	return 0;
 }
@@ -371,40 +351,28 @@ int trn_cli_update_agent_network_policy_enforcement_subcmd(CLIENT *clnt, int arg
 
 	char *buf = conf.conf_str;
 	json_str = trn_cli_parse_json(buf);
+
 	if (json_str == NULL) {
 		return -EINVAL;
 	}
 
 	int *rc;
+	struct rpc_trn_vsip_enforce_t enforce;
+	char rpc[] = "update_agent_network_policy_enforcement_1";
+	enforce.interface = conf.intf;
 
-	int counter = cJSON_GetArraySize(json_str); 
-	if (counter <= 0) {
-		print_err("Input policy size is less than or equal to zero. Please check your input. \n");
+	int err = trn_cli_parse_network_policy_enforcement(json_str, &enforce);
+	cJSON_Delete(json_str);
+
+	if (err != 0) {
+		print_err("Error: parsing network policy enforcement config.\n");
 		return -EINVAL;
 	}
 
-	struct rpc_trn_vsip_enforce_t enforces[counter];
-	char rpc[] = "update_agent_network_policy_enforcement_1";
-
-	for (int i = 0; i < counter; i++)
-	{
-		struct rpc_trn_vsip_enforce_t enforce;
-		enforce.interface = conf.intf;
-		enforce.count = counter;
-		cJSON *policy = cJSON_GetArrayItem(json_str, i);
-
-		int err = trn_cli_parse_network_policy_enforcement(policy, &enforce);
-		if (err != 0) {
-			print_err("Error: parsing network policy enforcement config.\n");
-			return -EINVAL;
-		}
-		enforces[i] = enforce;
-	}
-	cJSON_Delete(json_str);
-
-	rc = update_agent_network_policy_enforcement_1(enforces, clnt);
+	rc = update_agent_network_policy_enforcement_1(&enforce, clnt);
 	if (rc == (int *)NULL) {
-		print_err("RPC Error: client call failed: update_agent_network_policy_enforcement_1\n");
+		print_err("RPC Error: client call failed: update_agent_network_policy_enforcement_1 for local ip: 0x%x .\n",
+					enforce.local_ip);
 		return -EINVAL;
 	}
 
@@ -415,18 +383,9 @@ int trn_cli_update_agent_network_policy_enforcement_subcmd(CLIENT *clnt, int arg
 		return -EINVAL;
 	}
 
-	for (int k = 0; k < counter; k++)
-	{
-		if (&enforces[k] == NULL)
-		{
-			print_err("update_agent_enforcement_network_policy_1 Expected %d elements to be updated into network policy map, but only has %d elements. \n",
-					counter, k-1);
-			return -EINVAL;
-		}
-		dump_enforced_policy(&enforces[k]);
-	}
-	
-	print_msg("update_agent_network_policy_enforcement_1 successfully updated network policy enforcement maps\n");
+	dump_enforced_policy(&enforce);
+	print_msg("update_agent_network_policy_enforcement_1 successfully updated network policy for local ip: 0x%x for interface %s \n",
+				enforce.local_ip, enforce.interface);
 
 	return 0;
 }
@@ -449,35 +408,22 @@ int trn_cli_delete_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int a
 	}
 
 	int *rc;
+	struct rpc_trn_vsip_enforce_t enforce;
+	char rpc[] = "delete_transit_network_policy_enforcement_1";
+	enforce.interface = conf.intf;
 
-	int counter = cJSON_GetArraySize(json_str); 
-	if (counter <= 0) {
-		print_err("Input policy size is less than or equal to zero. Please check your input. \n");
+	int err = trn_cli_parse_network_policy_enforcement(json_str, &enforce);
+	cJSON_Delete(json_str);
+
+	if (err != 0) {
+		print_err("Error: parsing network policy enforcement config.\n");
 		return -EINVAL;
 	}
 
-	struct rpc_trn_vsip_enforce_t enforces[counter];
-	char rpc[] = "delete_transit_network_policy_enforcement_1";
-
-	for (int i = 0; i < counter; i++)
-	{
-		struct rpc_trn_vsip_enforce_t enforce;
-		enforce.interface = conf.intf;
-		enforce.count = counter;
-		cJSON *policy = cJSON_GetArrayItem(json_str, i);
-
-		int err = trn_cli_parse_network_policy_enforcement(policy, &enforce);
-		if (err != 0) {
-			print_err("Error: parsing network policy enforcement config.\n");
-			return -EINVAL;
-		}
-		enforces[i] = enforce;
-	}
-	cJSON_Delete(json_str);
-
-	rc = delete_transit_network_policy_enforcement_1(enforces, clnt);
+	rc = delete_transit_network_policy_enforcement_1(&enforce, clnt);
 	if (rc == (int *)NULL) {
-		print_err("RPC Error: client call failed: delete_transit_network_policy_enforcement_1\n");
+		print_err("RPC Error: client call failed: delete_transit_network_policy_enforcement_1 for local ip: 0x%x.\n",
+					enforce.local_ip);
 		return -EINVAL;
 	}
 
@@ -488,7 +434,9 @@ int trn_cli_delete_transit_network_policy_enforcement_subcmd(CLIENT *clnt, int a
 		return -EINVAL;
 	}
 
-	print_msg("delete_transit_network_policy_enforcement_1 successfully deleted network policy \n");
+	dump_enforced_policy(&enforce);
+	print_msg("delete_transit_network_policy_enforcement_1 successfully deleted network policy for local ip: 0x%x for interface %s\n",
+					enforce.local_ip, enforce.interface);
 
 	return 0;
 }
@@ -511,35 +459,22 @@ int trn_cli_delete_agent_network_policy_enforcement_subcmd(CLIENT *clnt, int arg
 	}
 
 	int *rc;
+	struct rpc_trn_vsip_enforce_t enforce;
+	char rpc[] = "delete_agent_network_policy_enforcement_1";
+	enforce.interface = conf.intf;
 
-	int counter = cJSON_GetArraySize(json_str); 
-	if (counter <= 0) {
-		print_err("Input policy size is less than or equal to zero. Please check your input. \n");
+	int err = trn_cli_parse_network_policy_enforcement(json_str, &enforce);
+	cJSON_Delete(json_str);
+
+	if (err != 0) {
+		print_err("Error: parsing network policy enforcement config.\n");
 		return -EINVAL;
 	}
 
-	struct rpc_trn_vsip_enforce_t enforces[counter];
-	char rpc[] = "delete_agent_network_policy_enforcement_1";
-
-	for (int i = 0; i < counter; i++)
-	{
-		struct rpc_trn_vsip_enforce_t enforce;
-		enforce.interface = conf.intf;
-		enforce.count = counter;
-		cJSON *policy = cJSON_GetArrayItem(json_str, i);
-
-		int err = trn_cli_parse_network_policy_enforcement(policy, &enforce);
-		if (err != 0) {
-			print_err("Error: parsing network policy enforcement config.\n");
-			return -EINVAL;
-		}
-		enforces[i] = enforce;
-	}
-	cJSON_Delete(json_str);
-
-	rc = delete_agent_network_policy_enforcement_1(enforces, clnt);
+	rc = delete_agent_network_policy_enforcement_1(&enforce, clnt);
 	if (rc == (int *)NULL) {
-		print_err("RPC Error: client call failed: delete_agent_network_policy_enforcement_1\n");
+		print_err("RPC Error: client call failed: delete_agent_network_policy_enforcement_1 for local ip: 0x%x.\n",
+					enforce.local_ip);
 		return -EINVAL;
 	}
 
@@ -550,7 +485,9 @@ int trn_cli_delete_agent_network_policy_enforcement_subcmd(CLIENT *clnt, int arg
 		return -EINVAL;
 	}
 
-	print_msg("delete_agent_network_policy_enforcement_1 successfully deleted network policy \n");
+	dump_enforced_policy(&enforce);
+	print_msg("delete_agent_network_policy_enforcement_1 successfully deleted network policy for local ip: 0x%x for interface %s\n",
+					enforce.local_ip, enforce.interface);
 
 	return 0;
 }
@@ -836,7 +773,6 @@ void dump_enforced_policy(struct rpc_trn_vsip_enforce_t *enforce)
 	print_msg("Interface: %s\n", enforce->interface);
 	print_msg("Tunnel ID: %ld\n", enforce->tunid);
 	print_msg("Local IP: %x\n", enforce->local_ip);
-	print_msg("count: %x\n", enforce->count);
 }
 
 void dump_protocol_port_policy(struct rpc_trn_vsip_ppo_t *ppo)

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -741,22 +741,15 @@ static void test_update_transit_network_policy_enforcement_1_svc(void **state)
 	UNUSED(state);
 	char itf[] = "lo";
 
-	struct rpc_trn_vsip_enforce_t enforce1[2] = {{
+	struct rpc_trn_vsip_enforce_t enforce1 = {
 		.interface = itf,
 		.tunid = 3,
-		.local_ip = 0x100000a,
-		.count = 2
-	},
-	{
-		.interface = itf,
-		.tunid = 3,
-		.local_ip = 0x100000a,
-		.count = 2
-	}};
+		.local_ip = 0x100000a
+	};
 
 	int *rc;
-	expect_function_calls(__wrap_bpf_map_update_elem, 2);
-	rc = update_transit_network_policy_enforcement_1_svc(enforce1, NULL);
+	expect_function_call(__wrap_bpf_map_update_elem);
+	rc = update_transit_network_policy_enforcement_1_svc(&enforce1, NULL);
 	assert_int_equal(*rc, 0);
 }
 
@@ -765,22 +758,15 @@ static void test_update_agent_network_policy_enforcement_1_svc(void **state)
 	UNUSED(state);
 	char itf[] = "lo";
 
-	struct rpc_trn_vsip_enforce_t enforce1[2] = {{
+	struct rpc_trn_vsip_enforce_t enforce1 = {
 		.interface = itf,
 		.tunid = 3,
-		.local_ip = 0x100000a,
-		.count = 2
-	},
-	{
-		.interface = itf,
-		.tunid = 3,
-		.local_ip = 0x100000a,
-		.count = 2
-	}};
+		.local_ip = 0x100000a
+	};
 
 	int *rc;
-	expect_function_calls(__wrap_bpf_map_update_elem, 2);
-	rc = update_agent_network_policy_enforcement_1_svc(enforce1, NULL);
+	expect_function_call(__wrap_bpf_map_update_elem);
+	rc = update_agent_network_policy_enforcement_1_svc(&enforce1, NULL);
 	assert_int_equal(*rc, 0);
 }
 
@@ -789,39 +775,29 @@ static void test_delete_transit_network_policy_enforcement_1_svc(void **state)
 	UNUSED(state);
 	char itf[] = "lo";
 
-	struct rpc_trn_vsip_enforce_t enforce_keys[2] = {{
+	struct rpc_trn_vsip_enforce_t enforce_key = {
 		.interface = itf,
 		.tunid = 3,
-		.local_ip = 0x100000a,
-		.count = 2
-	},
-	{
-		.interface = itf,
-		.tunid = 3,
-		.local_ip = 0x100000a,
-		.count = 2
-	}};
+		.local_ip = 0x100000a
+	};
 
 	int *rc;
 
 	/* Test delete_transit_network_policy_enforcement_1 with valid enforce_key */
 	will_return(__wrap_bpf_map_delete_elem, TRUE);
-	will_return(__wrap_bpf_map_delete_elem, TRUE);
 	expect_function_call(__wrap_bpf_map_delete_elem);
-	expect_function_call(__wrap_bpf_map_delete_elem);
-	rc = delete_transit_network_policy_enforcement_1_svc(enforce_keys, NULL);
+	rc = delete_transit_network_policy_enforcement_1_svc(&enforce_key, NULL);
 	assert_int_equal(*rc, 0);
 
 	/* Test delete_transit_network_policy_enforcement_1 with invalid enforce_key */
 	will_return(__wrap_bpf_map_delete_elem, FALSE);
 	expect_function_call(__wrap_bpf_map_delete_elem);
-	rc = delete_transit_network_policy_enforcement_1_svc(enforce_keys, NULL);
+	rc = delete_transit_network_policy_enforcement_1_svc(&enforce_key, NULL);
 	assert_int_equal(*rc, RPC_TRN_FATAL);
 
 	/* Test delete_transit_network_policy_enforcement_1 with invalid interface*/
-	enforce_keys[0].interface = "";
-	enforce_keys[1].interface = "";
-	rc = delete_transit_network_policy_enforcement_1_svc(enforce_keys, NULL);
+	enforce_key.interface = "";
+	rc = delete_transit_network_policy_enforcement_1_svc(&enforce_key, NULL);
 	assert_int_equal(*rc, RPC_TRN_ERROR);
 }
 
@@ -830,39 +806,29 @@ static void test_delete_agent_network_policy_enforcement_1_svc(void **state)
 	UNUSED(state);
 	char itf[] = "lo";
 
-	struct rpc_trn_vsip_enforce_t enforce_keys[2] = {{
+	struct rpc_trn_vsip_enforce_t enforce_key = {
 		.interface = itf,
 		.tunid = 3,
-		.local_ip = 0x100000a,
-		.count = 2
-	},
-	{
-		.interface = itf,
-		.tunid = 3,
-		.local_ip = 0x100000a,
-		.count = 2
-	}};
+		.local_ip = 0x100000a
+	};
 
 	int *rc;
 
-	/* Test delete_transit_network_policy_enforcement_1 with valid enforce_key */
-	will_return(__wrap_bpf_map_delete_elem, TRUE);
+	/* Test delete_agent_network_policy_enforcement_1 with valid enforce_key */
 	will_return(__wrap_bpf_map_delete_elem, TRUE);
 	expect_function_call(__wrap_bpf_map_delete_elem);
-	expect_function_call(__wrap_bpf_map_delete_elem);
-	rc = delete_agent_network_policy_enforcement_1_svc(enforce_keys, NULL);
+	rc = delete_agent_network_policy_enforcement_1_svc(&enforce_key, NULL);
 	assert_int_equal(*rc, 0);
 
-	/* Test delete_transit_network_policy_enforcement_1 with invalid enforce_key */
+	/* Test delete_agent_network_policy_enforcement_1 with invalid enforce_key */
 	will_return(__wrap_bpf_map_delete_elem, FALSE);
 	expect_function_call(__wrap_bpf_map_delete_elem);
-	rc = delete_agent_network_policy_enforcement_1_svc(enforce_keys, NULL);
+	rc = delete_agent_network_policy_enforcement_1_svc(&enforce_key, NULL);
 	assert_int_equal(*rc, RPC_TRN_FATAL);
 
-	/* Test delete_transit_network_policy_enforcement_1 with invalid interface*/
-	enforce_keys[0].interface = "";
-	enforce_keys[1].interface = "";
-	rc = delete_agent_network_policy_enforcement_1_svc(enforce_keys, NULL);
+	/* Test delete_agent_network_policy_enforcement_1 with invalid interface*/
+	enforce_key.interface = "";
+	rc = delete_agent_network_policy_enforcement_1_svc(&enforce_key, NULL);
 	assert_int_equal(*rc, RPC_TRN_ERROR);
 }
 

--- a/src/dmn/trn_agent_xdp_usr.c
+++ b/src/dmn/trn_agent_xdp_usr.c
@@ -603,37 +603,29 @@ int trn_delete_agent_network_policy_map(int fd,
 
 int trn_update_agent_network_policy_enforcement_map(struct agent_user_metadata_t *md,
 						      struct vsip_enforce_t *local,
-						      __u8 *isenforce,
-						      int counter)
+						      __u8 *isenforce)
 {
-	for (int i = 0; i < counter; i++)
-	{
-		int err = bpf_map_update_elem(md->eg_vsip_enforce_map_fd, &local[i], &isenforce[i], 0);
+	int err = bpf_map_update_elem(md->eg_vsip_enforce_map_fd, &local, &isenforce, 0);
 
-		if (err) {
-			TRN_LOG_ERROR("Update Enforcement egress map failed (err:%d) for ip address 0x%x. \n",
-					err, local[i].local_ip);
-			return 1;
-		}
+	if (err) {
+		TRN_LOG_ERROR("Update Enforcement egress map failed (err:%d) for ip address 0x%x. \n",
+				err, local->local_ip);
+		return 1;
 	}
 
 	return 0;
 }
 
 int trn_delete_agent_network_policy_enforcement_map(struct agent_user_metadata_t *md,
-						      struct vsip_enforce_t *local,
-						      int counter)
+						      struct vsip_enforce_t *local)
 {
-	for (int i = 0; i < counter; i++)
-	{
-		int err = bpf_map_delete_elem(md->eg_vsip_enforce_map_fd, &local[i]);
-
-		if (err) {
-			TRN_LOG_ERROR("Delete Enforcement egress map failed (err:%d) for ip address 0x%x. ",
-					err, local[i].local_ip);
-			return 1;
-		}
+	int err = bpf_map_delete_elem(md->eg_vsip_enforce_map_fd, &local);
+	if (err) {
+		TRN_LOG_ERROR("Delete Enforcement egress map failed (err:%d) for ip address 0x%x. ",
+				err, local->local_ip);
+		return 1;
 	}
+
 	return 0;
 }
 

--- a/src/dmn/trn_agent_xdp_usr.h
+++ b/src/dmn/trn_agent_xdp_usr.h
@@ -150,12 +150,10 @@ int trn_delete_agent_network_policy_map(int fd,
 
 int trn_update_agent_network_policy_enforcement_map(struct agent_user_metadata_t *md,
 						      struct vsip_enforce_t *local,
-						      __u8 *isenforce,
-						      int counter);
+						      __u8 *isenforce);
 
 int trn_delete_agent_network_policy_enforcement_map(struct agent_user_metadata_t *md,
-						      struct vsip_enforce_t *local,
-						      int counter);
+						      struct vsip_enforce_t *local);
 
 int trn_update_agent_network_policy_protocol_port_map(struct agent_user_metadata_t *md,
 						        struct vsip_ppo_t *policy,

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1532,17 +1532,8 @@ int *update_transit_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *pol
 	static int result = -1;
 	int rc;
 	char *itf = policy->interface;
-
-	int counter = policy->count;
-	if (counter == 0)
-	{
-		TRN_LOG_INFO("policy has length of 0. Nothing to do");
-		result = 0;
-		return &result;
-	}
-
-	struct vsip_enforce_t enforces[counter];
-	__u8 val[counter];
+	struct vsip_enforce_t enforce;
+	__u8 val;
 
 	TRN_LOG_INFO("update_transit_network_policy_enforcement_1_svc service");
 
@@ -1553,17 +1544,15 @@ int *update_transit_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *pol
 		goto error;
 	}
 
-	for (int i = 0; i < counter; i++)
-	{
-		enforces[i].tunnel_id = policy[i].tunid;
-		enforces[i].local_ip = policy[i].local_ip;
-		val[i] = 1;
-	}
+	enforce.tunnel_id = policy->tunid;
+	enforce.local_ip = policy->local_ip;
+	val = 1;
 
-	rc = trn_update_transit_network_policy_enforcement_map(md, enforces, val, counter);
+	rc = trn_update_transit_network_policy_enforcement_map(md, &enforce, &val);
 
 	if (rc != 0) {
-		TRN_LOG_ERROR("Failure updating transit network policy enforcement map \n");
+		TRN_LOG_ERROR("Failure updating transit network policy enforcement map ip address: 0x%x, for interface %s",
+					policy->local_ip, policy->interface);
 		result = RPC_TRN_FATAL;
 		goto error;
 	}
@@ -1581,17 +1570,8 @@ int *update_agent_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *polic
 	static int result = -1;
 	int rc;
 	char *itf = policy->interface;
-
-	int counter = policy->count;
-	if (counter == 0)
-	{
-		TRN_LOG_INFO("policy has length of 0. Nothing to do");
-		result = 0;
-		return &result;
-	}
-
-	struct vsip_enforce_t enforces[counter];
-	__u8 val[counter];
+	struct vsip_enforce_t enforce;
+	__u8 val;
 
 	TRN_LOG_INFO("update_agent_network_policy_enforcement_1_svc service");
 
@@ -1602,17 +1582,15 @@ int *update_agent_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *polic
 		goto error;
 	}
 
-	for (int i = 0; i < counter; i++)
-	{
-		enforces[i].tunnel_id = policy[i].tunid;
-		enforces[i].local_ip = policy[i].local_ip;
-		val[i] = 1;
-	}
+	enforce.tunnel_id = policy->tunid;
+	enforce.local_ip = policy->local_ip;
+	val = 1;
 
-	rc = trn_update_agent_network_policy_enforcement_map(md, enforces, val, counter);
+	rc = trn_update_agent_network_policy_enforcement_map(md, &enforce, &val);
 
 	if (rc != 0) {
-		TRN_LOG_ERROR("Failure updating agent network policy enforcement map \n");
+		TRN_LOG_ERROR("Failure updating agnet network policy enforcement map ip address: 0x%x, for interface %s",
+					policy->local_ip, policy->interface);
 		result = RPC_TRN_FATAL;
 		goto error;
 	}
@@ -1624,22 +1602,15 @@ error:
 	return &result;
 }
 
-int *delete_transit_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *enforce, struct svc_req *rqstp)
+int *delete_transit_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *policy, struct svc_req *rqstp)
 {
 	UNUSED(rqstp);
-	static int result = -1;
+	static int result;
 	int rc;
-	char *itf = enforce->interface;
-	int counter = enforce->count;
+	char *itf = policy->interface;
+	struct vsip_enforce_t enf;
 
 	TRN_LOG_INFO("delete_transit_network_policy_enforcement_1_svc service");
-
-	if (counter == 0){
-		TRN_LOG_INFO("policy list has length of 0. Nothing to do");
-		result = 0;
-		return &result;
-	}
-	struct vsip_enforce_t enfs[counter];
 
 	struct user_metadata_t *md = trn_itf_table_find(itf);
 	if (!md) {
@@ -1648,16 +1619,14 @@ int *delete_transit_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *enf
 		goto error;
 	}
 
-	for (int i = 0; i < counter; i++)
-	{
-		enfs[i].tunnel_id = enforce[i].tunid;
-		enfs[i].local_ip = enforce[i].local_ip;
-	}
+	enf.tunnel_id = policy->tunid;
+	enf.local_ip = policy->local_ip;
 
-	rc = trn_delete_transit_network_policy_enforcement_map(md, enfs, counter);
+	rc = trn_delete_transit_network_policy_enforcement_map(md, &enf);
 
 	if (rc != 0) {
-		TRN_LOG_ERROR("Failure deleting transit network policy enforcement map \n");
+		TRN_LOG_ERROR("Failure deleting transit network policy enforcement map ip address: 0x%x, for interface %s",
+					policy->local_ip, policy->interface);
 		result = RPC_TRN_FATAL;
 		goto error;
 	}
@@ -1669,22 +1638,15 @@ error:
 	return &result;
 }
 
-int *delete_agent_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *enforce, struct svc_req *rqstp)
+int *delete_agent_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *policy, struct svc_req *rqstp)
 {
 	UNUSED(rqstp);
-	static int result = -1;
+	static int result;
 	int rc;
-	char *itf = enforce->interface;
-	int counter = enforce->count;
+	char *itf = policy->interface;
+	struct vsip_enforce_t enf;
 
 	TRN_LOG_INFO("delete_agent_network_policy_enforcement_1_svc service");
-
-	if (counter == 0){
-		TRN_LOG_INFO("policy list has length of 0. Nothing to do");
-		result = 0;
-		return &result;
-	}
-	struct vsip_enforce_t enfs[counter];
 
 	struct agent_user_metadata_t *md = trn_vif_table_find(itf);
 	if (!md) {
@@ -1693,16 +1655,14 @@ int *delete_agent_network_policy_enforcement_1_svc(rpc_trn_vsip_enforce_t *enfor
 		goto error;
 	}
 
-	for (int i = 0; i < counter; i++)
-	{
-		enfs[i].tunnel_id = enforce[i].tunid;
-		enfs[i].local_ip = enforce[i].local_ip;
-	}
+	enf.tunnel_id = policy->tunid;
+	enf.local_ip = policy->local_ip;
 
-	rc = trn_delete_agent_network_policy_enforcement_map(md, enfs, counter);
+	rc = trn_delete_agent_network_policy_enforcement_map(md, &enf);
 
 	if (rc != 0) {
-		TRN_LOG_ERROR("Failure deleting agent network policy enforcement map \n");
+		TRN_LOG_ERROR("Failure deleting agent network policy enforcement map ip address: 0x%x, for interface %s",
+					policy->local_ip, policy->interface);
 		result = RPC_TRN_FATAL;
 		goto error;
 	}

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -672,36 +672,30 @@ int trn_delete_transit_network_policy_map(int fd,
 
 int trn_update_transit_network_policy_enforcement_map(struct user_metadata_t *md,
 						      struct vsip_enforce_t *local,
-						      __u8 *isenforce,
-						      int counter)
+						      __u8 *isenforce)
 {
-	for (int i = 0; i < counter; i++)
-	{
-		int err = bpf_map_update_elem(md->ing_vsip_enforce_map_fd, &local[i], &isenforce[i], 0);
+	int err = bpf_map_update_elem(md->ing_vsip_enforce_map_fd, &local, &isenforce, 0);
 
-		if (err) {
-			TRN_LOG_ERROR("Update Enforcement ingress map failed (err:%d).",
-					err);
-			return 1;
-		}
+	if (err) {
+		TRN_LOG_ERROR("Update Enforcement ingress map failed (err:%d).",
+				err);
+		return 1;
 	}
+
 	return 0;
 }
 
 int trn_delete_transit_network_policy_enforcement_map(struct user_metadata_t *md,
-						      struct vsip_enforce_t *local,
-						      int counter)
+						      struct vsip_enforce_t *local)
 {
-	for (int i = 0; i < counter; i++)
-	{
-		int err = bpf_map_delete_elem(md->ing_vsip_enforce_map_fd, &local[i]);
+	int err = bpf_map_delete_elem(md->ing_vsip_enforce_map_fd, &local);
 
-		if (err) {
-			TRN_LOG_ERROR("Delete Enforcement ingress map failed (err:%d).",
-					err);
-			return 1;
-		}
+	if (err) {
+		TRN_LOG_ERROR("Delete Enforcement ingress map failed (err:%d).",
+				err);
+		return 1;
 	}
+
 	return 0;
 }
 

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -223,12 +223,10 @@ int trn_delete_transit_network_policy_map(int fd,
 
 int trn_update_transit_network_policy_enforcement_map(struct user_metadata_t *md,
 						      struct vsip_enforce_t *local,
-						      __u8 *isenforce,
-						      int counter);
+						      __u8 *isenforce);
 
 int trn_delete_transit_network_policy_enforcement_map(struct user_metadata_t *md,
-						      struct vsip_enforce_t *local,
-						      int counter);
+						      struct vsip_enforce_t *local);
 
 int trn_update_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
 						        struct vsip_ppo_t *policy,

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -188,7 +188,6 @@ struct rpc_trn_vsip_enforce_t {
        string interface<20>;
        uint64_t tunid;
        uint32_t local_ip;
-       int count;
 };
 
 /* Defines a network policy protocol port table entry */


### PR DESCRIPTION
Enforcement map updates and deletes are different from other network policy related map updates and deletes. We decided to only use single update and delete for enforcement maps. 