### PR TITLE
Bug fix for protocol port map update and delete

### DIFF
--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -2816,7 +2816,7 @@ static void test_trn_cli_update_transit_network_policy_protocol_port_subcmd(void
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
-		.port = 6379,
+		.port = 60184,
 		.bit_val = 10
 	},
 	{
@@ -2824,7 +2824,7 @@ static void test_trn_cli_update_transit_network_policy_protocol_port_subcmd(void
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
-		.port = 6379,
+		.port = 60184,
 		.bit_val = 10
 	}};
 
@@ -2907,7 +2907,7 @@ static void test_trn_cli_update_agent_network_policy_protocol_port_subcmd(void *
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
-		.port = 6379,
+		.port = 60184,
 		.bit_val = 10
 	},
 	{
@@ -2915,7 +2915,7 @@ static void test_trn_cli_update_agent_network_policy_protocol_port_subcmd(void *
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
-		.port = 6379,
+		.port = 60184,
 		.bit_val = 10
 	}};
 
@@ -2994,14 +2994,14 @@ static void test_trn_cli_delete_transit_network_policy_protocol_port_subcmd(void
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
-		.port = 6379
+		.port = 60184
 	},
 	{
 		.interface = itf,
 		.tunid = 2,
 		.local_ip = 0x200000a,
 		.proto = 6,
-		.port = 6379
+		.port = 60184
 	}};
 
 	/* Test call delete_transit_network_policy_protocol_port successfully */
@@ -3079,14 +3079,14 @@ static void test_trn_cli_delete_agent_network_policy_protocol_port_subcmd(void *
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
-		.port = 6379
+		.port = 60184
 	},
 	{
 		.interface = itf,
 		.tunid = 2,
 		.local_ip = 0x200000a,
 		.proto = 6,
-		.port = 6379
+		.port = 60184
 	}};
 
 	/* Test call delete_agent_network_policy_protocol_port successfully */

--- a/src/cli/trn_cli.h
+++ b/src/cli/trn_cli.h
@@ -131,4 +131,5 @@ void dump_agent_md(struct rpc_trn_agent_metadata_t *agent_md);
 void dump_network_policy(struct rpc_trn_vsip_cidr_t *policy);
 void dump_enforced_policy(struct rpc_trn_vsip_enforce_t *enforce);
 void dump_protocol_port_policy(struct rpc_trn_vsip_ppo_t *ppo);
+void dump_protocol_port_policy_key(struct rpc_trn_vsip_ppo_key_t *ppo);
 uint32_t parse_ip_address(const cJSON *ipobj);

--- a/src/cli/trn_cli.h
+++ b/src/cli/trn_cli.h
@@ -131,5 +131,4 @@ void dump_agent_md(struct rpc_trn_agent_metadata_t *agent_md);
 void dump_network_policy(struct rpc_trn_vsip_cidr_t *policy);
 void dump_enforced_policy(struct rpc_trn_vsip_enforce_t *enforce);
 void dump_protocol_port_policy(struct rpc_trn_vsip_ppo_t *ppo);
-void dump_protocol_port_policy_key(struct rpc_trn_vsip_ppo_key_t *ppo);
 uint32_t parse_ip_address(const cJSON *ipobj);

--- a/src/cli/trn_cli_network_policy.c
+++ b/src/cli/trn_cli_network_policy.c
@@ -510,21 +510,18 @@ int trn_cli_update_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int
 	}
 
 	int *rc;
-
 	int counter = cJSON_GetArraySize(json_str); 
 	if (counter <= 0) {
 		print_err("Input policy size is less than or equal to zero. Please check your input. \n");
 		return -EINVAL;
 	}
 
-	struct rpc_trn_vsip_ppo_t ppos[counter];
 	char rpc[] = "update_transit_network_policy_protocol_port_1";
 
 	for (int i = 0; i < counter; i++)
 	{
 		struct rpc_trn_vsip_ppo_t ppo;
 		ppo.interface = conf.intf;
-		ppo.count = counter;
 		cJSON *policy = cJSON_GetArrayItem(json_str, i);
 
 		int err = trn_cli_parse_network_policy_protocol_port(policy, &ppo);
@@ -532,32 +529,22 @@ int trn_cli_update_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int
 			print_err("Error: parsing network policy protocol port config.\n");
 			return -EINVAL;
 		}
-		ppos[i] = ppo;
+
+		rc = update_transit_network_policy_protocol_port_1(&ppo, clnt);
+		if (rc == (int *)NULL) {
+			print_err("RPC Error: client call failed: update_transit_network_policy_protocol_port_1 \n");
+			return -EINVAL;
+		}
+
+		if (*rc != 0) {
+			print_err(
+				"Error: %s fatal daemon error, see transitd logs for details.\n",
+				rpc);
+			return -EINVAL;
+		}
+		dump_protocol_port_policy(&ppo);
 	}
 	cJSON_Delete(json_str);
-
-	rc = update_transit_network_policy_protocol_port_1(ppos, clnt);
-	if (rc == (int *)NULL) {
-		print_err("RPC Error: client call failed: update_transit_network_policy_protocol_port_1 \n");
-		return -EINVAL;
-	}
-
-	if (*rc != 0) {
-		print_err(
-			"Error: %s fatal daemon error, see transitd logs for details.\n",
-			rpc);
-		return -EINVAL;
-	}
-
-	for (int k = 0; k < counter; k++)
-	{
-		if (&ppos[k] == NULL){
-			print_err("update_transit_network_policy_protocol_port_1 Expected %d elements to be updated into network policy map, but only has %d elements. \n",
-					counter, k-1);
-			return -EINVAL; 
-		}
-		dump_protocol_port_policy(&ppos[k]);
-	}
 	print_msg("update_transit_network_policy_protocol_port_1 successfully updated network policy \n");
 
 	return 0;
@@ -581,21 +568,18 @@ int trn_cli_update_agent_network_policy_protocol_port_subcmd(CLIENT *clnt, int a
 	}
 
 	int *rc;
-
 	int counter = cJSON_GetArraySize(json_str); 
 	if (counter <= 0) {
 		print_err("Input policy size is less than or equal to zero. Please check your input. \n");
 		return -EINVAL;
 	}
 
-	struct rpc_trn_vsip_ppo_t ppos[counter];
 	char rpc[] = "update_agent_network_policy_protocol_port_1";
 
 	for (int i = 0; i < counter; i++)
 	{
 		struct rpc_trn_vsip_ppo_t ppo;
 		ppo.interface = conf.intf;
-		ppo.count = counter;
 		cJSON *policy = cJSON_GetArrayItem(json_str, i);
 
 		int err = trn_cli_parse_network_policy_protocol_port(policy, &ppo);
@@ -603,32 +587,22 @@ int trn_cli_update_agent_network_policy_protocol_port_subcmd(CLIENT *clnt, int a
 			print_err("Error: parsing network policy protocol port config.\n");
 			return -EINVAL;
 		}
-		ppos[i] = ppo;
+
+		rc = update_agent_network_policy_protocol_port_1(&ppo, clnt);
+		if (rc == (int *)NULL) {
+			print_err("RPC Error: client call failed: update_agent_network_policy_protocol_port_1 \n");
+			return -EINVAL;
+		}
+
+		if (*rc != 0) {
+			print_err(
+				"Error: %s fatal daemon error, see transitd logs for details.\n",
+				rpc);
+			return -EINVAL;
+		}
+		dump_protocol_port_policy(&ppo);
 	}
 	cJSON_Delete(json_str);
-
-	rc = update_agent_network_policy_protocol_port_1(ppos, clnt);
-	if (rc == (int *)NULL) {
-		print_err("RPC Error: client call failed: update_agent_network_policy_protocol_port_1 \n");
-		return -EINVAL;
-	}
-
-	if (*rc != 0) {
-		print_err(
-			"Error: %s fatal daemon error, see transitd logs for details.\n",
-			rpc);
-		return -EINVAL;
-	}
-
-	for (int k = 0; k < counter; k++)
-	{
-		if (&ppos[k] == NULL){
-			print_err("update_agent_network_policy_protocol_port_1 Expected %d elements to be updated into network policy map, but only has %d elements. \n",
-					counter, k-1);
-			return -EINVAL; 
-		}
-		dump_protocol_port_policy(&ppos[k]);
-	}
 	print_msg("update_agent_network_policy_protocol_port_1 successfully updated network policy \n");
 
 	return 0;
@@ -652,54 +626,37 @@ int trn_cli_delete_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int
 	}
 
 	int *rc;
-
 	int counter = cJSON_GetArraySize(json_str); 
 	if (counter <= 0) {
 		print_err("Input policy size is less than or equal to zero. Please check your input. \n");
 		return -EINVAL;
 	}
-
-	struct rpc_trn_vsip_ppo_key_t ppo_keys[counter];
 	char rpc[] = "delete_transit_network_policy_protocol_port_1";
 
 	for (int i = 0; i < counter; i++)
 	{
 		struct rpc_trn_vsip_ppo_key_t ppo_key;
 		ppo_key.interface = conf.intf;
-		ppo_key.count = counter;
 		cJSON *policy = cJSON_GetArrayItem(json_str, i);
 		int err = trn_cli_parse_network_policy_protocol_port_key(policy, &ppo_key);
 		if (err != 0) {
 			print_err("Error: parsing network policy protocol port config.\n");
 			return -EINVAL;
 		}
-		ppo_keys[i] = ppo_key;
+		rc = delete_transit_network_policy_protocol_port_1(&ppo_key, clnt);
+		if (rc == (int *)NULL) {
+			print_err("RPC Error: client call failed: delete_transit_network_policy_protocol_port_1 \n");
+			return -EINVAL;
+		}
+
+		if (*rc != 0) {
+			print_err(
+				"Error: %s fatal daemon error, see transitd logs for details.\n",
+				rpc);
+			return -EINVAL;
+		}
 	}
 	cJSON_Delete(json_str);
-
-	for (int k = 0; k < counter; k++)
-	{
-		if (&ppo_keys[k] == NULL){
-			print_err("delete_transit_network_policy_protocol_port_1 Expected %d elements to be updated into network policy map, but only has %d elements. \n",
-					counter, k-1);
-			return -EINVAL; 
-		}
-		dump_protocol_port_policy_key(&ppo_keys[k]);
-	}
-
-	rc = delete_transit_network_policy_protocol_port_1(ppo_keys, clnt);
-	if (rc == (int *)NULL) {
-		print_err("RPC Error: client call failed: delete_transit_network_policy_protocol_port_1 \n");
-		return -EINVAL;
-	}
-
-	if (*rc != 0) {
-		print_err(
-			"Error: %s fatal daemon error, see transitd logs for details.\n",
-			rpc);
-		return -EINVAL;
-	}
-
 	print_msg("delete_transit_network_policy_protocol_port_1 successfully deleted network policy \n");
 
 	return 0;
@@ -723,53 +680,39 @@ int trn_cli_delete_agent_network_policy_protocol_port_subcmd(CLIENT *clnt, int a
 	}
 
 	int *rc;
-
 	int counter = cJSON_GetArraySize(json_str); 
 	if (counter <= 0) {
 		print_err("Input policy size is less than or equal to zero. Please check your input. \n");
 		return -EINVAL;
 	}
 
-	struct rpc_trn_vsip_ppo_key_t ppo_keys[counter];
 	char rpc[] = "delete_agent_network_policy_protocol_port_1";
 
 	for (int i = 0; i < counter; i++)
 	{
 		struct rpc_trn_vsip_ppo_key_t ppo_key;
 		ppo_key.interface = conf.intf;
-		ppo_key.count = counter;
 		cJSON *policy = cJSON_GetArrayItem(json_str, i);
 		int err = trn_cli_parse_network_policy_protocol_port_key(policy, &ppo_key);
 		if (err != 0) {
 			print_err("Error: parsing network policy protocol port config.\n");
 			return -EINVAL;
 		}
-		ppo_keys[i] = ppo_key;
+
+		rc = delete_agent_network_policy_protocol_port_1(&ppo_key, clnt);
+		if (rc == (int *)NULL) {
+			print_err("RPC Error: client call failed: delete_agent_network_policy_protocol_port_1 \n");
+			return -EINVAL;
+		}
+
+		if (*rc != 0) {
+			print_err(
+				"Error: %s fatal daemon error, see transitd logs for details.\n",
+				rpc);
+			return -EINVAL;
+		}
 	}
 	cJSON_Delete(json_str);
-
-	for (int k = 0; k < counter; k++)
-	{
-		if (&ppo_keys[k] == NULL){
-			print_err("delete_transit_network_policy_protocol_port_1 Expected %d elements to be updated into network policy map, but only has %d elements. \n",
-					counter, k-1);
-			return -EINVAL; 
-		}
-		dump_protocol_port_policy_key(&ppo_keys[k]);
-	}
-
-	rc = delete_agent_network_policy_protocol_port_1(ppo_keys, clnt);
-	if (rc == (int *)NULL) {
-		print_err("RPC Error: client call failed: delete_agent_network_policy_protocol_port_1 \n");
-		return -EINVAL;
-	}
-
-	if (*rc != 0) {
-		print_err(
-			"Error: %s fatal daemon error, see transitd logs for details.\n",
-			rpc);
-		return -EINVAL;
-	}
 
 	print_msg("delete_agent_network_policy_protocol_port_1 successfully deleted network policy \n");
 
@@ -803,14 +746,4 @@ void dump_protocol_port_policy(struct rpc_trn_vsip_ppo_t *ppo)
 	print_msg("Protocol: %d\n", ppo->proto);
 	print_msg("Port: %x\n", ppo->port);
 	print_msg("bit value: %ld\n", ppo->bit_val);
-}
-
-void dump_protocol_port_policy_key(struct rpc_trn_vsip_ppo_key_t *ppo)
-{
-	print_msg("Interface: %s\n", ppo->interface);
-	print_msg("Tunnel ID: %ld\n", ppo->tunid);
-	print_msg("Local IP: %x\n", ppo->local_ip);
-	print_msg("Protocol: %d\n", ppo->proto);
-	print_msg("Port: %x\n", ppo->port);
-	print_msg("Count: %d\n", ppo->count);
 }

--- a/src/cli/trn_cli_network_policy.c
+++ b/src/cli/trn_cli_network_policy.c
@@ -677,6 +677,16 @@ int trn_cli_delete_transit_network_policy_protocol_port_subcmd(CLIENT *clnt, int
 	}
 	cJSON_Delete(json_str);
 
+	for (int k = 0; k < counter; k++)
+	{
+		if (&ppo_keys[k] == NULL){
+			print_err("delete_transit_network_policy_protocol_port_1 Expected %d elements to be updated into network policy map, but only has %d elements. \n",
+					counter, k-1);
+			return -EINVAL; 
+		}
+		dump_protocol_port_policy_key(&ppo_keys[k]);
+	}
+
 	rc = delete_transit_network_policy_protocol_port_1(ppo_keys, clnt);
 	if (rc == (int *)NULL) {
 		print_err("RPC Error: client call failed: delete_transit_network_policy_protocol_port_1 \n");
@@ -738,6 +748,16 @@ int trn_cli_delete_agent_network_policy_protocol_port_subcmd(CLIENT *clnt, int a
 	}
 	cJSON_Delete(json_str);
 
+	for (int k = 0; k < counter; k++)
+	{
+		if (&ppo_keys[k] == NULL){
+			print_err("delete_transit_network_policy_protocol_port_1 Expected %d elements to be updated into network policy map, but only has %d elements. \n",
+					counter, k-1);
+			return -EINVAL; 
+		}
+		dump_protocol_port_policy_key(&ppo_keys[k]);
+	}
+
 	rc = delete_agent_network_policy_protocol_port_1(ppo_keys, clnt);
 	if (rc == (int *)NULL) {
 		print_err("RPC Error: client call failed: delete_agent_network_policy_protocol_port_1 \n");
@@ -783,4 +803,14 @@ void dump_protocol_port_policy(struct rpc_trn_vsip_ppo_t *ppo)
 	print_msg("Protocol: %d\n", ppo->proto);
 	print_msg("Port: %x\n", ppo->port);
 	print_msg("bit value: %ld\n", ppo->bit_val);
+}
+
+void dump_protocol_port_policy_key(struct rpc_trn_vsip_ppo_key_t *ppo)
+{
+	print_msg("Interface: %s\n", ppo->interface);
+	print_msg("Tunnel ID: %ld\n", ppo->tunid);
+	print_msg("Local IP: %x\n", ppo->local_ip);
+	print_msg("Protocol: %d\n", ppo->proto);
+	print_msg("Port: %x\n", ppo->port);
+	print_msg("Count: %d\n", ppo->count);
 }

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -842,18 +842,16 @@ static void test_update_transit_network_policy_protocol_port_1_svc(void **state)
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
-		.port = 6379,
-		.bit_val = 10,
-		.count = 2
+		.port = 60184,
+		.bit_val = 10
 	},
 	{
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
-		.port = 6379,
-		.bit_val = 10,
-		.count = 2
+		.port = 60184,
+		.bit_val = 10
 	}};
 
 	int *rc;
@@ -872,18 +870,16 @@ static void test_update_agent_network_policy_protocol_port_1_svc(void **state)
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
-		.port = 6379,
-		.bit_val = 10,
-		.count = 2
+		.port = 60184,
+		.bit_val = 10
 	},
 	{
 		.interface = itf,
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
-		.port = 6379,
-		.bit_val = 10,
-		.count = 2
+		.port = 60184,
+		.bit_val = 10
 	}};
 
 	int *rc;
@@ -902,16 +898,14 @@ static void test_delete_transit_network_policy_protocol_port_1_svc(void **state)
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
-		.port = 6379,
-		.count = 2
+		.port = 60184
 	},
 	{
 		.interface = itf,
 		.tunid = 2,
 		.local_ip = 0x200000a,
 		.proto = 6,
-		.port = 6379,
-		.count = 2
+		.port = 60184
 	}};
 
 	int *rc;
@@ -946,16 +940,14 @@ static void test_delete_agent_network_policy_protocol_port_1_svc(void **state)
 		.tunid = 3,
 		.local_ip = 0x300000a,
 		.proto = 6,
-		.port = 6379,
-		.count = 2
+		.port = 60184
 	},
 	{
 		.interface = itf,
 		.tunid = 2,
 		.local_ip = 0x200000a,
 		.proto = 6,
-		.port = 6379,
-		.count = 2
+		.port = 60184
 	}};
 
 	int *rc;

--- a/src/dmn/trn_agent_xdp_usr.c
+++ b/src/dmn/trn_agent_xdp_usr.c
@@ -631,35 +631,27 @@ int trn_delete_agent_network_policy_enforcement_map(struct agent_user_metadata_t
 
 int trn_update_agent_network_policy_protocol_port_map(struct agent_user_metadata_t *md,
 						        struct vsip_ppo_t *policy,
-						        __u64 *bitmap,
-							int counter)
+						        __u64 bitmap)
 {
-	for (int i = 0; i < counter; i++)
-	{
-		int err = bpf_map_update_elem(md->eg_vsip_ppo_map_fd, &policy[i], &bitmap[i], 0);
+	int err = bpf_map_update_elem(md->eg_vsip_ppo_map_fd, policy, &bitmap, 0);
 
-		if (err) {
-			TRN_LOG_ERROR("Update Protocol-Port egress map failed (err:%d) for ip address 0x%x with protocol %d and port %d. \n",
-					err, policy[i].local_ip, policy[i].proto, policy[i].port);
-			return 1;
-		}
+	if (err) {
+		TRN_LOG_ERROR("Update Protocol-Port egress map failed (err:%d) for ip address 0x%x with protocol %d and port %d. \n",
+				err, policy->local_ip, policy->proto, policy->port);
+		return 1;
 	}
+
 	return 0;
 }
 
 int trn_delete_agent_network_policy_protocol_port_map(struct agent_user_metadata_t *md,
-						        struct vsip_ppo_t *policy,
-							int counter)
+						        struct vsip_ppo_t *policy)
 {
-	for (int i = 0; i < counter; i++)
-	{
-		int err = bpf_map_delete_elem(md->eg_vsip_ppo_map_fd, &policy[i]);
-
-		if (err) {
-			TRN_LOG_ERROR("Delete Protocol-Port egress map failed (err:%d).for ip address 0x%x with protocol %d and port %d. \n",
-					err, policy[i].local_ip, policy[i].proto, policy[i].port);
-			return 1;
-		}
+	int err = bpf_map_delete_elem(md->eg_vsip_ppo_map_fd, policy);
+	if (err) {
+		TRN_LOG_ERROR("Delete Protocol-Port egress map failed (err:%d).for ip address 0x%x with protocol %d and port %d. \n",
+				err, policy->local_ip, policy->proto, policy->port);
+		return 1;
 	}
 	return 0;
 }

--- a/src/dmn/trn_agent_xdp_usr.h
+++ b/src/dmn/trn_agent_xdp_usr.h
@@ -157,9 +157,7 @@ int trn_delete_agent_network_policy_enforcement_map(struct agent_user_metadata_t
 
 int trn_update_agent_network_policy_protocol_port_map(struct agent_user_metadata_t *md,
 						        struct vsip_ppo_t *policy,
-						        __u64 *bitmap,
-							int counter);
+						        __u64 bitmap);
 
 int trn_delete_agent_network_policy_protocol_port_map(struct agent_user_metadata_t *md,
-						        struct vsip_ppo_t *policy,
-							int counter);
+						        struct vsip_ppo_t *policy);

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1292,15 +1292,14 @@ int *update_transit_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc
 
 	for (int i = 0; i < counter; i++)
 	{
-		cidr[i].tunnel_id = policy->tunid;
+		cidr[i].tunnel_id = policy[i].tunid;
 		// cidr-related maps have tunnel-id(64 bits),
 		// local-ip(32 bits) prior to destination cidr;
 		// hence the final prefix length is 64+32+{cidr prefix}
-		cidr[i].prefixlen = policy->cidr_prefixlen + 96;
-		cidr[i].local_ip = policy->local_ip;
-		cidr[i].remote_ip = policy->cidr_ip;
-		bitmap[i] = policy->bit_val;
-		policy++;
+		cidr[i].prefixlen = policy[i].cidr_prefixlen + 96;
+		cidr[i].local_ip = policy[i].local_ip;
+		cidr[i].remote_ip = policy[i].cidr_ip;
+		bitmap[i] = policy[i].bit_val;
 	}
 
 	if (type == PRIMARY) {
@@ -1433,6 +1432,8 @@ int *delete_transit_network_policy_1_svc(rpc_trn_vsip_cidr_key_t *policy_key, st
 		cidr[i].prefixlen = policy_key[i].cidr_prefixlen + 96;
 		cidr[i].local_ip = policy_key[i].local_ip;
 		cidr[i].remote_ip = policy_key[i].cidr_ip;
+		TRN_LOG_INFO("policy %d: tunnel_id  %ld; local ip  0x%x; cidr ip  0x%x; count  %d\n", 
+				i, policy_key[i].tunid, policy_key[i].local_ip, policy_key[i].cidr_ip, policy_key[i].count);
 	}
 
 	if (type == PRIMARY) {
@@ -1497,6 +1498,8 @@ int *delete_agent_network_policy_1_svc(rpc_trn_vsip_cidr_key_t *policy_key, stru
 		cidr[i].prefixlen = policy_key[i].cidr_prefixlen + 96;
 		cidr[i].local_ip = policy_key[i].local_ip;
 		cidr[i].remote_ip = policy_key[i].cidr_ip;
+		TRN_LOG_INFO("policy %d: tunnel_id  %ld; local ip  0x%x; cidr ip  0x%x; count  %d\n", 
+				i, policy_key[i].tunid, policy_key[i].local_ip, policy_key[i].cidr_ip, policy_key[i].count);
 	}
 
 	if (type == PRIMARY) {
@@ -1705,12 +1708,14 @@ int *update_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_t *ppo, 
 		policies[i].proto = ppo[i].proto;
 		policies[i].port = ppo[i].port;
 		bitmap[i] = ppo[i].bit_val;
+		TRN_LOG_INFO("ppo %d: tunnel_id  %ld; local ip  0x%x; protocol  %d; port  %d; count  %d\n", 
+				i, ppo[i].tunid, ppo[i].local_ip, ppo[i].proto, ppo[i].port, ppo[i].count);
 	}
 
 	rc = trn_update_transit_network_policy_protocol_port_map(md, policies, bitmap, counter);
 
 	if (rc != 0) {
-		TRN_LOG_ERROR("Failure updating transit network policy enforcement map\n");
+		TRN_LOG_ERROR("Failure updating transit network policy protocol port map\n");
 		result = RPC_TRN_FATAL;
 		goto error;
 	}
@@ -1753,12 +1758,14 @@ int *update_agent_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_t *ppo, st
 		policies[i].proto = ppo[i].proto;
 		policies[i].port = ppo[i].port;
 		bitmap[i] = ppo[i].bit_val;
+		TRN_LOG_INFO("ppo %d: tunnel_id  %ld; local ip  0x%x; protocol  %d; port  %d; count  %d\n", 
+				i, ppo[i].tunid, ppo[i].local_ip, ppo[i].proto, ppo[i].port, ppo[i].count);
 	}
 
 	rc = trn_update_agent_network_policy_protocol_port_map(md, policies, bitmap, counter);
 
 	if (rc != 0) {
-		TRN_LOG_ERROR("Failure updating agent network policy enforcement map\n");
+		TRN_LOG_ERROR("Failure updating agent network policy protocol port map\n");
 		result = RPC_TRN_FATAL;
 		goto error;
 	}
@@ -1777,9 +1784,8 @@ int *delete_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_key_t *p
 	int rc;
 	char *itf = ppo_key->interface;
 	int counter = ppo_key->count;
-
+	
 	TRN_LOG_INFO("delete_transit_network_policy_protocol_port_1 service");
-
 	if (counter == 0){
 		TRN_LOG_INFO("policy list has length of 0. Nothing to do");
 		result = 0;
@@ -1794,17 +1800,20 @@ int *delete_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_key_t *p
 		goto error;
 	}
 
-	for (int i = 0; i < counter; i++){
+	for (int i = 0; i < counter; i++)
+	{
 		policies[i].tunnel_id = ppo_key[i].tunid;
 		policies[i].local_ip = ppo_key[i].local_ip;
 		policies[i].proto = ppo_key[i].proto;
 		policies[i].port = ppo_key[i].port;
+		TRN_LOG_INFO("ppo %d: tunnel_id  %ld; local ip  0x%x; protocol  %d; port  %d; count  %d\n", 
+				i, ppo_key[i].tunid, ppo_key[i].local_ip, ppo_key[i].proto, ppo_key[i].port, ppo_key[i].count);
 	}
 
 	rc = trn_delete_transit_network_policy_protocol_port_map(md, policies, counter);
 
 	if (rc != 0) {
-		TRN_LOG_ERROR("Failure updating transit network policy enforcement map \n");
+		TRN_LOG_ERROR("Failure deleting transit network policy protocol port map\n");
 		result = RPC_TRN_FATAL;
 		goto error;
 	}
@@ -1845,12 +1854,14 @@ int *delete_agent_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_key_t *ppo
 		policies[i].local_ip = ppo_key[i].local_ip;
 		policies[i].proto = ppo_key[i].proto;
 		policies[i].port = ppo_key[i].port;
+		TRN_LOG_INFO("ppo %d: tunnel_id  %ld; local ip  0x%x; protocol  %d; port  %d; count  %d\n", 
+				i, ppo_key[i].tunid, ppo_key[i].local_ip, ppo_key[i].proto, ppo_key[i].port, ppo_key[i].count);
 	}
 
 	rc = trn_delete_agent_network_policy_protocol_port_map(md, policies, counter);
 
 	if (rc != 0) {
-		TRN_LOG_ERROR("Failure updating agent network policy enforcement map \n");
+		TRN_LOG_ERROR("Failure updating agent network policy protocol port map \n");
 		result = RPC_TRN_FATAL;
 		goto error;
 	}

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -701,35 +701,27 @@ int trn_delete_transit_network_policy_enforcement_map(struct user_metadata_t *md
 
 int trn_update_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
 						        struct vsip_ppo_t *policy,
-						        __u64 *bitmap,
-							int counter)
+						        __u64 bitmap)
 {
-	for (int i = 0; i < counter; i++)
-	{
-		int err = bpf_map_update_elem(md->ing_vsip_ppo_map_fd, &policy[i], &bitmap[i], 0);
-
-		if (err) {
-			TRN_LOG_ERROR("Update Protocol-Port ingress map failed (err:%d) for ip address 0x%x with protocol %d and port %d. \n",
-					err, policy[i].local_ip, policy[i].proto, policy[i].port);
-			return 1;
-		}
+	int err = bpf_map_update_elem(md->ing_vsip_ppo_map_fd, policy, &bitmap, 0);
+	if (err) {
+		TRN_LOG_ERROR("Update Protocol-Port ingress map failed (err:%d) for ip address 0x%x with protocol %d and port %d. \n",
+				err, policy->local_ip, policy->proto, policy->port);
+		return 1;
 	}
 	return 0;
 }
 
 int trn_delete_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
-						        struct vsip_ppo_t *policy,
-							int counter)
+						        struct vsip_ppo_t *policy)
 {
-	for (int i = 0; i < counter; i++)
-	{
-		int err = bpf_map_delete_elem(md->ing_vsip_ppo_map_fd, &policy[i]);
+	int err = bpf_map_delete_elem(md->ing_vsip_ppo_map_fd, policy);
 
-		if (err) {
-			TRN_LOG_ERROR("Delete Protocol-Port ingress map failed (err:%d).for ip address 0x%x with protocol %d and port %d. \n",
-					err, policy[i].local_ip, policy[i].proto, policy[i].port);
-			return 1;
-		}
+	if (err) {
+		TRN_LOG_ERROR("Delete Protocol-Port ingress map failed (err:%d).for ip address 0x%x with protocol %d and port %d. \n",
+				err, policy->local_ip, policy->proto, policy->port);
+		return 1;
 	}
+
 	return 0;
 }

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -230,9 +230,7 @@ int trn_delete_transit_network_policy_enforcement_map(struct user_metadata_t *md
 
 int trn_update_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
 						        struct vsip_ppo_t *policy,
-						        __u64 *bitmap,
-							int counter);
+						        __u64 bitmap);
 
 int trn_delete_transit_network_policy_protocol_port_map(struct user_metadata_t *md,
-						        struct vsip_ppo_t *policy,
-							int counter);
+						        struct vsip_ppo_t *policy);

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -198,7 +198,6 @@ struct rpc_trn_vsip_ppo_t {
        uint8_t proto;
        uint16_t port;
        uint64_t bit_val;
-       int count;
 };
 
 /* Defines a network policy protocol port table key */
@@ -208,7 +207,6 @@ struct rpc_trn_vsip_ppo_key_t {
        uint32_t local_ip;
        uint8_t proto;
        uint16_t port;
-       int count;
 };
 
 /*----- Protocol. -----*/


### PR DESCRIPTION
This resolves issue #396 
The issue is with RPC:
int UPDATE_TRANSIT_NETWORK_POLICY_PROTOCOL_PORT(rpc_trn_vsip_ppo_t) = 27;
int DELETE_TRANSIT_NETWORK_POLICY_PROTOCOL_PORT(rpc_trn_vsip_ppo_key_t) = 28;
int UPDATE_AGENT_NETWORK_POLICY_PROTOCOL_PORT(rpc_trn_vsip_ppo_t) = 33;
int DELETE_AGENT_NETWORK_POLICY_PROTOCOL_PORT(rpc_trn_vsip_ppo_key_t) = 34;

The size of the param rpc_trn_vsip_ppo_key_t and rpc_trn_vsip_ppo_t is fixed. Thus, only the first item of the array was passed to daemon.

Because RPC has above restriction, I can only pass one param rpc_trn_vsip_ppo_key_t or rpc_trn_vsip_ppo_t item at once to the RPC call. Thus, this PR is to switch to single update at the RPC level