### PR TITLE
Fix Bugs: Code error to check whether the policy data has changed or not

### DIFF
--- a/mizar/networkpolicy/networkpolicy_util.py
+++ b/mizar/networkpolicy/networkpolicy_util.py
@@ -146,7 +146,7 @@ class NetworkPolicyUtil:
         
         old_data_for_networkpolicy = ep.get_data_for_networkpolicy()
         if len(old_data_for_networkpolicy) > 0:
-            if len(old_data_for_networkpolicy["old"]) > 0 and old_data_for_networkpolicy["old"]["ingress"] == data_for_networkpolicy_ingress and old_data_for_networkpolicy["old"]["egress"] == data_for_networkpolicy_egress:
+            if old_data_for_networkpolicy["ingress"] == data_for_networkpolicy_ingress and old_data_for_networkpolicy["egress"] == data_for_networkpolicy_egress:
                 return
 
             old_data_for_networkpolicy["old"] = {}


### PR DESCRIPTION
The logic is to compare with old data whether ingress data and egress data has changed or not. But instead of checking old_data.ingress == data.ingress, it wrongly checks old_data.old.ingress == data.ingress. 