### PR TITLE
For NetworkPolicy, fix pod creating issue

### DIFF
--- a/mizar/common/common.py
+++ b/mizar/common/common.py
@@ -323,6 +323,17 @@ def build_label_filter(label_dict):
         str_list.pop()
     return "".join(str_list)
 
+def kube_get_pod(core_api, name):
+    try:
+        response = core_api.list_pod_for_all_namespaces(
+            watch=False,
+            field_selector="metadata.name={}".format(name)
+        )
+        if response is not None and len(response.items) > 0:
+            return response.items[0]
+    except:
+        return None
+
 def get_spec_val(key, spec, default=""):
     return default if key not in spec else spec[key]
 

--- a/mizar/dp/mizar/workflows/builtins/pods/create.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/create.py
@@ -47,8 +47,6 @@ class k8sPodCreate(WorkflowTask):
     def run(self):
         logger.info("Run {task}".format(task=self.__class__.__name__))
 
-        networkpolicy_util.handle_pod_change_for_networkpolicy(self.param.diff)
-
         if "hostIP" not in self.param.body['status']:
             self.raise_temporary_error("Pod spec not ready.")
         spec = {
@@ -111,5 +109,7 @@ class k8sPodCreate(WorkflowTask):
                 "Endpoint {} already exists!".format(spec["name"]))
         # Create the corresponding simple endpoint objects
         endpoint_opr.create_simple_endpoints(interfaces, spec)
+
+        networkpolicy_util.handle_pod_change_for_networkpolicy(self.param.diff)
 
         self.finalize()

--- a/mizar/obj/endpoint.py
+++ b/mizar/obj/endpoint.py
@@ -337,7 +337,7 @@ class Endpoint:
             return
         self.ingress_networkpolicies.append(policy_name)
         self.ingress_networkpolicies.sort()
-        if len(self.ingress_networkpolicies) == 1:
+        if len(self.ingress_networkpolicies) == 1 and self.ip != "":
             self.update_network_policy_enforcement_map_ingress()
         self.store_update_obj()
 
@@ -346,7 +346,7 @@ class Endpoint:
             return
         self.egress_networkpolicies.append(policy_name)
         self.egress_networkpolicies.sort()
-        if len(self.egress_networkpolicies) == 1:
+        if len(self.egress_networkpolicies) == 1 and self.ip != "":
             self.update_network_policy_enforcement_map_egress()
         self.store_update_obj()
 

--- a/mizar/obj/networkpolicy.py
+++ b/mizar/obj/networkpolicy.py
@@ -27,7 +27,7 @@ logger = logging.getLogger()
 
 class NetworkPolicy:
     def __init__(self, name, namespace, obj_api, opr_store, spec=None):
-        self.name = name,
+        self.name = name
         self.namespace = namespace
         self.obj_api = obj_api
         self.store = opr_store


### PR DESCRIPTION
When a new pod created, it may bring impact to an existing policy by affecting its endpoints or affecting its rules.
The issue is because the original implementation didn't handle ip assignment for pod creating. When pod creating, it needs sometime to get ip assigned. Without ip, policy updating will be failed. The fix is to address the issue.

Manual test passed for the fix.