### PR TITLE
Fix cidr-trie issue and policy deleting issue

### DIFF
--- a/mizar/common/ipv4_trie.py
+++ b/mizar/common/ipv4_trie.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 The Authors.
+
+# Authors: Hong Chang   <@Hong-Chang>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:The above copyright
+# notice and this permission notice shall be included in all copies or
+# substantial portions of the Software.THE SOFTWARE IS PROVIDED "AS IS",
+# WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+# THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+class IPv4Trie:
+    def __init__(self):
+        self.head = IPv4Node()        
+
+    def insert(self, cidr):
+        bit_array = IPv4Util.get_bit_array_from_ipv4_cidr(cidr)
+
+        node = self.head
+        for bit in bit_array:
+            if bit not in node.children:
+                node.children[bit] = IPv4Node(bit)
+            node = node.children[bit]
+        node.is_end = True
+        node.cidr = IPv4Util.get_standard_cidr(cidr)
+
+    def find_all(self, cidr):
+        result = []
+        bit_array = IPv4Util.get_bit_array_from_ipv4_cidr(cidr)
+
+        node = self.head
+        if node.is_end:
+            result.append(node.cidr)
+        for bit in bit_array:
+            if bit not in node.children:
+                return result
+            node = node.children[bit]
+            if node.is_end:
+                result.append(node.cidr)
+        return result
+
+class IPv4Node:
+    def __init__(self, value = False):
+        self.children = {}
+        self.is_end = False
+        self.value = value
+        self.cidr = ""
+
+class IPv4Util:
+    @staticmethod
+    def get_bit_array_from_ipv4_cidr(cidr):
+        splitted = cidr.split("/")
+        if len(splitted) == 0 or len(splitted) > 2:
+            raise ValueError("{} is not a valid IPv4 or CIDR.".format(cidr))
+        ip = splitted[0]
+        length_str = "32" if len(splitted) == 1 else splitted[1]
+        if not length_str.isdigit():
+            raise ValueError("{} is not a valid IPv4 or CIDR.".format(cidr))
+        length = int(length_str)
+
+        splitted = ip.split(".")
+        if len(splitted) != 4:
+            raise ValueError("{} is not a valid IPv4 or CIDR.".format(cidr))
+
+        for segment in splitted:
+            if not segment.isdigit():
+                raise ValueError("{} is not a valid IPv4 or CIDR.".format(cidr))
+            value = int(segment)
+            if value < 0 or value > 255:
+                raise ValueError("{} is not a valid IPv4 or CIDR.".format(cidr))
+
+        result = []
+        if length == 0:
+            return result
+        index = 0
+        for segment in splitted:
+            bits = IPv4Util.get_8_bit_list(cidr, segment)
+            for i in range(8):
+                result.append(bits[i])
+                index += 1
+                if index == length:
+                    return result
+        return result
+
+    @staticmethod
+    def get_8_bit_list(cidr, segment):
+        binary = "{0:b}".format(int(segment))        
+
+        result = []
+        for _ in range(8 - len(binary)):
+            result.append(False)
+        for i in range(len(binary)):
+            result.append(bool(int(binary[i])))
+
+        return result
+
+    # Standarlize cidr. For example, 0.1.2.3/0 => 0.0.0.0/0
+    @staticmethod
+    def get_standard_cidr(cidr):
+        bit_array = IPv4Util.get_bit_array_from_ipv4_cidr(cidr)
+        length = len(bit_array)
+        for _ in range(32 - length):
+            bit_array.append(False)
+
+        str_list = []
+        for i in range(4):
+            segment_chars = []
+            for j in range(8):
+                segment_chars.append(str(int(bit_array[i * 8 + j])))
+            str_list.append(str(int("".join(segment_chars), 2)))
+            if i < 3:
+                str_list.append(".")
+
+        str_list.append("/")
+        str_list.append(str(length))
+        return "".join(str_list)

--- a/mizar/common/ipv4_trie.py
+++ b/mizar/common/ipv4_trie.py
@@ -22,7 +22,7 @@ class IPv4Trie:
     def __init__(self):
         self.head = IPv4Node()        
 
-    def insert(self, cidr):
+    def insert(self, cidr, obj):
         bit_array = IPv4Util.get_bit_array_from_ipv4_cidr(cidr)
 
         node = self.head
@@ -32,6 +32,7 @@ class IPv4Trie:
             node = node.children[bit]
         node.is_end = True
         node.cidr = IPv4Util.get_standard_cidr(cidr)
+        node.obj = obj
 
     def find_all(self, cidr):
         result = []
@@ -39,13 +40,13 @@ class IPv4Trie:
 
         node = self.head
         if node.is_end:
-            result.append(node.cidr)
+            result.append((node.cidr, node.obj))
         for bit in bit_array:
             if bit not in node.children:
                 return result
             node = node.children[bit]
             if node.is_end:
-                result.append(node.cidr)
+                result.append((node.cidr, node.obj))
         return result
 
 class IPv4Node:
@@ -54,6 +55,7 @@ class IPv4Node:
         self.is_end = False
         self.value = value
         self.cidr = ""
+        self.obj = None
 
 class IPv4Util:
     @staticmethod

--- a/mizar/networkpolicy/networkpolicy_util.py
+++ b/mizar/networkpolicy/networkpolicy_util.py
@@ -20,7 +20,8 @@
 
 import logging
 import time
-from cidr_trie import PatriciaTrie
+import epdb
+from mizar.common.ipv4_trie import IPv4Trie
 from mizar.dp.mizar.operators.endpoints.endpoints_operator import *
 from mizar.dp.mizar.operators.networkpolicies.networkpolicies_operator import *
 
@@ -37,59 +38,80 @@ class NetworkPolicyUtil:
         endpoint_name_list = self.retrieve_endpoints_for_networkpolicy(policy_name, policy_namespace, pod_label_dict)
         endpoint_names_to_be_handled = set()
 
-        if "Ingress" in policy_types:
-            if policy_name not in networkpolicy_opr.store.networkpolicy_endpoints_ingress_store:
-                networkpolicy_opr.store.networkpolicy_endpoints_ingress_store[policy_name] = set()
-
-            # Find newly added endpoint and add it into store.networkpolicy_endpoints_ingress_store
-            for endpoint_name in endpoint_name_list:
-                endpoint_names_to_be_handled.add(endpoint_name) 
-                if endpoint_name not in networkpolicy_opr.store.networkpolicy_endpoints_ingress_store[policy_name]:                
-                    networkpolicy_opr.store.add_networkpolicy_endpoint_ingress(policy_name, endpoint_name)                       
-
-            # Find deleted endpoint and remove it from store.networkpolicy_endpoints_ingress_store
-            endpoint_names_to_be_removed_ingress = set()
-            for endpoint_name in networkpolicy_opr.store.networkpolicy_endpoints_ingress_store[policy_name]:
-                if endpoint_name not in endpoint_name_list:
+        if policy_types is None:
+            #epdb.serve(port=8888)
+            if policy_name in networkpolicy_opr.store.networkpolicy_endpoints_ingress_store:
+                for endpoint_name in networkpolicy_opr.store.networkpolicy_endpoints_ingress_store[policy_name]:                    
+                    ep = networkpolicy_opr.store.get_ep(endpoint_name)
+                    if ep is None:
+                        logger.warn("In operator store, found endpoint {} in networkpolicy_endpoints_ingress_store but cannot retrieve it from eps_store.".format(endpoint_name))
+                    else:
+                        ep.remove_ingress_networkpolicy(policy_name)
                     endpoint_names_to_be_handled.add(endpoint_name)
-                    endpoint_names_to_be_removed_ingress.add(endpoint_name)
-            for endpoint_name in endpoint_names_to_be_removed_ingress:            
-                networkpolicy_opr.store.networkpolicy_endpoints_ingress_store[policy_name].remove(endpoint_name)
-                ep = networkpolicy_opr.store.get_ep(endpoint_name)
-                if ep is None:
-                    logger.warn("In operator store, found endpoint {} in networkpolicy_endpoints_ingress_store but cannot retrieve it from eps_store.".format(endpoint_name))
-                else:
-                    ep.remove_ingress_networkpolicy(policy_name)
-            if len(networkpolicy_opr.store.networkpolicy_endpoints_ingress_store[policy_name]) == 0:
                 networkpolicy_opr.store.networkpolicy_endpoints_ingress_store.pop(policy_name)
-
-        if "Egress" in policy_types:
-            if policy_name not in networkpolicy_opr.store.networkpolicy_endpoints_egress_store:
-                networkpolicy_opr.store.networkpolicy_endpoints_egress_store[policy_name] = set()
-
-            # Find newly added endpoint and add it into store.networkpolicy_endpoints_egress_store
-            for endpoint_name in endpoint_name_list:
-                endpoint_names_to_be_handled.add(endpoint_name) 
-                if endpoint_name not in networkpolicy_opr.store.networkpolicy_endpoints_egress_store[policy_name]:                
-                    networkpolicy_opr.store.add_networkpolicy_endpoint_egress(policy_name, endpoint_name)                       
-
-            # Find deleted endpoint and remove it from store.networkpolicy_endpoints_egress_store
-            endpoint_names_to_be_removed_egress = set()
-            for endpoint_name in networkpolicy_opr.store.networkpolicy_endpoints_egress_store[policy_name]:
-                if endpoint_name not in endpoint_name_list:
+            if policy_name in networkpolicy_opr.store.networkpolicy_endpoints_egress_store:
+                for endpoint_name in networkpolicy_opr.store.networkpolicy_endpoints_egress_store[policy_name]:
+                    ep = networkpolicy_opr.store.get_ep(endpoint_name)
+                    if ep is None:
+                        logger.warn("In operator store, found endpoint {} in networkpolicy_endpoints_egress_store but cannot retrieve it from eps_store.".format(endpoint_name))
+                    else:
+                        ep.remove_egress_networkpolicy(policy_name)
                     endpoint_names_to_be_handled.add(endpoint_name)
-                    endpoint_names_to_be_removed_egress.add(endpoint_name)
-            for endpoint_name in endpoint_names_to_be_removed_egress:            
-                networkpolicy_opr.store.networkpolicy_endpoints_egress_store[policy_name].remove(endpoint_name)
-                ep = networkpolicy_opr.store.get_ep(endpoint_name)
-                if ep is None:
-                    logger.warn("In operator store, found endpoint {} in networkpolicy_endpoints_egress_store but cannot retrieve it from eps_store.".format(endpoint_name))
-                else:
-                    ep.remove_egress_networkpolicy(policy_name)
-            if len(networkpolicy_opr.store.networkpolicy_endpoints_egress_store[policy_name]) == 0:
                 networkpolicy_opr.store.networkpolicy_endpoints_egress_store.pop(policy_name)
+        else:
+            if "Ingress" in policy_types:
+                if policy_name not in networkpolicy_opr.store.networkpolicy_endpoints_ingress_store:
+                    networkpolicy_opr.store.networkpolicy_endpoints_ingress_store[policy_name] = set()
 
-        self.add_networkpolicy_for_endpoint(policy_name, policy_types)
+                # Find newly added endpoint and add it into store.networkpolicy_endpoints_ingress_store
+                for endpoint_name in endpoint_name_list:
+                    endpoint_names_to_be_handled.add(endpoint_name) 
+                    if endpoint_name not in networkpolicy_opr.store.networkpolicy_endpoints_ingress_store[policy_name]:                
+                        networkpolicy_opr.store.add_networkpolicy_endpoint_ingress(policy_name, endpoint_name)                       
+
+                # Find deleted endpoint and remove it from store.networkpolicy_endpoints_ingress_store
+                endpoint_names_to_be_removed_ingress = set()
+                for endpoint_name in networkpolicy_opr.store.networkpolicy_endpoints_ingress_store[policy_name]:
+                    if endpoint_name not in endpoint_name_list:
+                        endpoint_names_to_be_handled.add(endpoint_name)
+                        endpoint_names_to_be_removed_ingress.add(endpoint_name)
+                for endpoint_name in endpoint_names_to_be_removed_ingress:            
+                    networkpolicy_opr.store.networkpolicy_endpoints_ingress_store[policy_name].remove(endpoint_name)
+                    ep = networkpolicy_opr.store.get_ep(endpoint_name)
+                    if ep is None:
+                        logger.warn("In operator store, found endpoint {} in networkpolicy_endpoints_ingress_store but cannot retrieve it from eps_store.".format(endpoint_name))
+                    else:
+                        ep.remove_ingress_networkpolicy(policy_name)
+                if len(networkpolicy_opr.store.networkpolicy_endpoints_ingress_store[policy_name]) == 0:
+                    networkpolicy_opr.store.networkpolicy_endpoints_ingress_store.pop(policy_name)
+
+            if "Egress" in policy_types:
+                if policy_name not in networkpolicy_opr.store.networkpolicy_endpoints_egress_store:
+                    networkpolicy_opr.store.networkpolicy_endpoints_egress_store[policy_name] = set()
+
+                # Find newly added endpoint and add it into store.networkpolicy_endpoints_egress_store
+                for endpoint_name in endpoint_name_list:
+                    endpoint_names_to_be_handled.add(endpoint_name) 
+                    if endpoint_name not in networkpolicy_opr.store.networkpolicy_endpoints_egress_store[policy_name]:                
+                        networkpolicy_opr.store.add_networkpolicy_endpoint_egress(policy_name, endpoint_name)                       
+
+                # Find deleted endpoint and remove it from store.networkpolicy_endpoints_egress_store
+                endpoint_names_to_be_removed_egress = set()
+                for endpoint_name in networkpolicy_opr.store.networkpolicy_endpoints_egress_store[policy_name]:
+                    if endpoint_name not in endpoint_name_list:
+                        endpoint_names_to_be_handled.add(endpoint_name)
+                        endpoint_names_to_be_removed_egress.add(endpoint_name)
+                for endpoint_name in endpoint_names_to_be_removed_egress:            
+                    networkpolicy_opr.store.networkpolicy_endpoints_egress_store[policy_name].remove(endpoint_name)
+                    ep = networkpolicy_opr.store.get_ep(endpoint_name)
+                    if ep is None:
+                        logger.warn("In operator store, found endpoint {} in networkpolicy_endpoints_egress_store but cannot retrieve it from eps_store.".format(endpoint_name))
+                    else:
+                        ep.remove_egress_networkpolicy(policy_name)
+                if len(networkpolicy_opr.store.networkpolicy_endpoints_egress_store[policy_name]) == 0:
+                    networkpolicy_opr.store.networkpolicy_endpoints_egress_store.pop(policy_name)
+
+        self.set_networkpolicy_for_endpoint(policy_name, policy_types)
 
         return endpoint_names_to_be_handled
 
@@ -119,8 +141,8 @@ class NetworkPolicyUtil:
 
         return endpoint_name_list
 
-    def add_networkpolicy_for_endpoint(self, policy_name, policy_types):
-        if "Ingress" in policy_types:
+    def set_networkpolicy_for_endpoint(self, policy_name, policy_types):
+        if policy_types is not None and "Ingress" in policy_types:
             if policy_name in networkpolicy_opr.store.networkpolicy_endpoints_ingress_store:
                 for endpoint_name in networkpolicy_opr.store.networkpolicy_endpoints_ingress_store[policy_name]:
                     ep = networkpolicy_opr.store.get_ep(endpoint_name)
@@ -131,7 +153,7 @@ class NetworkPolicyUtil:
         else:
             self.remove_networkpolicy_from_endpoint_ingress(policy_name)
             
-        if "Egress" in policy_types:
+        if policy_types is not None and "Egress" in policy_types:
             if policy_name in networkpolicy_opr.store.networkpolicy_endpoints_egress_store:
                 for endpoint_name in networkpolicy_opr.store.networkpolicy_endpoints_egress_store[policy_name]:
                     ep = networkpolicy_opr.store.get_ep(endpoint_name)
@@ -362,24 +384,19 @@ class NetworkPolicyUtil:
     def build_cidr_and_policies_map(self, access_rules, cidr_type):
         cidr_map_name = "cidrs_map_" + cidr_type
         cidr_and_policies_map_name = "cidr_and_policies_map_" + cidr_type
-        trie = PatriciaTrie()
-        policy_name_set = set()
+        trie = IPv4Trie()
         for indexed_policy_name, cidrs in access_rules[cidr_map_name].items():
             for cidr in cidrs:
                 if cidr not in access_rules[cidr_and_policies_map_name]:
                     access_rules[cidr_and_policies_map_name][cidr] = set()
                 access_rules[cidr_and_policies_map_name][cidr].add(indexed_policy_name)
-                policy_name_set.add(indexed_policy_name)
                 trie.insert(cidr, access_rules[cidr_and_policies_map_name][cidr])
         for cidr, indexed_policy_names in access_rules[cidr_and_policies_map_name].items():
             found_cidr_map = trie.find_all(cidr)
             for found_cidr_tuple in found_cidr_map:
                 if indexed_policy_names != found_cidr_tuple[1]:
                     for foundPolicyName in found_cidr_tuple[1]:
-                        # In the trie, there could be matched cidr but whose policies are from other direction (ingress/egress).
-                        # So in following line adds a condition to limit the scope of the matched policies.
-                        if cidr in access_rules[cidr_and_policies_map_name] and foundPolicyName in policy_name_set:
-                            indexed_policy_names.add(foundPolicyName)
+                        indexed_policy_names.add(foundPolicyName)
 
     def build_port_and_policies_map(self, access_rules):
         for indexed_policy_name, ports in access_rules["ports_map"].items():

--- a/mizar/networkpolicy/networkpolicy_util.py
+++ b/mizar/networkpolicy/networkpolicy_util.py
@@ -20,7 +20,6 @@
 
 import logging
 import time
-import epdb
 from mizar.common.ipv4_trie import IPv4Trie
 from mizar.dp.mizar.operators.endpoints.endpoints_operator import *
 from mizar.dp.mizar.operators.networkpolicies.networkpolicies_operator import *
@@ -39,7 +38,6 @@ class NetworkPolicyUtil:
         endpoint_names_to_be_handled = set()
 
         if policy_types is None:
-            #epdb.serve(port=8888)
             if policy_name in networkpolicy_opr.store.networkpolicy_endpoints_ingress_store:
                 for endpoint_name in networkpolicy_opr.store.networkpolicy_endpoints_ingress_store[policy_name]:                    
                     ep = networkpolicy_opr.store.get_ep(endpoint_name)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         'luigi==2.8.12',
         'grpcio',
         'protobuf',
-        'fs',
-        'cidr-trie'
+        'fs'
     ]
 )


### PR DESCRIPTION
Cidr could be contained by another cidr. In the case, when get a cidr, we need to return all its parent cidrs. Trie is a good data structure for the scenario. I investigated some Python libs for cidr and ip address. Original I'm using cidr-trie but later it's found issue and are not usable. We decided to implement a simple version of cidr trie. This is the implementation.

The pr also fixed issue of unexpected result when deleting policy.