### PR TITLE
mizar cni: cmd version not to attempt the parsing none args into dict 

### DIFF
--- a/mizar/cni/mizarcni.py
+++ b/mizar/cni/mizarcni.py
@@ -46,7 +46,6 @@ class Cni:
         self.interface = os.environ.get("CNI_IFNAME")
         self.cni_path = os.environ.get("CNI_PATH")
         self.cni_args = os.environ.get("CNI_ARGS")
-        self.cni_args_dict = {}
         if self.command == "VERSION":
             return
         self.cni_args_dict = dict(i.split("=")

--- a/mizar/cni/mizarcni.py
+++ b/mizar/cni/mizarcni.py
@@ -46,6 +46,9 @@ class Cni:
         self.interface = os.environ.get("CNI_IFNAME")
         self.cni_path = os.environ.get("CNI_PATH")
         self.cni_args = os.environ.get("CNI_ARGS")
+        self.cni_args_dict = {}
+        if self.command == "VERSION":
+            return
         self.cni_args_dict = dict(i.split("=")
                                   for i in self.cni_args.split(";"))
         self.k8s_namespace = self.cni_args_dict.get('K8S_POD_NAMESPACE', '')
@@ -73,8 +76,9 @@ class Cni:
         self.iproute = IPRoute()
 
     def __del__(self):
-        logger.info("Closing IPRoute")
-        self.iproute.close()
+        if self.command != "VERSION":
+            logger.info("Closing IPRoute")
+            self.iproute.close()
 
     def run(self):
         logging.info("CNI ARGS {}".format(self.cni_args_dict))


### PR DESCRIPTION
This fixes #403.

Current implementation of mizar cni parses CNI_ARGS into a dict, which works for ADD/DELETE cmd. However, for VERSION cmd, it fails as the var is none. Typically, K8S container runtime would call VERSION cmd to probe the cni plugin; the failure would lead CR to believe cni plugin not ready, which would put nodes in not-ready state.

The PR patches mizar cni (py script) not to try the invalid parsing in VERSION case.

It is confirmed that Kind (mizar onebox) has no regression impact if the patch is applied.