### PR TITLE
mizarcni bug fix: bind mount arbitrary netns path to whch ip netns expects

### DIFF
--- a/mizar/cni/mizarcni.py
+++ b/mizar/cni/mizarcni.py
@@ -148,11 +148,12 @@ class Cni:
         if not self.netns.startswith(netns_folder):
             dst_netns = self.netns.replace('/', '_')
             dst_netns_path = os.path.join(netns_folder, dst_netns)
-            if bindmount_netns(self.netns, dst_netns_path) == 0:
+            errorcode = bindmount_netns(self.netns, dst_netns_path)
+            if errorcode == 0:
                 self.netns = dst_netns_path
             else:
-                logger.error("failed to bind mount {} to {}".format(self.netns, dst_netns_path))
-                raise OSError("failed to bind mount netns")
+                logger.error("failed to bind mount {} to {}: error code {}".format(self.netns, dst_netns_path, errorcode))
+                raise OSError("failed to bind mount netns {} to {}, error code: {}".format(self.netns, dst_netns_path, errorcode))
 
         _, netns = os.path.split(self.netns)
         iproute_ns = NetNS(netns)

--- a/mizar/cni/mizarcni.py
+++ b/mizar/cni/mizarcni.py
@@ -144,7 +144,17 @@ class Cni:
         the GW.
         """
 
-        head, netns = os.path.split(self.netns)
+        netns_folder = "/var/run/netns/"
+        if not self.netns.startswith(netns_folder):
+            dst_netns = self.netns.replace('/', '_')
+            dst_netns_path = os.path.join(netns_folder, dst_netns)
+            if bindmount_netns(self.netns, dst_netns_path) == 0:
+                self.netns = dst_netns_path
+            else:
+                logger.error("failed to bind mount {} to {}".format(self.netns, dst_netns_path))
+                raise OSError("failed to bind mount netns")
+
+        _, netns = os.path.split(self.netns)
         iproute_ns = NetNS(netns)
         veth_index = get_iface_index(interface.veth.name, self.iproute)
 

--- a/mizar/cni/mizarcni.py
+++ b/mizar/cni/mizarcni.py
@@ -48,6 +48,18 @@ class Cni:
         self.cni_args = os.environ.get("CNI_ARGS")
         if self.command == "VERSION":
             return
+
+        netns_folder = "/var/run/netns/"
+        if not self.netns.startswith(netns_folder):
+            dst_netns = self.netns.replace('/', '_')
+            dst_netns_path = os.path.join(netns_folder, dst_netns)
+            if self.command == "ADD":
+                errorcode = bindmount_netns(self.netns, dst_netns_path)
+                if errorcode != 0:
+                    logger.error("failed to bind mount {} to {}: error code {}".format(self.netns, dst_netns_path, errorcode))
+                    raise OSError("failed to bind mount netns {} to {}, error code: {}".format(self.netns, dst_netns_path, errorcode))
+            self.netns = dst_netns_path
+
         self.cni_args_dict = dict(i.split("=")
                                   for i in self.cni_args.split(";"))
         self.k8s_namespace = self.cni_args_dict.get('K8S_POD_NAMESPACE', '')
@@ -144,17 +156,6 @@ class Cni:
         the GW.
         """
 
-        netns_folder = "/var/run/netns/"
-        if not self.netns.startswith(netns_folder):
-            dst_netns = self.netns.replace('/', '_')
-            dst_netns_path = os.path.join(netns_folder, dst_netns)
-            errorcode = bindmount_netns(self.netns, dst_netns_path)
-            if errorcode == 0:
-                self.netns = dst_netns_path
-            else:
-                logger.error("failed to bind mount {} to {}: error code {}".format(self.netns, dst_netns_path, errorcode))
-                raise OSError("failed to bind mount netns {} to {}, error code: {}".format(self.netns, dst_netns_path, errorcode))
-
         _, netns = os.path.split(self.netns)
         iproute_ns = NetNS(netns)
         veth_index = get_iface_index(interface.veth.name, self.iproute)
@@ -196,6 +197,9 @@ class Cni:
                               interface=self.interface)
         InterfaceServiceClient(
             "localhost").DeleteInterface(param)
+        _, netns = os.path.split(self.netns)
+        if len(netns) > 0:
+            subprocess.run(["ip", "netns", "delete", netns])
         exit(0)
 
     def do_get(self):

--- a/mizar/common/common.py
+++ b/mizar/common/common.py
@@ -19,6 +19,7 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
 # THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import os
 import subprocess
 import ctypes
 import logging
@@ -417,8 +418,6 @@ def conf_list_has_max_elements(conf, conf_list):
     return False
 
 def bindmount_netns(src_netns_path, dst_netns_path):
-    import os
-    import subprocess
     os.mknod(dst_netns_path)
     bindmount = subprocess.run(["mount", "--bind", src_netns_path, dst_netns_path])
     return bindmount.returncode

--- a/mizar/common/common.py
+++ b/mizar/common/common.py
@@ -415,3 +415,10 @@ def conf_list_has_max_elements(conf, conf_list):
     if (counter + item_len > CONSTANTS.MAX_CLI_CHAR_LENGTH):
         return True
     return False
+
+def bindmount_netns(src_netns_path, dst_netns_path):
+    import os
+    import subprocess
+    os.mknod(dst_netns_path)
+    bindmount = subprocess.run(["mount", "--bind", src_netns_path, dst_netns_path])
+    return bindmount.returncode


### PR DESCRIPTION
This fixes #404.

The current mizar cni uses ip netns to handle netns and assumes netns path starting with "/var/run/netns/". Many container runtimes don't provide netns arg in such form (e.g. containerd provides /proc/\<pid\>/ns/netns), which would break the mizar cni plugin. This PR fixes the issue by bind mounting netns path to file under /var/run/netns/

This fix is necessary due to mizarcni being python script, which relies on ip netns shell command heavily.