### PR TITLE
Fix except data update/delete operation order issue

### DIFF
--- a/mizar/obj/endpoint.py
+++ b/mizar/obj/endpoint.py
@@ -387,19 +387,20 @@ class Endpoint:
         self.rpc.delete_agent_substrate_ep(ep, bouncer.ip)
 
     def update_networkpolicy_per_endpoint(self, data):
-        self.update_network_policy_ingress("except", data["ingress"]["cidr_table_except"])
-        self.update_network_policy_egress("except", data["egress"]["cidr_table_except"])
-
         if len(data["old"]) > 0:
             self.delete_network_policy_ingress("no_except", data["old"]["ingress"]["cidr_table_no_except"])
-            self.delete_network_policy_ingress("with_except", data["old"]["ingress"]["cidr_table_with_except"])
-            self.delete_network_policy_ingress("except", data["old"]["ingress"]["cidr_table_except"])
+            self.delete_network_policy_ingress("with_except", data["old"]["ingress"]["cidr_table_with_except"])            
             self.delete_network_policy_egress("no_except", data["old"]["egress"]["cidr_table_no_except"])
             self.delete_network_policy_egress("with_except", data["old"]["egress"]["cidr_table_with_except"])
+            # When deleting policy data, except data should be after cidr data
+            self.delete_network_policy_ingress("except", data["old"]["ingress"]["cidr_table_except"])
             self.delete_network_policy_egress("except", data["old"]["egress"]["cidr_table_except"])
             self.delete_network_policy_protocol_port_ingress(data["old"]["ingress"]["port_table"])
             self.delete_network_policy_protocol_port_egress(data["old"]["egress"]["port_table"])
 
+        # When updating policy data, except data should be before cidr data
+        self.update_network_policy_ingress("except", data["ingress"]["cidr_table_except"])
+        self.update_network_policy_egress("except", data["egress"]["cidr_table_except"])
         self.update_network_policy_ingress("no_except", data["ingress"]["cidr_table_no_except"])
         self.update_network_policy_ingress("with_except", data["ingress"]["cidr_table_with_except"])
         self.update_network_policy_egress("no_except", data["egress"]["cidr_table_no_except"])


### PR DESCRIPTION
1. Adjust except data's operation order, make sure: when deleting, it's after cidr data; when updating, it's before cidr data.
2. When old data and new data contain same items, ignore the operation on those items.