### PR TITLE
containerizes mizarcni installation

### DIFF
--- a/etc/docker/install-mizarcni.sh
+++ b/etc/docker/install-mizarcni.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2020 The Mizar Authors.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:The above copyright
+# notice and this permission notice shall be included in all copies or
+# substantial portions of the Software.THE SOFTWARE IS PROVIDED "AS IS",
+# WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+# THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+cp -rf /var/mizar /install/var/
+nsenter -t 1 -m -u -n -i bash /var/mizar/etc/docker/node-init.cni.sh
+echo "mizarcni installed on the host"

--- a/etc/docker/mizarcni.Dockerfile
+++ b/etc/docker/mizarcni.Dockerfile
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2020 The Mizar Authors.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:The above copyright
+# notice and this permission notice shall be included in all copies or
+# substantial portions of the Software.THE SOFTWARE IS PROVIDED "AS IS",
+# WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+# THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+FROM debian
+COPY . /var/mizar
+COPY etc/docker/install-mizarcni.sh /
+ENTRYPOINT ["bash"]
+CMD ["/install-mizarcni.sh"]

--- a/etc/docker/mizarcni.Dockerfile
+++ b/etc/docker/mizarcni.Dockerfile
@@ -18,6 +18,5 @@
 
 FROM debian
 COPY . /var/mizar
-COPY etc/docker/install-mizarcni.sh /
 ENTRYPOINT ["bash"]
-CMD ["/install-mizarcni.sh"]
+CMD ["/var/mizar/etc/docker/install-mizarcni.sh"]

--- a/etc/docker/node-init.cni.sh
+++ b/etc/docker/node-init.cni.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2020 The Mizar Authors.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:The above copyright
+# notice and this permission notice shall be included in all copies or
+# substantial portions of the Software.THE SOFTWARE IS PROVIDED "AS IS",
+# WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+# THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+set -eu
+
+mkdir -p /etc/cni/net.d
+mkdir -p /opt/cni/bin
+
+apt-get update -y
+apt-get install -y \
+    sudo \
+    rpcbind \
+    rsyslog \
+    libelf-dev \
+    iproute2  \
+    net-tools \
+    iputils-ping \
+    ethtool \
+    curl \
+    python3 \
+    python3-pip
+
+pip3 install --upgrade protobuf
+pip3 install --ignore-installed /var/mizar/
+ln -snf /sys/fs/bpf /bpffs
+ln -snf /var/mizar/build/bin /trn_bin
+ln -snf /var/mizar/build/xdp /trn_xdp
+ln -snf /var/mizar/etc/cni/10-mizarcni.conf /etc/cni/net.d/10-mizarcni.conf
+ln -snf /var/mizar/mizar/cni.py /opt/cni/bin/mizarcni
+ln -snf /var/mizar/build/tests/mizarcni.config /etc/mizarcni.config
+
+echo "mizarcni installed"

--- a/install/common.sh
+++ b/install/common.sh
@@ -158,6 +158,7 @@ function common:build_docker_images {
     docker image push $docker_account/endpointopr:latest
     docker image build -t $docker_account/testpod:latest -f etc/docker/test.Dockerfile .
     docker image push $docker_account/testpod:latest
+    docker image build -t mizarnet/mizarcni:latest -f etc/docker/mizarcni.Dockerfile .
 }
 
 function common:check_pod_by_image {


### PR DESCRIPTION
This closes #383.

Current mizar cni installation is through pre-built kindnode image in Kind dev env; this works for Kind as the node is using the customized image and has cni plugin embedded. For general cases like k8s by kubeadm, we need other means to have mizar cni plugin installed on nodes, preferably in containerized form. This PR is about the container image that accomplishes mizar cni plugin installation. 

Following command will install mizar cni plug-in onto the host (verified on Ubuntu 20.04.1 LTS):
```bash
docker run --privileged --network=host --pid=host -v /var:/install/var mizarnet/mizarcni:tagname 
``` 