### PR TITLE
install mizar cni as part of node agent deployment

### DIFF
--- a/etc/deploy/deploy.mizar.componens.yaml
+++ b/etc/deploy/deploy.mizar.componens.yaml
@@ -443,11 +443,23 @@ spec:
       terminationGracePeriodSeconds: 0
       hostNetwork: true
       hostPID: true
+      initContainers:
+        - name: mizar-cni
+          image: mizarnet/mizarcni:0.7
+          volumeMounts:
+            - name: var
+              mountPath: /install/var
+          securityContext:
+            privileged: true
       containers:
         - image: fwnetworking/dropletd:0.7
           name: mizar-daemon
           securityContext:
             privileged: true
+      volumes:
+        - name: var
+          hostPath:
+            path: /var
 ---
 # mizar deployment of operator
 apiVersion: apps/v1

--- a/mizar/cni/mizarcni.py
+++ b/mizar/cni/mizarcni.py
@@ -46,6 +46,7 @@ class Cni:
         self.interface = os.environ.get("CNI_IFNAME")
         self.cni_path = os.environ.get("CNI_PATH")
         self.cni_args = os.environ.get("CNI_ARGS")
+        self.cni_args_dict = {}
         if self.command == "VERSION":
             return
 
@@ -92,7 +93,8 @@ class Cni:
             self.iproute.close()
 
     def run(self):
-        logging.info("CNI ARGS {}".format(self.cni_args_dict))
+        if len(self.cni_args_dict) != 0:
+            logging.info("CNI ARGS {}".format(self.cni_args_dict))
         val = "Unsuported cni command!"
         switcher = {
             'ADD': self.do_add,


### PR DESCRIPTION
This fixes #405.

Current mizar lacks a k8s way to install cni plugin. Kind env istalls mizar cni as pre-built work node image, which does not work for general k8s cluster setup. This PR puts mizarcni installation as part of mizar daemonSet.

This PR also has a minor fix of mizarcni code - to always initialize cni_args_dict. Since it is so trivial, it is included in this PR.