### PR TITLE
remote container images use mizarnet prefix

### DIFF
--- a/etc/deploy/daemon.deploy.yaml
+++ b/etc/deploy/daemon.deploy.yaml
@@ -43,7 +43,7 @@ spec:
       hostNetwork: true
       hostPID: true
       containers:
-        - image: fwnetworking/dropletd:latest
+        - image: mizarnet/dropletd:latest
           name: mizar-daemon
           securityContext:
             privileged: true

--- a/etc/deploy/deploy.daemon.yaml
+++ b/etc/deploy/deploy.daemon.yaml
@@ -64,7 +64,7 @@ spec:
             path: /var
             type: Directory
       initContainers:
-        - image: fwnetworking/mizar:latest
+        - image: mizarnet/mizar:latest
           name: node-init
           command: [./node-init.sh]
           securityContext:
@@ -73,7 +73,7 @@ spec:
             - name: mizar
               mountPath: /home
       containers:
-        - image: fwnetworking/dropletd:latest
+        - image: mizarnet/dropletd:latest
           name: mizar-daemon
           securityContext:
             privileged: true

--- a/etc/deploy/deploy.mizar.componens.yaml
+++ b/etc/deploy/deploy.mizar.componens.yaml
@@ -452,7 +452,7 @@ spec:
           securityContext:
             privileged: true
       containers:
-        - image: fwnetworking/dropletd:0.7
+        - image: mizarnet/dropletd:0.7
           name: mizar-daemon
           securityContext:
             privileged: true
@@ -484,7 +484,7 @@ spec:
       terminationGracePeriodSeconds: 0
       hostNetwork: true
       containers:
-        - image: fwnetworking/endpointopr:0.7
+        - image: mizarnet/endpointopr:0.7
           name: mizar-operator
           securityContext:
             privileged: true

--- a/etc/deploy/deploy.operator.yaml
+++ b/etc/deploy/deploy.operator.yaml
@@ -40,7 +40,7 @@ spec:
         - operator: Exists
           effect: NoSchedule
       containers:
-        - image: fwnetworking/endpointopr:latest
+        - image: mizarnet/endpointopr:latest
           name: mizar-operator
           securityContext:
             privileged: true

--- a/etc/deploy/operator.deploy.yaml
+++ b/etc/deploy/operator.deploy.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 0
       hostNetwork: true
       containers:
-        - image: fwnetworking/endpointopr:latest
+        - image: mizarnet/endpointopr:latest
           name: mizar-operator
           securityContext:
             privileged: true

--- a/etc/docker/daemon.Dockerfile
+++ b/etc/docker/daemon.Dockerfile
@@ -19,7 +19,7 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
 # THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-FROM fwnetworking/python_base:latest
+FROM mizarnet/python_base:latest
 COPY . /var/mizar/
 RUN apt-get install -y iproute2
 RUN pip3 install /var/mizar/

--- a/etc/docker/operator.Dockerfile
+++ b/etc/docker/operator.Dockerfile
@@ -19,7 +19,7 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
 # THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-FROM fwnetworking/python_base:latest
+FROM mizarnet/python_base:latest
 COPY . /var/mizar/
 RUN pip3 install /var/mizar/
 RUN ln -snf /var/mizar/build/bin /trn_bin

--- a/install/common.sh
+++ b/install/common.sh
@@ -151,14 +151,10 @@ function common:build_docker_images {
     fi
 
     docker image build -t $docker_account/mizar:latest -f etc/docker/mizar.Dockerfile .
-    docker image push $docker_account/mizar:latest
     docker image build -t $docker_account/dropletd:latest -f etc/docker/daemon.Dockerfile .
-    docker image push $docker_account/dropletd:latest
     docker image build -t $docker_account/endpointopr:latest -f etc/docker/operator.Dockerfile .
-    docker image push $docker_account/endpointopr:latest
     docker image build -t $docker_account/testpod:latest -f etc/docker/test.Dockerfile .
-    docker image push $docker_account/testpod:latest
-    docker image build -t mizarnet/mizarcni:latest -f etc/docker/mizarcni.Dockerfile .
+    docker image build -t $docker_account/mizarcni:latest -f etc/docker/mizarcni.Dockerfile .
 }
 
 function common:check_pod_by_image {

--- a/install/deploy_daemon.sh
+++ b/install/deploy_daemon.sh
@@ -27,7 +27,7 @@ DOCKER_ACC=${3:-"localhost:5000"}
 YAML_FILE="dev.daemon.deploy.yaml"
 
 if [[ "$USER" == "user" || "$USER" == "final" ]]; then
-    DOCKER_ACC="fwnetworking"
+    DOCKER_ACC="mizarnet"
     YAML_FILE="daemon.deploy.yaml"
 fi
 

--- a/install/deploy_operator.sh
+++ b/install/deploy_operator.sh
@@ -28,7 +28,7 @@ YAML_FILE="dev.operator.deploy.yaml"
 . install/common.sh
 
 if [[ "$USER" == "user" || "$USER" == "final" ]]; then
-    DOCKER_ACC="fwnetworking"
+    DOCKER_ACC="mizarnet"
     YAML_FILE="operator.deploy.yaml"
 fi
 

--- a/install/environment_adaptors/arktos_up_adaptor.sh
+++ b/install/environment_adaptors/arktos_up_adaptor.sh
@@ -23,7 +23,7 @@
 source install/common.sh
 
 function environment_adaptor:prepare_binary {
-    # Current for arktos-up env, we use images from fwnetworking instead of localhost:5000
+    # Current for arktos-up env, we use images from mizarnet instead of localhost:5000
     # So skip invoking common:build_docker_images
     # common:build_docker_images 
     :

--- a/install/environment_adaptors/k8s_kind_adaptor.sh
+++ b/install/environment_adaptors/k8s_kind_adaptor.sh
@@ -30,7 +30,7 @@ function environment_adaptor:prepare_binary {
         local docker_account="localhost:5000"
     else
         local user="prod"
-        local docker_account="fwnetworking"
+        local docker_account="mizarnet"
     fi
 
     local cwd=$(pwd)

--- a/k8s/kind/Dockerfile
+++ b/k8s/kind/Dockerfile
@@ -19,7 +19,7 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
 # THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-FROM fwnetworking/kindnode:latest
+FROM mizarnet/kindnode:latest
 COPY . /var/mizar/
 RUN pip3 install /var/mizar/
 RUN ln -snf /var/mizar/build/bin /trn_bin

--- a/k8s/kind/create_cluster.sh
+++ b/k8s/kind/create_cluster.sh
@@ -53,7 +53,7 @@ if [[ $USER == "dev" ]]; then
   REPO="localhost:5000"
 else
   PATCH=""
-  REPO="fwnetworking"
+  REPO="mizarnet"
 fi
 
 NODE_TEMPLATE="  - role: worker

--- a/mizar/obj/tests/test_pod_arktos_vpc1.yaml
+++ b/mizar/obj/tests/test_pod_arktos_vpc1.yaml
@@ -9,6 +9,6 @@ metadata:
 spec:
   containers:
   - name: arktospodvpc1net1
-    image: fwnetworking/testpod
+    image: mizarnet/testpod
     ports:
       - containerPort: 443


### PR DESCRIPTION
This closes #427.

The remote images created by mizar project are currently pushed to "fwnetworking" dockerhub account, and having names like "fwnetworking/dropletd". To inline with open source convention, the account should migrate to company-neutral "mizarnet". This PR is code-related part of such migration.

Besides the code change in this PR, mizarnet account has been created, and mizar project specific container images have been uploaded.

