### PR TITLE
Assign IP during pod create before network policy wf

### DIFF
--- a/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
+++ b/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
@@ -331,7 +331,7 @@ class EndpointOperator(object):
             OR arktos needs check wheter the ip and subnet is valid
             """
             ep.set_net(net_info.get('subnet', spec['subnet']))
-            ep.set_ip(net_info.get('ip', ''))
+            ep.set_ip(spec['ip'])
 
             ep.set_mac(interface.address.mac)
             ep.set_veth_name(interface.veth.name)

--- a/mizar/dp/mizar/operators/nets/nets_operator.py
+++ b/mizar/dp/mizar/operators/nets/nets_operator.py
@@ -111,13 +111,12 @@ class NetOperator(object):
     def allocate_endpoint(self, ep):
         n = self.store.get_net(ep.net)
         logger.info("IP {} for net {}".format(ep.ip, n.name))
-        if ep.ip == "":
-            if ep.type == OBJ_DEFAULTS.ep_type_host:
-                ip = ep.get_droplet_ip()
-            else:
-                ip = n.allocate_ip()
+        if ep.type == OBJ_DEFAULTS.ep_type_host:
+            ip = ep.get_droplet_ip()
             ep.set_ip(ip)
-
+        if ep.ip == "":
+            ip = n.allocate_ip()
+            ep.set_ip(ip)
         gw = n.get_gw_ip()
         if ep.get_prefix() == "":
             ep.set_prefix(n.get_prefixlen())

--- a/mizar/dp/mizar/workflows/builtins/pods/create.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/create.py
@@ -60,7 +60,6 @@ class k8sPodCreate(WorkflowTask):
             'phase': self.param.body['status']['phase'],
             'interfaces': [{'name': 'eth0'}]
         }
-        logger.info("Pod spec {}".format(spec))
 
         spec['vni'] = vpc_opr.store_get(spec['vpc']).vni
         spec['droplet'] = droplet_opr.store_get_by_ip(spec['hostIP'])
@@ -87,6 +86,12 @@ class k8sPodCreate(WorkflowTask):
                 net_config = self.param.extra["interfaces"]
                 configs = json.loads(net_config)
                 spec['interfaces'] = configs
+
+        n = net_opr.store.get_net(spec['subnet'])
+        ip = n.allocate_ip()
+        spec['ip'] = ip
+
+        logger.info("Pod spec {}".format(spec))
 
         # make sure not to trigger init or create simple endpoint
         # if Arktos network is already marked ready (Needs to confirm with Arktos team)


### PR DESCRIPTION
Currently, mizar assigns IP during ep obj creation. But this cause issue for network policy update. 
This PR assigns an IP address for each pod at early stage so that network policy operator can update its new ip. 