### PR TITLE
namespace missing in issue 436 Pod creation stuck in ContainerCreating state

### DIFF
--- a/mizar/arktos/arktos_service.py
+++ b/mizar/arktos/arktos_service.py
@@ -38,6 +38,7 @@ class ArktosService(BuiltinsServiceServicer):
         logger.info("Creating pod from Arktos Service {}".format(request.name))
         param = reset_param(HandlerParam())
         param.name = request.name
+        param.namespace = request.namespace
         param.body['status'] = {}
         param.body['metadata'] = {}
         param.body['status']['hostIP'] = request.host_ip
@@ -174,6 +175,7 @@ class ArktosService(BuiltinsServiceServicer):
             "Deleting pod from Network Controller {}".format(request.name))
         param = reset_param(HandlerParam())
         param.name = request.name
+        param.namespace = request.namespace        
         return run_arktos_workflow(wffactory().k8sPodDelete(param=param))
 
     def DeleteService(self, request, context):


### PR DESCRIPTION
In issue 436 Pod creation stuck in ContainerCreating state, the error message is: AttributeError: 'HandlerParam' object has no attribute 'namespace'.

It's because in latest mizar code of pods/create.py, it added reading namespace from self.param.namespace. The code adds setting of namespace in pods/triggers.py, but didn't handle the coding from arktos_service.py.
This fix is to add setting of namespace in arktos_service.py.