### PR TITLE
run apt update when building dropletd image

### DIFF
--- a/etc/docker/daemon.Dockerfile
+++ b/etc/docker/daemon.Dockerfile
@@ -21,6 +21,6 @@
 
 FROM mizarnet/python_base:latest
 COPY . /var/mizar/
-RUN apt-get install -y iproute2
+RUN apt update && apt-get install -y iproute2
 RUN pip3 install /var/mizar/
 CMD mizard


### PR DESCRIPTION
This fixes #439.

When mizar-daemon pod image (dropletd) is build, it installs iproute2 etc. Recently debian the relevant repository seems to undertake version update, which requires client to catch up with, otherwise apt install won't succeed any more.

The fix is ensuring to run "apt update" before "apt install iproute2".

