### PR TITLE
449 Implement Label Based Network Policies - Store pod/namespace label combination in operator store

### DIFF
--- a/mizar/dp/mizar/workflows/builtins/pods/create.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/create.py
@@ -104,7 +104,7 @@ class k8sPodCreate(WorkflowTask):
         #     return
 
         if spec['phase'] != 'Pending':
-            networkpolicy_util.handle_pod_change_for_networkpolicy(self.param.name, self.param.namespace, self.param.diff)
+            networkpolicy_util.handle_pod_change_for_networkpolicy(self.param.name, self.param.namespace, self.param.body.metadata.labels, self.param.diff)
             self.finalize()
             return
 
@@ -117,6 +117,6 @@ class k8sPodCreate(WorkflowTask):
         # Create the corresponding simple endpoint objects
         endpoint_opr.create_simple_endpoints(interfaces, spec)
 
-        networkpolicy_util.handle_pod_change_for_networkpolicy(self.param.name, self.param.namespace, self.param.diff)
+        networkpolicy_util.handle_pod_change_for_networkpolicy(self.param.name, self.param.namespace, self.param.body.metadata.labels, self.param.diff)
 
         self.finalize()

--- a/mizar/networkpolicy/networkpolicy_util.py
+++ b/mizar/networkpolicy/networkpolicy_util.py
@@ -520,7 +520,7 @@ class NetworkPolicyUtil:
         self.handle_networkpolicy_change(policy_name_list)
 
     def get_label_combination(self, labels):
-        if labels is None or len(labels) == 0:
+        if not labels:
             return ""
 
         label_list = []

--- a/mizar/obj/endpoint.py
+++ b/mizar/obj/endpoint.py
@@ -68,6 +68,8 @@ class Endpoint:
         self.ingress_networkpolicies = []
         self.egress_networkpolicies = []
         self.data_for_networkpolicy = {}
+        self.pod_label_value = 0
+        self.namespace_label_value = 0
         if spec is not None:
             self.set_obj_spec(spec)
 

--- a/mizar/store/operator_store.py
+++ b/mizar/store/operator_store.py
@@ -67,6 +67,13 @@ class OprStore(object):
         self.networkpolicy_endpoints_ingress_store = {}
         self.networkpolicy_endpoints_egress_store = {}
 
+        self.pod_label_value_store = {
+            "": 0
+        }
+        self.namespace_label_value_store = {
+            "": 0
+        }
+
         self.dividers_store = {}
         self.dividers_vpc_store = {}
 
@@ -320,6 +327,18 @@ class OprStore(object):
             self.networkpolicy_endpoints_egress_store[policy_name] = set()
         self.networkpolicy_endpoints_egress_store[policy_name].add(endpoint_name)
 
+    def get_or_add_pod_label_value(self, label_combination):
+        if label_combination not in self.pod_label_value_store:
+            self.pod_label_value_store[label_combination] = len(self.pod_label_value_store)
+            # todo update the value to daemon
+        return self.pod_label_value_store[label_combination]
+
+    def get_or_add_namespace_label_value(self, label_combination):
+        if label_combination not in self.namespace_label_value_store:
+            self.namespace_label_value_store[label_combination] = len(self.namespace_label_value_store)
+            # todo update the value to daemon
+        return self.namespace_label_value_store[label_combination]
+    
     def update_droplet(self, droplet):
         self.droplets_store[droplet.name] = droplet
 


### PR DESCRIPTION
The changes are:
1. Watch pod change for label and namespace label
2. Generate pod and namespace label values from label combination
3. Set label values to corresponding endpoint
4. Save label values in operator store. Put "todo" comments for next task which is to send label value to daemon