### PR TITLE
Use mizarnet docker account instead of fwnetworking. Allow non-root users to run kind-setup. Misc cleanups

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+tput setaf 1
+echo "NOTE: This script will reboot the system if you opt to allow kernel update."
+echo "      If reboot is not required, it will log you out and require re-login for new permissions to take effect."
+echo ""
+read -n 1 -s -r -p "Press Ctrl-c to quit, any key to continue..."
+tput sgr0
+
+logout_needed=false
+
 sudo apt-get update
 sudo apt-get install -y \
     build-essential clang-7 llvm-7 \
@@ -9,12 +18,30 @@ sudo apt-get install -y \
     libcmocka-dev \
     lcov
 
-sudo apt install docker.io
-sudo pip3 install netaddr docker scapy
+sudo apt-get install -y docker.io
+sudo pip3 install --upgrade pip
+sudo pip3 install netaddr docker scapy grpcio-tools
 sudo systemctl unmask docker.service
 sudo systemctl unmask docker.socket
+
+cat /etc/group | grep docker | grep ${USER} &> /dev/null
+if [ $? -ne 0 ]; then
+  sudo usermod -aG docker ${USER}
+  logout_needed=true
+fi
+
 sudo systemctl start docker
 sudo systemctl enable docker
+
+# Install kind
+if [ ! -f /usr/local/bin/kind ]; then
+    pushd /tmp
+    ver=$(curl -s https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
+    curl -Lo kind "https://github.com/kubernetes-sigs/kind/releases/download/$ver/kind-$(uname)-amd64"
+    chmod +x kind
+    sudo mv kind /usr/local/bin
+    popd
+fi
 
 sudo docker build -f ./test/Dockerfile -t buildbox:v2 ./test
 
@@ -22,18 +49,22 @@ git submodule update --init --recursive
 
 kernel_ver=`uname -r`
 echo "Running kernel version: $kernel_ver"
+mj_ver=$(echo $kernel_ver | cut -d. -f1)
+mn_ver=$(echo $kernel_ver | cut -d. -f2)
 
-if [ "$kernel_ver" != "5.6.0-rc2" ]; then
+if [[ "$mj_ver" < "5" ]] || [[ "$mn_ver" < "6" ]]; then
+        tput setaf 1
 	echo "Mizar requires an updated kernel: linux-5.6-rc2 for TCP to function correctly. Current version is $kernel_ver"
 
 	read -p "Execute kernel update script (y/n)?" choice
+	tput sgr0
 	case "$choice" in
 	  y|Y ) sh ./kernelupdate.sh;;
 	  n|N ) echo "Please run kernelupdate.sh to download and update the kernel!"; exit;;
 	  * ) echo "Please run kernelupdate.sh to download and update the kernel!"; exit;;
 	esac
 fi
-ver=$(curl -s https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
-curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/$ver/kind-$(uname)-amd64
-chmod +x kind
-mv kind /usr/local/bin
+
+if [ "$logout_needed" = true ]; then
+    logout
+fi

--- a/install/common.sh
+++ b/install/common.sh
@@ -24,13 +24,13 @@
 function delete_pods {
     NAME=$1
     TYPE=$2
-    sudo kubectl delete $TYPE.apps/$NAME 2> ${KUBECTL_LOG}
+    kubectl delete $TYPE.apps/$NAME 2> ${KUBECTL_LOG}
     echo -n "Waiting for ${NAME} pods to terminate."
-    sudo kubectl get pods | grep $NAME > /dev/null
+    kubectl get pods | grep $NAME > /dev/null
     while [[ $? -eq 0 ]]; do
         echo -n "."
         sleep 1
-        sudo kubectl get pods | grep $NAME > /dev/null
+        kubectl get pods | grep $NAME > /dev/null
     done
     echo
 }
@@ -41,10 +41,10 @@ function common:check_cluster_ready {
     local function_name="common:check_cluster_ready"
     echo "[$function_name] Checking cluster readyness by getting node status."
     if [[ $show_cluster_status == 1 ]]; then
-        sudo kubectl cluster-info
+        kubectl cluster-info
     fi
 
-    local cluster_status=`sudo kubectl cluster-info | grep Kubernetes | grep is | grep running`
+    local cluster_status=`kubectl cluster-info | grep Kubernetes | grep is | grep running`
     if [[ -z "$cluster_status" ]]; then
         return 0
     else
@@ -159,7 +159,7 @@ function common:build_docker_images {
 
 function common:check_pod_by_image {
     local image_name=$1
-    local pod_name=$(sudo kubectl get pods -l run=$image_name | grep "$image_name" | awk '{print $1}')
+    local pod_name=$(kubectl get pods -l run=$image_name | grep "$image_name" | awk '{print $1}')
     if [[ -z $pod_name ]]; then
         return 0
     else
@@ -170,12 +170,12 @@ function common:check_pod_by_image {
 function common:check_pod_running_in_mizar {
     local image_name="pod-test"
     
-    sudo kubectl run $image_name --image=localhost:5000/testpod
+    kubectl run $image_name --image=localhost:5000/testpod
     sleep 2
-    sudo kubectl wait --for=condition=Ready pod -l run=$image_name --timeout=60s
+    kubectl wait --for=condition=Ready pod -l run=$image_name --timeout=60s
 
-    local pod_name=$(sudo kubectl get pods -l run=$image_name -o wide | grep " 10.0." | awk '{print $1}')
-    sudo kubectl delete deploy $image_name
+    local pod_name=$(kubectl get pods -l run=$image_name -o wide | grep " 10.0." | awk '{print $1}')
+    kubectl delete deploy $image_name
     common:execute_and_retry "common:check_pod_by_image $image_name" 0 "" "" 60 0
     if [[ -z $pod_name ]]; then
         return 0

--- a/install/common.sh
+++ b/install/common.sh
@@ -145,16 +145,16 @@ function common:build_docker_images {
     local docker_account="localhost:5000"
     local reg_name='local-registry'
 
-    local registry_running="$(sudo docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+    local registry_running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
     if [ "${registry_running}" != "true" ]; then
-        sudo docker run -d --restart=always -p "5000:5000" --name "${reg_name}" registry:2
+        docker run -d --restart=always -p "5000:5000" --name "${reg_name}" registry:2
     fi
 
-    sudo docker image build -t $docker_account/mizar:latest -f etc/docker/mizar.Dockerfile .
-    sudo docker image build -t $docker_account/dropletd:latest -f etc/docker/daemon.Dockerfile .
-    sudo docker image build -t $docker_account/endpointopr:latest -f etc/docker/operator.Dockerfile .
-    sudo docker image build -t $docker_account/testpod:latest -f etc/docker/test.Dockerfile .
-    sudo docker image build -t $docker_account/mizarcni:latest -f etc/docker/mizarcni.Dockerfile .
+    docker image build -t $docker_account/mizar:latest -f etc/docker/mizar.Dockerfile .
+    docker image build -t $docker_account/dropletd:latest -f etc/docker/daemon.Dockerfile .
+    docker image build -t $docker_account/endpointopr:latest -f etc/docker/operator.Dockerfile .
+    docker image build -t $docker_account/testpod:latest -f etc/docker/test.Dockerfile .
+    docker image build -t $docker_account/mizarcni:latest -f etc/docker/mizarcni.Dockerfile .
 }
 
 function common:check_pod_by_image {

--- a/install/create_crds.sh
+++ b/install/create_crds.sh
@@ -24,16 +24,16 @@
 DIR=${1:-.}
 
 # Create the CRDs
-kubectl delete bouncers.mizar.com --all 2> /tmp/kubetctl.err
-kubectl delete dividers.mizar.com --all 2> /tmp/kubetctl.err
-kubectl delete droplets.mizar.com --all 2> /tmp/kubetctl.err
-kubectl delete endpoints.mizar.com --all 2> /tmp/kubetctl.err
-kubectl delete subnets.mizar.com --all 2> /tmp/kubetctl.err
-kubectl delete vpcs.mizar.com --all 2> /tmp/kubetctl.err
+sudo kubectl delete bouncers.mizar.com --all 2> ${KUBECTL_LOG}
+sudo kubectl delete dividers.mizar.com --all 2> ${KUBECTL_LOG}
+sudo kubectl delete droplets.mizar.com --all 2> ${KUBECTL_LOG}
+sudo kubectl delete endpoints.mizar.com --all 2> ${KUBECTL_LOG}
+sudo kubectl delete subnets.mizar.com --all 2> ${KUBECTL_LOG}
+sudo kubectl delete vpcs.mizar.com --all 2> ${KUBECTL_LOG}
 
-kubectl apply -f $DIR/etc/crds/bouncers.crd.yaml
-kubectl apply -f $DIR/etc/crds/dividers.crd.yaml
-kubectl apply -f $DIR/etc/crds/droplets.crd.yaml
-kubectl apply -f $DIR/etc/crds/endpoints.crd.yaml
-kubectl apply -f $DIR/etc/crds/subnets.crd.yaml
-kubectl apply -f $DIR/etc/crds/vpcs.crd.yaml
+sudo kubectl apply -f $DIR/etc/crds/bouncers.crd.yaml
+sudo kubectl apply -f $DIR/etc/crds/dividers.crd.yaml
+sudo kubectl apply -f $DIR/etc/crds/droplets.crd.yaml
+sudo kubectl apply -f $DIR/etc/crds/endpoints.crd.yaml
+sudo kubectl apply -f $DIR/etc/crds/subnets.crd.yaml
+sudo kubectl apply -f $DIR/etc/crds/vpcs.crd.yaml

--- a/install/create_crds.sh
+++ b/install/create_crds.sh
@@ -24,16 +24,16 @@
 DIR=${1:-.}
 
 # Create the CRDs
-sudo kubectl delete bouncers.mizar.com --all 2> ${KUBECTL_LOG}
-sudo kubectl delete dividers.mizar.com --all 2> ${KUBECTL_LOG}
-sudo kubectl delete droplets.mizar.com --all 2> ${KUBECTL_LOG}
-sudo kubectl delete endpoints.mizar.com --all 2> ${KUBECTL_LOG}
-sudo kubectl delete subnets.mizar.com --all 2> ${KUBECTL_LOG}
-sudo kubectl delete vpcs.mizar.com --all 2> ${KUBECTL_LOG}
+kubectl delete bouncers.mizar.com --all 2> ${KUBECTL_LOG}
+kubectl delete dividers.mizar.com --all 2> ${KUBECTL_LOG}
+kubectl delete droplets.mizar.com --all 2> ${KUBECTL_LOG}
+kubectl delete endpoints.mizar.com --all 2> ${KUBECTL_LOG}
+kubectl delete subnets.mizar.com --all 2> ${KUBECTL_LOG}
+kubectl delete vpcs.mizar.com --all 2> ${KUBECTL_LOG}
 
-sudo kubectl apply -f $DIR/etc/crds/bouncers.crd.yaml
-sudo kubectl apply -f $DIR/etc/crds/dividers.crd.yaml
-sudo kubectl apply -f $DIR/etc/crds/droplets.crd.yaml
-sudo kubectl apply -f $DIR/etc/crds/endpoints.crd.yaml
-sudo kubectl apply -f $DIR/etc/crds/subnets.crd.yaml
-sudo kubectl apply -f $DIR/etc/crds/vpcs.crd.yaml
+kubectl apply -f $DIR/etc/crds/bouncers.crd.yaml
+kubectl apply -f $DIR/etc/crds/dividers.crd.yaml
+kubectl apply -f $DIR/etc/crds/droplets.crd.yaml
+kubectl apply -f $DIR/etc/crds/endpoints.crd.yaml
+kubectl apply -f $DIR/etc/crds/subnets.crd.yaml
+kubectl apply -f $DIR/etc/crds/vpcs.crd.yaml

--- a/install/create_service_account.sh
+++ b/install/create_service_account.sh
@@ -22,10 +22,9 @@
 # THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 DIR=${1:-.}
-USER=${2:-dev}
 
 # Create the service account
-kubectl apply -f $DIR/etc/account/serviceaccount.yaml
+sudo kubectl apply -f $DIR/etc/account/serviceaccount.yaml
 
 # Bind the service account to cluster admin
-kubectl apply -f $DIR/etc/account/binding.yaml
+sudo kubectl apply -f $DIR/etc/account/binding.yaml

--- a/install/create_service_account.sh
+++ b/install/create_service_account.sh
@@ -24,7 +24,7 @@
 DIR=${1:-.}
 
 # Create the service account
-sudo kubectl apply -f $DIR/etc/account/serviceaccount.yaml
+kubectl apply -f $DIR/etc/account/serviceaccount.yaml
 
 # Bind the service account to cluster admin
-sudo kubectl apply -f $DIR/etc/account/binding.yaml
+kubectl apply -f $DIR/etc/account/binding.yaml

--- a/install/create_testimage.sh
+++ b/install/create_testimage.sh
@@ -22,9 +22,8 @@
 # THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 DIR=${1:-.}
-USER=${2:-dev}
-DOCKER_ACC=${3:-"localhost:5000"}
+DOCKER_ACC=${2:-"localhost:5000"}
 
 # Build the daemon image
-docker image build -t $DOCKER_ACC/testpod:latest -f $DIR/etc/docker/test.Dockerfile $DIR
-docker image push $DOCKER_ACC/testpod:latest
+sudo docker image build -t $DOCKER_ACC/testpod:latest -f $DIR/etc/docker/test.Dockerfile $DIR
+sudo docker image push $DOCKER_ACC/testpod:latest

--- a/install/create_testimage.sh
+++ b/install/create_testimage.sh
@@ -22,8 +22,15 @@
 # THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 DIR=${1:-.}
-DOCKER_ACC=${2:-"localhost:5000"}
+MODE=${2:-dev}
+DOCKER_ACC=${3:-"localhost:5000"}
+
+if [[ "$MODE" == "user" || "$MODE" == "final" ]]; then
+    DOCKER_ACC="mizarnet"
+fi
 
 # Build the daemon image
-sudo docker image build -t $DOCKER_ACC/testpod:latest -f $DIR/etc/docker/test.Dockerfile $DIR
-sudo docker image push $DOCKER_ACC/testpod:latest
+if [[ "$MODE" == "dev" || "$MODE" == "final" ]]; then
+  sudo docker image build -t $DOCKER_ACC/testpod:latest -f $DIR/etc/docker/test.Dockerfile $DIR
+  sudo docker image push $DOCKER_ACC/testpod:latest
+fi

--- a/install/create_testimage.sh
+++ b/install/create_testimage.sh
@@ -31,6 +31,6 @@ fi
 
 # Build the daemon image
 if [[ "$MODE" == "dev" || "$MODE" == "final" ]]; then
-  sudo docker image build -t $DOCKER_ACC/testpod:latest -f $DIR/etc/docker/test.Dockerfile $DIR
-  sudo docker image push $DOCKER_ACC/testpod:latest
+  docker image build -t $DOCKER_ACC/testpod:latest -f $DIR/etc/docker/test.Dockerfile $DIR
+  docker image push $DOCKER_ACC/testpod:latest
 fi

--- a/install/deploy_daemon.sh
+++ b/install/deploy_daemon.sh
@@ -33,8 +33,8 @@ fi
 
 # Build the daemon image
 if [[ "$MODE" == "dev" || "$MODE" == "final" ]]; then
-    sudo docker image build -t $DOCKER_ACC/dropletd:latest -f $DIR/etc/docker/daemon.Dockerfile $DIR
-    sudo docker image push $DOCKER_ACC/dropletd:latest
+    docker image build -t $DOCKER_ACC/dropletd:latest -f $DIR/etc/docker/daemon.Dockerfile $DIR
+    docker image push $DOCKER_ACC/dropletd:latest
 fi
 
 # Delete existing deployment and deploy

--- a/install/deploy_daemon.sh
+++ b/install/deploy_daemon.sh
@@ -38,5 +38,5 @@ if [[ "$MODE" == "dev" || "$MODE" == "final" ]]; then
 fi
 
 # Delete existing deployment and deploy
-sudo kubectl delete daemonset.apps/mizar-daemon 2> ${KUBECTL_LOG}
-sudo kubectl apply -f $DIR/etc/deploy/$YAML_FILE
+kubectl delete daemonset.apps/mizar-daemon 2> ${KUBECTL_LOG}
+kubectl apply -f $DIR/etc/deploy/$YAML_FILE

--- a/install/deploy_daemon.sh
+++ b/install/deploy_daemon.sh
@@ -22,21 +22,21 @@
 # THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 DIR=${1:-.}
-USER=${2:-dev}
+MODE=${2:-dev}
 DOCKER_ACC=${3:-"localhost:5000"}
 YAML_FILE="dev.daemon.deploy.yaml"
 
-if [[ "$USER" == "user" || "$USER" == "final" ]]; then
+if [[ "$MODE" == "user" || "$MODE" == "final" ]]; then
     DOCKER_ACC="mizarnet"
     YAML_FILE="daemon.deploy.yaml"
 fi
 
 # Build the daemon image
-if [[ "$USER" == "dev" || "$USER" == "final" ]]; then
-    docker image build -t $DOCKER_ACC/dropletd:latest -f $DIR/etc/docker/daemon.Dockerfile $DIR
-    docker image push $DOCKER_ACC/dropletd:latest
+if [[ "$MODE" == "dev" || "$MODE" == "final" ]]; then
+    sudo docker image build -t $DOCKER_ACC/dropletd:latest -f $DIR/etc/docker/daemon.Dockerfile $DIR
+    sudo docker image push $DOCKER_ACC/dropletd:latest
 fi
 
 # Delete existing deployment and deploy
-kubectl delete daemonset.apps/mizar-daemon 2> /tmp/kubetctl.err
-kubectl apply -f $DIR/etc/deploy/$YAML_FILE
+sudo kubectl delete daemonset.apps/mizar-daemon 2> ${KUBECTL_LOG}
+sudo kubectl apply -f $DIR/etc/deploy/$YAML_FILE

--- a/install/deploy_operator.sh
+++ b/install/deploy_operator.sh
@@ -40,4 +40,4 @@ fi
 
 # Delete existing deployment and deploy
 delete_pods mizar-operator deployment
-sudo kubectl apply -f $DIR/etc/deploy/$YAML_FILE
+kubectl apply -f $DIR/etc/deploy/$YAML_FILE

--- a/install/deploy_operator.sh
+++ b/install/deploy_operator.sh
@@ -34,8 +34,8 @@ fi
 
 # Build the operator image
 if [[ "$MODE" == "dev" || "$MODE" == "final" ]]; then
-    sudo docker image build -t $DOCKER_ACC/endpointopr:latest -f $DIR/etc/docker/operator.Dockerfile $DIR
-    sudo docker image push $DOCKER_ACC/endpointopr:latest
+    docker image build -t $DOCKER_ACC/endpointopr:latest -f $DIR/etc/docker/operator.Dockerfile $DIR
+    docker image push $DOCKER_ACC/endpointopr:latest
 fi
 
 # Delete existing deployment and deploy

--- a/install/deploy_operator.sh
+++ b/install/deploy_operator.sh
@@ -22,22 +22,22 @@
 # THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 DIR=${1:-.}
-USER=${2:-dev}
+MODE=${2:-dev}
 DOCKER_ACC=${3:-"localhost:5000"}
 YAML_FILE="dev.operator.deploy.yaml"
 . install/common.sh
 
-if [[ "$USER" == "user" || "$USER" == "final" ]]; then
+if [[ "$MODE" == "user" || "$MODE" == "final" ]]; then
     DOCKER_ACC="mizarnet"
     YAML_FILE="operator.deploy.yaml"
 fi
 
 # Build the operator image
-if [[ "$USER" == "dev" || "$USER" == "final" ]]; then
-    docker image build -t $DOCKER_ACC/endpointopr:latest -f $DIR/etc/docker/operator.Dockerfile $DIR
-    docker image push $DOCKER_ACC/endpointopr:latest
+if [[ "$MODE" == "dev" || "$MODE" == "final" ]]; then
+    sudo docker image build -t $DOCKER_ACC/endpointopr:latest -f $DIR/etc/docker/operator.Dockerfile $DIR
+    sudo docker image push $DOCKER_ACC/endpointopr:latest
 fi
 
 # Delete existing deployment and deploy
 delete_pods mizar-operator deployment
-kubectl apply -f $DIR/etc/deploy/$YAML_FILE
+sudo kubectl apply -f $DIR/etc/deploy/$YAML_FILE

--- a/k8s/kind/create_cluster.sh
+++ b/k8s/kind/create_cluster.sh
@@ -29,18 +29,18 @@ NODES=${3:-1}
 reg_name='local-kind-registry'
 reg_port='5000'
 reg_network='kind'
-running="$(sudo docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
 reg_url=$reg_name
-kind_version=$(sudo kind version)
+kind_version=$(kind version)
 if [ "${running}" != 'true' ]; then
-  sudo docker run \
+  docker run \
     -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
     registry:2
 fi
 
 case "${kind_version}" in
   "kind v0.7."* | "kind v0.6."* | "kind v0.5."*)
-    reg_url="$(sudo docker inspect -f '{{.NetworkSettings.IPAddress}}' "${reg_name}")"
+    reg_url="$(docker inspect -f '{{.NetworkSettings.IPAddress}}' "${reg_name}")"
     reg_network='bridge'
     ;;
 esac
@@ -67,7 +67,7 @@ do
 done
 
 # create a cluster with the local registry enabled in containerd and n Nodes.
-cat <<EOF | sudo kind create cluster --name kind --kubeconfig ${KINDCONF} --config=-
+cat <<EOF | kind create cluster --name kind --kubeconfig ${KINDCONF} --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
@@ -80,8 +80,8 @@ ${FINAL_NODES}
 EOF
 
 if [[ $reg_network == "kind" ]]; then
-  sudo docker network connect $reg_network "${reg_name}"
-  for node in $(sudo kind get nodes); do
+  docker network connect $reg_network "${reg_name}"
+  for node in $(kind get nodes); do
     kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${reg_port}";
   done
 fi

--- a/k8s/kind/create_cluster.sh
+++ b/k8s/kind/create_cluster.sh
@@ -82,6 +82,6 @@ EOF
 if [[ $reg_network == "kind" ]]; then
   sudo docker network connect $reg_network "${reg_name}"
   for node in $(sudo kind get nodes); do
-    sudo kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${reg_port}";
+    kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${reg_port}";
   done
 fi

--- a/kind-setup.sh
+++ b/kind-setup.sh
@@ -65,6 +65,11 @@ MODE=${1:-user}
 NODES=${2:-3}
 timeout=240
 
+if [[ "$MODE" == "dev" ]]; then
+  make clean
+  make all
+fi
+
 sudo kind delete cluster
 sudo docker network rm kind 2> /dev/null
 # All interfaces in the network have an MTU of 9000 to
@@ -97,7 +102,7 @@ source install/create_service_account.sh $CWD
 
 source install/deploy_daemon.sh $CWD $MODE $DOCKER_ACC
 source install/deploy_operator.sh $CWD $MODE $DOCKER_ACC
-source install/create_testimage.sh $CWD $DOCKER_ACC
+source install/create_testimage.sh $CWD $MODE $DOCKER_ACC
 
 end=$((SECONDS + $timeout))
 echo -n "Waiting for cluster to come up."

--- a/kind-setup.sh
+++ b/kind-setup.sh
@@ -25,7 +25,7 @@
 function get_status() {
     OBJECT=$1
 
-    sudo kubectl get $OBJECT 2> ${KUBECTL_LOG} | awk '
+    kubectl get $OBJECT 2> ${KUBECTL_LOG} | awk '
     NR==1 {
         for (i=1; i<=NF; i++) {
             f[$i] = i


### PR DESCRIPTION
This fixes the issue USTC folks hit with kind-setup script by switching from fwnetworking account to mizarnet docker account. 

This PR also enables kind-setup to work for non-root users, and contains a few misc cleanups.