### PR TITLE
Add label values into traffic in agent side and retrieve the values from traffic in transit side

### DIFF
--- a/src/xdp/trn_kern.h
+++ b/src/xdp/trn_kern.h
@@ -54,6 +54,7 @@
 #define TRN_GNV_OPT_CLASS 0x0111
 #define TRN_GNV_RTS_OPT_TYPE 0x48
 #define TRN_GNV_SCALED_EP_OPT_TYPE 0x49
+#define TRN_GNV_LABEL_VALUE_OPT_TYPE 0x50
 
 /* Scaled endpoint messages type */
 #define TRN_SCALED_EP_MODIFY 0x4d // (M: Modify)
@@ -76,6 +77,21 @@ struct trn_gnv_scaled_ep_opt {
 	__u8 r1 : 1;
 	/* opt data */
 	struct trn_gnv_scaled_ep_data scaled_ep_data;
+} __attribute__((packed, aligned(4)));
+
+struct trn_gnv_label_value_data {
+	__u32 value;
+} __attribute__((packed, aligned(4)));
+
+struct trn_gnv_label_value_opt {
+	__be16 opt_class;
+	__u8 type;
+	__u8 length : 5;
+	__u8 r3 : 1;
+	__u8 r2 : 1;
+	__u8 r1 : 1;
+	/* opt data */
+	struct trn_gnv_label_value_data label_value_data;
 } __attribute__((packed, aligned(4)));
 
 struct trn_gnv_rts_data {
@@ -147,6 +163,8 @@ struct transit_packet {
 	struct genevehdr *geneve;
 	struct trn_gnv_rts_opt *rts_opt;
 	struct trn_gnv_scaled_ep_opt *scaled_ep_opt;
+	struct trn_gnv_label_value_opt *pod_label_value_opt;
+	struct trn_gnv_label_value_opt *namespace_label_value_opt;
 	int gnv_hdr_len;
 	int gnv_opt_len;
 

--- a/src/xdp/trn_transit_xdp.c
+++ b/src/xdp/trn_transit_xdp.c
@@ -744,6 +744,13 @@ static __inline int trn_process_geneve(struct transit_packet *pkt)
 		return XDP_ABORTED;
 	}
 
+	if (pkt->pod_label_value_opt->type != TRN_GNV_LABEL_VALUE_OPT_TYPE) {
+		bpf_debug(
+			"[Scaled_EP:%d:0x%x] ABORTED: Unsupported Geneve option type\n",
+			__LINE__, bpf_ntohl(pkt->itf_ipv4));
+		return XDP_ABORTED;
+	}
+
 	pkt->namespace_label_value_opt = (void *)pkt->pod_label_value_opt + sizeof(*pkt->pod_label_value_opt);
 
 	if (pkt->namespace_label_value_opt + 1 > pkt->data_end) {
@@ -755,6 +762,13 @@ static __inline int trn_process_geneve(struct transit_packet *pkt)
 	if (pkt->namespace_label_value_opt->opt_class != TRN_GNV_OPT_CLASS) {
 		bpf_debug(
 			"[Scaled_EP:%d:0x%x] ABORTED: Unsupported Geneve option class\n",
+			__LINE__, bpf_ntohl(pkt->itf_ipv4));
+		return XDP_ABORTED;
+	}
+
+	if (pkt->namespace_label_value_opt->type != TRN_GNV_LABEL_VALUE_OPT_TYPE) {
+		bpf_debug(
+			"[Scaled_EP:%d:0x%x] ABORTED: Unsupported Geneve option type\n",
 			__LINE__, bpf_ntohl(pkt->itf_ipv4));
 		return XDP_ABORTED;
 	}

--- a/src/xdp/trn_transit_xdp.c
+++ b/src/xdp/trn_transit_xdp.c
@@ -729,6 +729,22 @@ static __inline int trn_process_geneve(struct transit_packet *pkt)
 		return XDP_ABORTED;
 	}
 
+	pkt->pod_label_value_opt = (void *)pkt->scaled_ep_opt + sizeof(*pkt->scaled_ep_opt);
+	if (pkt->pod_label_value_opt + 1 > pkt->data_end) {
+		bpf_debug("[Scaled_EP:%d:0x%x] ABORTED: Bad offset\n", __LINE__,
+			  bpf_ntohl(pkt->itf_ipv4));
+		return XDP_ABORTED;
+	}	
+
+	pkt->namespace_label_value_opt = (void *)pkt->pod_label_value_opt + sizeof(*pkt->pod_label_value_opt);
+	if (pkt->namespace_label_value_opt + 1 > pkt->data_end) {
+		bpf_debug("[Scaled_EP:%d:0x%x] ABORTED: Bad offset\n", __LINE__,
+			  bpf_ntohl(pkt->itf_ipv4));
+		return XDP_ABORTED;
+	}
+	// TODO: Handle label based policy from pod_label_value (pkt->pod_label_value_opt->label_value_data.value) 
+	// and namespace_label_value (pkt->namespace_label_value_opt->label_value_data.value)
+
 	return trn_process_inner_eth(pkt);
 }
 

--- a/src/xdp/trn_transit_xdp.c
+++ b/src/xdp/trn_transit_xdp.c
@@ -730,18 +730,35 @@ static __inline int trn_process_geneve(struct transit_packet *pkt)
 	}
 
 	pkt->pod_label_value_opt = (void *)pkt->scaled_ep_opt + sizeof(*pkt->scaled_ep_opt);
+	
 	if (pkt->pod_label_value_opt + 1 > pkt->data_end) {
 		bpf_debug("[Scaled_EP:%d:0x%x] ABORTED: Bad offset\n", __LINE__,
 			  bpf_ntohl(pkt->itf_ipv4));
 		return XDP_ABORTED;
-	}	
+	}
+
+	if (pkt->pod_label_value_opt->opt_class != TRN_GNV_OPT_CLASS) {
+		bpf_debug(
+			"[Scaled_EP:%d:0x%x] ABORTED: Unsupported Geneve option class\n",
+			__LINE__, bpf_ntohl(pkt->itf_ipv4));
+		return XDP_ABORTED;
+	}
 
 	pkt->namespace_label_value_opt = (void *)pkt->pod_label_value_opt + sizeof(*pkt->pod_label_value_opt);
+
 	if (pkt->namespace_label_value_opt + 1 > pkt->data_end) {
 		bpf_debug("[Scaled_EP:%d:0x%x] ABORTED: Bad offset\n", __LINE__,
 			  bpf_ntohl(pkt->itf_ipv4));
 		return XDP_ABORTED;
 	}
+
+	if (pkt->namespace_label_value_opt->opt_class != TRN_GNV_OPT_CLASS) {
+		bpf_debug(
+			"[Scaled_EP:%d:0x%x] ABORTED: Unsupported Geneve option class\n",
+			__LINE__, bpf_ntohl(pkt->itf_ipv4));
+		return XDP_ABORTED;
+	}
+
 	// TODO: Handle label based policy from pod_label_value (pkt->pod_label_value_opt->label_value_data.value) 
 	// and namespace_label_value (pkt->namespace_label_value_opt->label_value_data.value)
 


### PR DESCRIPTION
What does this PR do?
1. Add necessary geneve option structs for label values
2. Add label values intro traffic in agent side
3. Retrieve label values from traffic in transit side

How was this tested?
I did manual e2e test and label values can be retrieved correctly in transit side from packet. 

Are there any user facing / API changes?
No.