### PR TITLE
Network bandwidth rate-limiting via EDT for low priority Pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,10 @@ clean::
 	rm -f *.gcov
 
 .PHONY: test
-test:: lcov functest
+test:: test_docker_image lcov functest
+
+test_docker_image:
+	sudo docker build -f ./test/Dockerfile -t buildbox:v2 ./test
 
 .PHONY: unittest
 unittest::

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,16 +11,19 @@ logout_needed=false
 
 sudo apt-get update
 sudo apt-get install -y \
-    build-essential clang-7 llvm-7 \
+    build-essential \
+    clang-7 \
+    llvm-7 \
     libelf-dev \
     python3.7 \
     python3-pip \
     libcmocka-dev \
     lcov \
-	python3.7-dev \
-	python3-apt \
-	pkg-config \
-	docker.io
+    scapy \
+    python3.7-dev \
+    python3-apt \
+    pkg-config \
+    docker.io
 
 sudo systemctl unmask docker.service
 sudo systemctl unmask docker.socket
@@ -39,7 +42,7 @@ sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
 sudo update-alternatives --set python3 /usr/bin/python3.7
 # Fix for apt-pkg missing when using python3.7
 sudo ln -s /usr/lib/python3/dist-packages/apt_pkg.cpython-36m-x86_64-linux-gnu.so /usr/lib/python3/dist-packages/apt_pkg.so
-sudo pip3 install netaddr docker grpcio grpcio-tools
+sudo pip3 install netaddr docker grpcio grpcio-tools scapy
 
 ver=$(curl -s https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
 curl -Lo kind "https://github.com/kubernetes-sigs/kind/releases/download/$ver/kind-$(uname)-amd64"

--- a/k8s/kind/Dockerfile
+++ b/k8s/kind/Dockerfile
@@ -27,3 +27,5 @@ RUN ln -snf /var/mizar/build/xdp /trn_xdp
 RUN ln -snf /var/mizar/etc/cni/10-mizarcni.conf /etc/cni/net.d/10-mizarcni.conf
 RUN ln -snf /var/mizar/mizar/cni.py /opt/cni/bin/mizarcni
 RUN ln -snf /var/mizar/build/tests/mizarcni.config /etc/mizarcni.config
+
+RUN apt-get update -y && apt-get install -y bridge-utils

--- a/kind-setup.sh
+++ b/kind-setup.sh
@@ -126,7 +126,6 @@ source install/create_crds.sh $CWD
 source install/create_service_account.sh $CWD
 
 source install/deploy_daemon.sh $CWD $MODE $DOCKER_ACC
-sleep 5
 source install/deploy_operator.sh $CWD $MODE $DOCKER_ACC
 source install/create_testimage.sh $CWD $MODE $DOCKER_ACC
 

--- a/mizar/common/constants.py
+++ b/mizar/common/constants.py
@@ -40,6 +40,9 @@ class CONSTANTS:
     XDP_GENERIC = "2"
     XDP_DRIVER = "4"
     XDP_OFFLOAD = "8"
+    MIZAR_BRIDGE = "mzbr0"
+    MIZAR_EGRESS_BW_TAG = "mizar.com/egress-bandwidth"
+    MIZAR_INGRESS_BW_TAG = "mizar.com/ingress-bandwidth"
 
 
 class OBJ_STATUS:

--- a/mizar/daemon/app.py
+++ b/mizar/daemon/app.py
@@ -23,7 +23,7 @@ logger = logging.getLogger()
 POOL_WORKERS = 10
 
 
-def init():
+def init(benchmark=False):
     # Setup the droplet's host
     script = (f''' bash -c '\
     nsenter -t 1 -m -u -n -i ls -1 /etc/cni/net.d/*conf* | grep -v '10-mizarcni.conf$' | xargs rm -rf && \
@@ -51,8 +51,16 @@ def init():
     r = subprocess.Popen(cmd, shell=True)
     logging.info("Running transitd")
     time.sleep(1)
+
+    if benchmark:
+        transit_xdp_path = "/trn_xdp/trn_transit_xdp_ebpf.o"
+        tc_edt_ebpf_path = "/trn_xdp/trn_edt_tc_ebpf.o"
+    else:
+        transit_xdp_path = "/trn_xdp/trn_transit_xdp_ebpf_debug.o"
+        tc_edt_ebpf_path = "/trn_xdp/trn_edt_tc_ebpf_debug.o"
+
     config = {
-        "xdp_path": "/trn_xdp/trn_transit_xdp_ebpf_debug.o",
+        "xdp_path": transit_xdp_path,
         "pcapfile": "/bpffs/transit_xdp.pcap",
         "xdp_flag": CONSTANTS.XDP_GENERIC
     }
@@ -63,6 +71,46 @@ def init():
     r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
     output = r.stdout.read().decode().strip()
     logging.info("Running load-transit-xdp: {}".format(output))
+
+    # Setup mizar bridge, update routes, and load EDT TC eBPF program
+    brscript = (f''' bash -c '\
+    nsenter -t 1 -m -u -n -i ip link add {CONSTANTS.MIZAR_BRIDGE} type bridge && \
+    nsenter -t 1 -m -u -n -i sysctl -w net.bridge.bridge-nf-call-iptables=0 && \
+    nsenter -t 1 -m -u -n -i ip link set dev {CONSTANTS.MIZAR_BRIDGE} up && \
+    nsenter -t 1 -m -u -n -i ip link set eth0 master {CONSTANTS.MIZAR_BRIDGE} && \
+    nsenter -t 1 -m -u -n -i brctl show' ''')
+    r = subprocess.Popen(brscript, shell=True, stdout=subprocess.PIPE)
+    output = r.stdout.read().decode().strip()
+    logging.info("Mizar bridge setup complete.\n{}\n".format(output))
+
+    logging.info("Node IP: {}".format(ip))
+
+    gwcmd = 'nsenter -t 1 -m -u -n -i ip route | grep default | awk \'{print $3}\''
+    r = subprocess.Popen(gwcmd, shell=True, stdout=subprocess.PIPE)
+    defaultgw = r.stdout.read().decode().strip()
+    logging.info("Default gateway: {}".format(defaultgw))
+
+    cidrcmd = 'nsenter -t 1 -m -u -n -i ip route | grep "proto kernel" | awk \'{print $1}\''
+    r = subprocess.Popen(cidrcmd, shell=True, stdout=subprocess.PIPE)
+    nodecidr = r.stdout.read().decode().strip()
+    logging.info("CIDR: {}".format(nodecidr))
+
+    rtscript = (f''' bash -c '\
+    nsenter -t 1 -m -u -n -i ip route change {nodecidr} dev {CONSTANTS.MIZAR_BRIDGE} proto kernel scope link src {ip} && \
+    nsenter -t 1 -m -u -n -i ip route change default via {defaultgw} dev {CONSTANTS.MIZAR_BRIDGE} && \
+    nsenter -t 1 -m -u -n -i ip route show' ''')
+    r = subprocess.Popen(rtscript, shell=True, stdout=subprocess.PIPE)
+    output = r.stdout.read().decode().strip()
+    logging.info("Route update complete.\n{}\n".format(output))
+
+    tcscript = (f''' bash -c '\
+    nsenter -t 1 -m -u -n -i tc qdisc add dev eth0 clsact && \
+    nsenter -t 1 -m -u -n -i tc filter del dev eth0 egress && \
+    nsenter -t 1 -m -u -n -i tc filter add dev eth0 egress bpf da obj {tc_edt_ebpf_path} sec edt && \
+    nsenter -t 1 -m -u -n -i tc filter show dev eth0 egress' ''')
+    r = subprocess.Popen(tcscript, shell=True, stdout=subprocess.PIPE)
+    output = r.stdout.read().decode().strip()
+    logging.info("Load EDT eBPF program done.\n{}\n".format(output))
 
 
 def serve():

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -164,7 +164,8 @@ class InterfaceServer(InterfaceServiceServicer):
         # Network namespace operations (Move these to the CNI)
 
         veth_peer_index = get_iface_index(interface.veth.peer, self.iproute)
-        self.iproute.link('set', index=veth_peer_index, state='up', mtu=9000)
+        mzbr_index = get_iface_index(CONSTANTS.MIZAR_BRIDGE, self.iproute)
+        self.iproute.link('set', index=veth_peer_index, master=mzbr_index, state='up', mtu=9000)
 
         # Configure the Transit Agent
         self._ConfigureTransitAgent(interface)
@@ -429,7 +430,8 @@ class LocalTransitRpc:
             "tunnel_id": interface.address.tunnel_id,
             "ip": interface.address.ip_address,
             "pod_label_value": interface.pod_label_value,
-            "namespace_label_value": interface.namespace_label_value
+            "namespace_label_value": interface.namespace_label_value,
+            "egress_bandwidth_bps": interface.egress_bandwidth_bps
         }
         jsonconf = json.dumps(jsonconf)
         cmd = f'''{self.trn_cli_update_packet_metadata} -i \'{itf}\' -j \'{jsonconf}\''''

--- a/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
+++ b/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
@@ -295,7 +295,8 @@ class EndpointOperator(object):
             bouncers=bouncers,
             status=interface.status,
             pod_label_value=interface.pod_label_value,
-            namespace_label_value=interface.namespace_label_value
+            namespace_label_value=interface.namespace_label_value,
+            egress_bandwidth_bps=interface.egress_bandwidth_bps
         )]
 
         if ep.type == OBJ_DEFAULTS.ep_type_host:
@@ -404,7 +405,8 @@ class EndpointOperator(object):
                 veth=veth,
                 status=InterfaceStatus.init,
                 pod_label_value=str(spec['pod_label_value']),
-                namespace_label_value=str(spec['namespace_label_value'])
+                namespace_label_value=str(spec['namespace_label_value']),
+                egress_bandwidth_bps=str(spec['egress_bandwidth_bps'])
             ))
         if len(interfaces_list) > 0:
             interfaces = InterfacesList(interfaces=interfaces_list)

--- a/mizar/dp/mizar/workflows/builtins/pods/create.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/create.py
@@ -95,6 +95,21 @@ class k8sPodCreate(WorkflowTask):
         ip = n.allocate_ip()
         spec['ip'] = ip
 
+        # Get 'mizar.com/egress-bandwidth' from pod annotations
+        egress_bw_bps = int(0)
+        annotations = self.param.body['metadata'].get('annotations', {})
+        if len(annotations) > 0:
+            k8s_egress_bw_bps = annotations.get(CONSTANTS.MIZAR_EGRESS_BW_TAG)
+            if k8s_egress_bw_bps is not None:
+                egress_bw_bps = k8s_egress_bw_bps
+                if k8s_egress_bw_bps.endswith('K'):
+                    egress_bw_bps = int(float(k8s_egress_bw_bps.replace('K', '')) * 1e3)
+                elif k8s_egress_bw_bps.endswith('M'):
+                    egress_bw_bps = int(float(k8s_egress_bw_bps.replace('M', '')) * 1e6)
+                elif k8s_egress_bw_bps.endswith('G'):
+                    egress_bw_bps = int(float(k8s_egress_bw_bps.replace('G', '')) * 1e9)
+        spec['egress_bandwidth_bps'] = egress_bw_bps
+
         logger.info("Pod spec {}".format(spec))
 
         # make sure not to trigger init or create simple endpoint

--- a/mizar/dp/mizar/workflows/builtins/pods/create.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/create.py
@@ -96,19 +96,21 @@ class k8sPodCreate(WorkflowTask):
         spec['ip'] = ip
 
         # Get 'mizar.com/egress-bandwidth' from pod annotations
-        egress_bw_bps = int(0)
+        egress_bw = int(0)
         annotations = self.param.body['metadata'].get('annotations', {})
         if len(annotations) > 0:
-            k8s_egress_bw_bps = annotations.get(CONSTANTS.MIZAR_EGRESS_BW_TAG)
-            if k8s_egress_bw_bps is not None:
-                egress_bw_bps = k8s_egress_bw_bps
-                if k8s_egress_bw_bps.endswith('K'):
-                    egress_bw_bps = int(float(k8s_egress_bw_bps.replace('K', '')) * 1e3)
-                elif k8s_egress_bw_bps.endswith('M'):
-                    egress_bw_bps = int(float(k8s_egress_bw_bps.replace('M', '')) * 1e6)
-                elif k8s_egress_bw_bps.endswith('G'):
-                    egress_bw_bps = int(float(k8s_egress_bw_bps.replace('G', '')) * 1e9)
-        spec['egress_bandwidth_bps'] = egress_bw_bps
+            k8s_egress_bw = annotations.get(CONSTANTS.MIZAR_EGRESS_BW_TAG)
+            # Convert [B|KB|MB|GB]/s to bits per second.
+            if k8s_egress_bw is not None:
+                if k8s_egress_bw.endswith('K'):
+                    egress_bw = int(float(k8s_egress_bw.replace('K', '')) * 1e3)
+                elif k8s_egress_bw.endswith('M'):
+                    egress_bw = int(float(k8s_egress_bw.replace('M', '')) * 1e6)
+                elif k8s_egress_bw.endswith('G'):
+                    egress_bw = int(float(k8s_egress_bw.replace('G', '')) * 1e9)
+                else:
+                    egress_bw = int(k8s_egress_bw)
+        spec['egress_bandwidth_bps'] = egress_bw * 8
 
         logger.info("Pod spec {}".format(spec))
 

--- a/mizar/proto/mizar/proto/interface.proto
+++ b/mizar/proto/mizar/proto/interface.proto
@@ -76,6 +76,7 @@ message Interface {
   InterfaceStatus status = 8;
   string pod_label_value = 9;
   string namespace_label_value = 10;
+  string egress_bandwidth_bps = 11;
 }
 
 message InterfacesList {

--- a/src/cli/trn_cli_common.c
+++ b/src/cli/trn_cli_common.c
@@ -448,6 +448,7 @@ int trn_cli_parse_packet_metadata(const cJSON *jsonobj, struct rpc_trn_packet_me
 	cJSON *ip = cJSON_GetObjectItem(jsonobj, "ip");
 	cJSON *pod_label_value = cJSON_GetObjectItem(jsonobj, "pod_label_value");
 	cJSON *namespace_label_value = cJSON_GetObjectItem(jsonobj, "namespace_label_value");
+	cJSON *egress_bandwidth_value = cJSON_GetObjectItem(jsonobj, "egress_bandwidth_bps");
 
 	if (cJSON_IsString(tunnel_id)) {
 		packet_metadata->tunid = atoi(tunnel_id->valuestring);
@@ -484,6 +485,17 @@ int trn_cli_parse_packet_metadata(const cJSON *jsonobj, struct rpc_trn_packet_me
 		packet_metadata->namespace_label_value = namespace_label_value->valueint;	
 	} else {
 		print_err("Error: namespace_label_value Error\n");
+		return -EINVAL;
+	}
+
+	if (egress_bandwidth_value == NULL) {
+		packet_metadata->egress_bandwidth_bps = 0;
+	} else if (cJSON_IsString(egress_bandwidth_value)) {
+		packet_metadata->egress_bandwidth_bps = atoi(egress_bandwidth_value->valuestring);
+	} else if (cJSON_IsNumber(egress_bandwidth_value)) {
+		packet_metadata->egress_bandwidth_bps = egress_bandwidth_value->valueint;
+	} else {
+		print_err("Error: egress_bandwidth_value Error\n");
 		return -EINVAL;
 	}
 

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -558,6 +558,32 @@ static void test_update_packet_metadata_1_svc(void **state)
 		.tunid = 3,
 		.pod_label_value = 11,
 		.namespace_label_value = 1,
+		.egress_bandwidth_bps = 250000,
+	};
+
+	int *rc;
+	expect_function_call(__wrap_bpf_map_update_elem);
+	rc = update_packet_metadata_1_svc(&packet_metadata1, NULL);
+	assert_int_equal(*rc, 0);
+}
+
+static void test_update_packet_metadata_egress_bw_1_svc(void **state)
+{
+	UNUSED(state);
+
+	char itf[] = "veth";
+	char vitf[] = "veth0";
+	char hosted_itf[] = "";
+	uint32_t remote[] = { 0x200000a };
+	char mac[6] = { 1, 2, 3, 4, 5, 6 };
+
+	struct rpc_trn_packet_metadata_t packet_metadata1 = {
+		.interface = itf,
+		.ip = 0x100000a,
+		.tunid = 3,
+		.pod_label_value = 0,
+		.namespace_label_value = 0,
+		.egress_bandwidth_bps = 750000,
 	};
 
 	int *rc;
@@ -1645,6 +1671,7 @@ int main()
 		cmocka_unit_test(test_update_agent_md_1_svc),
 		cmocka_unit_test(test_update_agent_ep_1_svc),
 		cmocka_unit_test(test_update_packet_metadata_1_svc),
+		cmocka_unit_test(test_update_packet_metadata_egress_bw_1_svc),
 		cmocka_unit_test(test_update_transit_pod_label_policy_1_svc),
 		cmocka_unit_test(test_update_transit_namespace_label_policy_1_svc),
 		cmocka_unit_test(test_update_transit_pod_and_namespace_label_policy_1_svc),

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1004,10 +1004,10 @@ int *update_packet_metadata_1_svc(rpc_trn_packet_metadata_t *packet_metadata, st
 	struct packet_metadata_t value;
 
 	TRN_LOG_DEBUG("update_packet_metadata_1 packet metadata tunid: %ld, ip: 0x%x,"
-		      " pod_label_value: %d, namespace_label_value: %d",
-		      packet_metadata->tunid, packet_metadata->ip,
-		      packet_metadata->pod_label_value,
-			  packet_metadata->namespace_label_value);
+		" pod_label_value: %d, namespace_label_value: %d, egress_bw: %lu",
+		packet_metadata->tunid, packet_metadata->ip,
+		packet_metadata->pod_label_value, packet_metadata->namespace_label_value,
+		packet_metadata->egress_bandwidth_bps);
 
 	struct agent_user_metadata_t *md = trn_vif_table_find(itf);
 
@@ -1021,7 +1021,8 @@ int *update_packet_metadata_1_svc(rpc_trn_packet_metadata_t *packet_metadata, st
 	memcpy(key.tunip, &packet_metadata->tunid, sizeof(packet_metadata->tunid));	
 	key.tunip[2] = packet_metadata->ip;
 	value.pod_label_value = packet_metadata->pod_label_value;
-	value.namespace_label_value = packet_metadata->namespace_label_value;	
+	value.namespace_label_value = packet_metadata->namespace_label_value;
+	value.egress_bandwidth_bps = packet_metadata->egress_bandwidth_bps;
 
 	rc = trn_agent_update_packet_metadata(md, &key, &value);
 

--- a/src/extern/module.mk
+++ b/src/extern/module.mk
@@ -12,4 +12,4 @@ clean::
 	rm -f src/extern/*.o
 	rm -f src/extern/*.gcda
 	rm -rf lib/*
-	make clean -C src/extern/libbpf/src
+	if [ -d "src/extern/libbpf/src" ]; then make clean -C src/extern/libbpf/src; fi

--- a/src/include/trn_datamodel.h
+++ b/src/include/trn_datamodel.h
@@ -204,3 +204,9 @@ enum conn_status {
 	UNI_DIRECTION 	= 1 << 1,	// reserved; traffic is uni-direction only, or bi-direction
 	FLAG_REEVAL 	= 1 << 2,	// need to re-evaluate allow/deny traffic
 };
+
+struct edt_config_t {
+	__u64 bps;
+	__u64 t_last;
+	__u64 t_horizon_drop;
+} __attribute__((packed));

--- a/src/include/trn_datamodel.h
+++ b/src/include/trn_datamodel.h
@@ -87,6 +87,7 @@ struct packet_metadata_key_t {
 struct packet_metadata_t {
 	__u32 pod_label_value;
 	__u32 namespace_label_value;
+	__u64 egress_bandwidth_bps;
 } __attribute__((packed, aligned(4)));
 
 struct network_key_t {

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -86,6 +86,7 @@ struct rpc_trn_packet_metadata_t {
        uint64_t tunid;
        uint32_t pod_label_value;
        uint32_t namespace_label_value;
+       uint64_t egress_bandwidth_bps;
 };
 
 /* Defines a unique key to get/delete an packet metadata */

--- a/src/xdp/shared_map_defs.h
+++ b/src/xdp/shared_map_defs.h
@@ -160,3 +160,13 @@ struct bpf_map_def SEC("maps") ing_pod_and_namespace_label_policy_map = {
 	.map_flags = 0,
 };
 BPF_ANNOTATE_KV_PAIR(ing_pod_and_namespace_label_policy_map, struct pod_and_namespace_label_policy_t, __u64);
+
+// TC eBPF EDT configuration map
+struct bpf_map_def SEC("maps") edt_config_map = {
+    .type        = BPF_MAP_TYPE_HASH,
+    .key_size    = sizeof(int),
+    .value_size  = sizeof(struct edt_config_t),
+    .max_entries = 1,
+    .map_flags   = 0,
+};
+BPF_ANNOTATE_KV_PAIR(edt_config_map, struct edt_config_t, __u64);

--- a/src/xdp/trn_edt_tc.c
+++ b/src/xdp/trn_edt_tc.c
@@ -1,0 +1,158 @@
+#include <linux/bpf.h>
+#include <linux/pkt_cls.h>
+#include <linux/if_ether.h>
+#include <linux/in.h>
+#include <linux/ip.h>
+#include <linux/udp.h>
+#include <stdint.h>
+#include "extern/bpf_endian.h"
+#include "extern/bpf_helpers.h"
+#include "src/include/trn_datamodel.h"
+#include "trn_kern.h"
+
+#define LOWBPS          (20UL)
+#define ONEKBPS         (1000UL)
+#define TENKBPS         (1000UL * 10)
+#define HUNDREDKBPS     (1000ULL * 100ULL)
+#define ONEMBPS         (1000000ULL)
+#define NSEC_PER_SEC    (1000ULL * 1000ULL * 1000UL)
+#define NSEC_PER_MSEC   (1000ULL * 1000ULL)
+#define NSEC_PER_USEC   (1000UL)
+
+#ifndef __section
+#define __section(NAME)                  \
+	__attribute__((section(NAME), used))
+#endif
+
+#ifndef barrier
+#define barrier()		asm volatile("": : :"memory")
+#endif
+
+#ifndef __READ_ONCE
+#define __READ_ONCE(X)		(*(volatile typeof(X) *)&X)
+#endif
+
+#ifndef __WRITE_ONCE
+#define __WRITE_ONCE(X, V)	(*(volatile typeof(X) *)&X) = (V)
+#endif
+
+/* {READ,WRITE}_ONCE() with verifier workaround via bpf_barrier(). */
+#ifndef READ_ONCE
+#define READ_ONCE(X)						\
+			({ typeof(X) __val = __READ_ONCE(X);	\
+				barrier();			\
+				 __val; })
+#endif
+
+#ifndef WRITE_ONCE
+#define WRITE_ONCE(X, V)					\
+			({ typeof(X) __val = (V);		\
+				__WRITE_ONCE(X, __val);		\
+				barrier();			\
+				__val; })
+#endif
+
+
+struct edt_info {
+    __u64 bps;
+    __u64 t_last;
+    __u64 t_horizon_drop;
+};
+
+struct bpf_map_def SEC("maps") THROTTLE_MAP = {
+    .type        = BPF_MAP_TYPE_HASH,
+    .key_size    = sizeof(int),
+    .value_size  = sizeof(struct edt_info),
+    .max_entries = 1,
+    .map_flags   = 0,
+};
+
+int edt_schedule_departure(struct __sk_buff *skb)
+{
+	int key = 0;
+	struct edt_info *einfo;
+	__u64 delay = 0, now = 0, t = 0, t_next = 0;
+	char einfo_null_msg[] = "ERR: Map not found\n";
+	char einfo_ts_msg[] = "EVAL tlast=%llu now=%llu tstamp=%llu\n";
+	char einfo_ts_set_msg[] = "SET now=%llu dlay=%llu tnxt=%llu\n";
+	char einfo_ts_drop_msg[] = "*DROP* now=%llu dlay=%llu tnxt=%llu\n";
+
+	einfo = (struct edt_info *)bpf_map_lookup_elem(&THROTTLE_MAP, &key);
+	if (!einfo) {
+		bpf_trace_printk(einfo_null_msg, sizeof(einfo_null_msg));
+		return TC_ACT_OK;
+	}
+
+	now = bpf_ktime_get_ns();
+
+	t = skb->tstamp;
+	bpf_trace_printk(einfo_ts_msg, sizeof(einfo_ts_msg), einfo->t_last, now, t);
+	if (t < now) {
+		t = now;
+	}
+	delay = (skb->wire_len) * NSEC_PER_SEC / einfo->bps;
+	t_next = READ_ONCE(einfo->t_last) + delay;
+	if (t_next <= t) {
+		WRITE_ONCE(einfo->t_last, t);
+		return TC_ACT_OK;
+	}
+
+	/* FQ implements a drop horizon, see also 39d010504e6b ("net_sched:
+	 * sch_fq: add horizon attribute"). However, we explicitly need the
+	 * drop horizon here to i) avoid having t_last messed up and ii) to
+	 * potentially allow for per aggregate control.
+	 */
+	if (t_next - now >= einfo->t_horizon_drop) {
+		bpf_trace_printk(einfo_ts_drop_msg, sizeof(einfo_ts_drop_msg), now, delay, t_next);
+		return TC_ACT_SHOT;
+	}
+	WRITE_ONCE(einfo->t_last, t_next);
+
+	bpf_trace_printk(einfo_ts_set_msg, sizeof(einfo_ts_set_msg), now, delay, t_next);
+	skb->tstamp = t_next;
+	return TC_ACT_OK;
+}
+
+__section("edt")
+int tc_edt(struct __sk_buff *skb)
+{
+	//
+	// Set skb->tstamp to enforce EDT rate limiting
+	//
+	int rc = TC_ACT_OK;
+	char in_msg[] = "=====>>>>\n";
+	char out_msg[] = "<<<<===== [TC_Action: %d]\n";
+	char edt_msg[] = "[TC-EDT:0x%x] Low priority packet Dst: 0x%x\n";
+	void *data = (void *)(long)skb->data;
+	void *data_end = (void *)(long)skb->data_end;
+
+	//TODO: User creates this map
+	int key = 0;
+	struct edt_info einfo = {};
+	if (!bpf_map_lookup_elem(&THROTTLE_MAP, &key)) {
+		//einfo.bps = LOWBPS;
+		//einfo.bps = 2 * HUNDREDKBPS;
+		einfo.bps = 6 * ONEKBPS;
+		einfo.t_last = 0;
+		einfo.t_horizon_drop = 2 * NSEC_PER_SEC;
+		bpf_map_update_elem(&THROTTLE_MAP, &key, &einfo, BPF_NOEXIST);
+	}
+
+	if (data + sizeof(struct ethhdr) + sizeof(struct iphdr) + sizeof(struct udphdr) < data_end) {
+		struct ethhdr *eth = data;
+		struct iphdr *ip = (data + sizeof(struct ethhdr));
+		// Enforce EDT only for GENEVE frames classified as MINCOST
+		if (ip->protocol == IPPROTO_UDP) {
+			struct udphdr *udp = (data + sizeof(struct ethhdr) + sizeof(struct iphdr));
+			if ((udp->dest == GEN_DSTPORT) && (ip->tos & IPTOS_MINCOST)) {
+				bpf_trace_printk(in_msg, sizeof(in_msg));
+				bpf_trace_printk(edt_msg, sizeof(edt_msg), ip->saddr, ip->daddr, udp->source);
+				rc = edt_schedule_departure(skb);
+				bpf_trace_printk(out_msg, sizeof(out_msg), rc);
+			}
+		}
+	}
+	return rc;
+}
+
+char __license[] __section("license") = "GPL";

--- a/src/xdp/trn_kern.h
+++ b/src/xdp/trn_kern.h
@@ -180,6 +180,7 @@ struct transit_packet {
 	/* Inner IP */
 	struct iphdr *inner_ip;
 	__u8 inner_ttl;
+	__u8 inner_tos;
 
 	/* Inner udp */
 	struct udphdr *inner_udp;


### PR DESCRIPTION
What does this change do?
This PR adds feature that allows classification of Pods into high and low priority pods for network bandwidth, and uses the EDT algorithm to rate-limit traffic for low priority pods.

Why is it needed?
It partially implements the feature request to ensure high priority Pods have sufficient network bandwidth available to them.
See [design doc](https://docs.google.com/document/d/1zpmKGAYlm5V6M1yfNU0ES_Af1t8YM69oUJrow2sJtu0/edit).

How was this tested?
Manual E2E testing. (Unit tests and automated tests is work in progress)

Are there any user facing / API changes?
No.
