### PR TITLE
Network bandwidth limiting viaEDT - use bytes/sec and use node src IP as key in EDT eBPF map

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,7 @@ clean::
 	rm -f *.gcov
 
 .PHONY: test
-test:: test_docker_image lcov functest
-
-test_docker_image:
-	sudo docker build -f ./test/Dockerfile -t buildbox:v2 ./test
+test:: lcov functest
 
 .PHONY: unittest
 unittest::

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -431,7 +431,7 @@ class LocalTransitRpc:
             "ip": interface.address.ip_address,
             "pod_label_value": interface.pod_label_value,
             "namespace_label_value": interface.namespace_label_value,
-            "egress_bandwidth_bps": interface.egress_bandwidth_bps
+            "egress_bandwidth_bytes_per_sec": interface.egress_bandwidth_bytes_per_sec
         }
         jsonconf = json.dumps(jsonconf)
         cmd = f'''{self.trn_cli_update_packet_metadata} -i \'{itf}\' -j \'{jsonconf}\''''

--- a/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
+++ b/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
@@ -296,7 +296,7 @@ class EndpointOperator(object):
             status=interface.status,
             pod_label_value=interface.pod_label_value,
             namespace_label_value=interface.namespace_label_value,
-            egress_bandwidth_bps=interface.egress_bandwidth_bps
+            egress_bandwidth_bytes_per_sec=interface.egress_bandwidth_bytes_per_sec
         )]
 
         if ep.type == OBJ_DEFAULTS.ep_type_host:
@@ -406,7 +406,7 @@ class EndpointOperator(object):
                 status=InterfaceStatus.init,
                 pod_label_value=str(spec['pod_label_value']),
                 namespace_label_value=str(spec['namespace_label_value']),
-                egress_bandwidth_bps=str(spec['egress_bandwidth_bps'])
+                egress_bandwidth_bytes_per_sec=str(spec['egress_bandwidth_bytes_per_sec'])
             ))
         if len(interfaces_list) > 0:
             interfaces = InterfacesList(interfaces=interfaces_list)

--- a/mizar/dp/mizar/workflows/builtins/pods/create.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/create.py
@@ -100,7 +100,7 @@ class k8sPodCreate(WorkflowTask):
         annotations = self.param.body['metadata'].get('annotations', {})
         if len(annotations) > 0:
             k8s_egress_bw = annotations.get(CONSTANTS.MIZAR_EGRESS_BW_TAG)
-            # Convert [B|KB|MB|GB]/s to bits per second.
+            # Convert [KB|MB|GB]/s to bytes per second.
             if k8s_egress_bw is not None:
                 if k8s_egress_bw.endswith('K'):
                     egress_bw = int(float(k8s_egress_bw.replace('K', '')) * 1e3)
@@ -110,7 +110,7 @@ class k8sPodCreate(WorkflowTask):
                     egress_bw = int(float(k8s_egress_bw.replace('G', '')) * 1e9)
                 else:
                     egress_bw = int(k8s_egress_bw)
-        spec['egress_bandwidth_bps'] = egress_bw * 8
+        spec['egress_bandwidth_bytes_per_sec'] = egress_bw
 
         logger.info("Pod spec {}".format(spec))
 

--- a/mizar/proto/mizar/proto/interface.proto
+++ b/mizar/proto/mizar/proto/interface.proto
@@ -76,7 +76,7 @@ message Interface {
   InterfaceStatus status = 8;
   string pod_label_value = 9;
   string namespace_label_value = 10;
-  string egress_bandwidth_bps = 11;
+  string egress_bandwidth_bytes_per_sec = 11;
 }
 
 message InterfacesList {

--- a/src/cli/test/test_cli.c
+++ b/src/cli/test/test_cli.c
@@ -566,7 +566,7 @@ static int check_packet_metadata_equal(const LargestIntegralType value,
 	if (packet_metadata->namespace_label_value != c_packet_metadata->namespace_label_value) {
 		return false;
 	}
-	if (packet_metadata->egress_bandwidth_bps != c_packet_metadata->egress_bandwidth_bps) {
+	if (packet_metadata->egress_bandwidth_bytes_per_sec != c_packet_metadata->egress_bandwidth_bytes_per_sec) {
 		return false;
 	}
 
@@ -1946,7 +1946,7 @@ static void test_trn_cli_update_packet_metadata_egress_bw_subcmd(void **state)
 		.ip = 0x100000a,
 		.pod_label_value = 0,
 		.namespace_label_value = 0,
-		.egress_bandwidth_bps = 250000,
+		.egress_bandwidth_bytes_per_sec = 250000,
 		.tunid = 0,
 	};
 
@@ -1965,14 +1965,14 @@ static void test_trn_cli_update_packet_metadata_egress_bw_subcmd(void **state)
 			QUOTE({
 				"tunnel_id": "0",
 				"ip": "10.0.0.1",
-				"egress_bandwidth_bps": "250000"
+				"egress_bandwidth_bytes_per_sec": "250000"
 			}),
 			{
 				.interface = "eth0",
 				.ip = 0x100000a,
 				.pod_label_value = 0,
 				.namespace_label_value = 0,
-				.egress_bandwidth_bps = 250000,
+				.egress_bandwidth_bytes_per_sec = 250000,
 				.tunid = 0,
 			},
 			0,
@@ -1983,14 +1983,14 @@ static void test_trn_cli_update_packet_metadata_egress_bw_subcmd(void **state)
 			QUOTE({
 				"tunnel_id": "0",
 				"ip": "10.0.0.1",
-				"egress_bandwidth_bps": 350000
+				"egress_bandwidth_bytes_per_sec": 350000
 			}),
 			{
 				.interface = "eth0",
 				.ip = 0x100000a,
 				.pod_label_value = 0,
 				.namespace_label_value = 0,
-				.egress_bandwidth_bps = 350000,
+				.egress_bandwidth_bytes_per_sec = 350000,
 				.tunid = 0,
 			},
 			0,
@@ -2001,14 +2001,14 @@ static void test_trn_cli_update_packet_metadata_egress_bw_subcmd(void **state)
 			QUOTE({
 				"tunnel_id": "0",
 				"ip": "10.0.0.1",
-				"egress_bandwidth_bps": "0"
+				"egress_bandwidth_bytes_per_sec": "0"
 			}),
 			{
 				.interface = "eth0",
 				.ip = 0x100000a,
 				.pod_label_value = 0,
 				.namespace_label_value = 0,
-				.egress_bandwidth_bps = 0,
+				.egress_bandwidth_bytes_per_sec = 0,
 				.tunid = 0,
 			},
 			0,
@@ -2019,14 +2019,14 @@ static void test_trn_cli_update_packet_metadata_egress_bw_subcmd(void **state)
 			QUOTE({
 				"tunnel_id": "0",
 				"ip": "10.0.0.1",
-				"egress_bandwidth_bps": 0
+				"egress_bandwidth_bytes_per_sec": 0
 			}),
 			{
 				.interface = "eth0",
 				.ip = 0x100000a,
 				.pod_label_value = 0,
 				.namespace_label_value = 0,
-				.egress_bandwidth_bps = 0,
+				.egress_bandwidth_bytes_per_sec = 0,
 				.tunid = 0,
 			},
 			0,
@@ -2037,14 +2037,14 @@ static void test_trn_cli_update_packet_metadata_egress_bw_subcmd(void **state)
 			QUOTE({
 				"tunnel_id": "0",
 				"ip": "10.0.0.1",
-				"egress_bandwidth_bps": ""
+				"egress_bandwidth_bytes_per_sec": ""
 			}),
 			{
 				.interface = "eth0",
 				.ip = 0x100000a,
 				.pod_label_value = 0,
 				.namespace_label_value = 0,
-				.egress_bandwidth_bps = 0,
+				.egress_bandwidth_bytes_per_sec = 0,
 				.tunid = 0,
 			},
 			0,
@@ -2055,14 +2055,14 @@ static void test_trn_cli_update_packet_metadata_egress_bw_subcmd(void **state)
 			QUOTE({
 				"tunnel_id": "0",
 				"ip": "10.0.0.1",
-				"egress_bandwidth_bps": "{123, 456}"
+				"egress_bandwidth_bytes_per_sec": "{123, 456}"
 			}),
 			{
 				.interface = "eth0",
 				.ip = 0x100000a,
 				.pod_label_value = 0,
 				.namespace_label_value = 0,
-				.egress_bandwidth_bps = 0,
+				.egress_bandwidth_bytes_per_sec = 0,
 				.tunid = 0,
 			},
 			-EINVAL,

--- a/src/cli/trn_cli_common.c
+++ b/src/cli/trn_cli_common.c
@@ -448,7 +448,7 @@ int trn_cli_parse_packet_metadata(const cJSON *jsonobj, struct rpc_trn_packet_me
 	cJSON *ip = cJSON_GetObjectItem(jsonobj, "ip");
 	cJSON *pod_label_value = cJSON_GetObjectItem(jsonobj, "pod_label_value");
 	cJSON *namespace_label_value = cJSON_GetObjectItem(jsonobj, "namespace_label_value");
-	cJSON *egress_bandwidth_value = cJSON_GetObjectItem(jsonobj, "egress_bandwidth_bps");
+	cJSON *egress_bandwidth_value = cJSON_GetObjectItem(jsonobj, "egress_bandwidth_bytes_per_sec");
 
 	if (cJSON_IsString(tunnel_id)) {
 		packet_metadata->tunid = atoi(tunnel_id->valuestring);
@@ -489,11 +489,11 @@ int trn_cli_parse_packet_metadata(const cJSON *jsonobj, struct rpc_trn_packet_me
 	}
 
 	if (egress_bandwidth_value == NULL) {
-		packet_metadata->egress_bandwidth_bps = 0;
+		packet_metadata->egress_bandwidth_bytes_per_sec = 0;
 	} else if (cJSON_IsString(egress_bandwidth_value)) {
-		packet_metadata->egress_bandwidth_bps = atoi(egress_bandwidth_value->valuestring);
+		packet_metadata->egress_bandwidth_bytes_per_sec = atoi(egress_bandwidth_value->valuestring);
 	} else if (cJSON_IsNumber(egress_bandwidth_value)) {
-		packet_metadata->egress_bandwidth_bps = egress_bandwidth_value->valueint;
+		packet_metadata->egress_bandwidth_bytes_per_sec = egress_bandwidth_value->valueint;
 	} else {
 		print_err("Error: egress_bandwidth_value Error\n");
 		return -EINVAL;

--- a/src/dmn/test/test_dmn.c
+++ b/src/dmn/test/test_dmn.c
@@ -558,7 +558,7 @@ static void test_update_packet_metadata_1_svc(void **state)
 		.tunid = 3,
 		.pod_label_value = 11,
 		.namespace_label_value = 1,
-		.egress_bandwidth_bps = 250000,
+		.egress_bandwidth_bytes_per_sec = 250000,
 	};
 
 	int *rc;
@@ -583,7 +583,7 @@ static void test_update_packet_metadata_egress_bw_1_svc(void **state)
 		.tunid = 3,
 		.pod_label_value = 0,
 		.namespace_label_value = 0,
-		.egress_bandwidth_bps = 750000,
+		.egress_bandwidth_bytes_per_sec = 750000,
 	};
 
 	int *rc;

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1004,10 +1004,10 @@ int *update_packet_metadata_1_svc(rpc_trn_packet_metadata_t *packet_metadata, st
 	struct packet_metadata_t value;
 
 	TRN_LOG_DEBUG("update_packet_metadata_1 packet metadata tunid: %ld, ip: 0x%x,"
-		" pod_label_value: %d, namespace_label_value: %d, egress_bw: %lu",
+		" pod_label_value: %d, namespace_label_value: %d, egress_bw_bytes_per_sec: %lu",
 		packet_metadata->tunid, packet_metadata->ip,
 		packet_metadata->pod_label_value, packet_metadata->namespace_label_value,
-		packet_metadata->egress_bandwidth_bps);
+		packet_metadata->egress_bandwidth_bytes_per_sec);
 
 	struct agent_user_metadata_t *md = trn_vif_table_find(itf);
 
@@ -1022,7 +1022,7 @@ int *update_packet_metadata_1_svc(rpc_trn_packet_metadata_t *packet_metadata, st
 	key.tunip[2] = packet_metadata->ip;
 	value.pod_label_value = packet_metadata->pod_label_value;
 	value.namespace_label_value = packet_metadata->namespace_label_value;
-	value.egress_bandwidth_bps = packet_metadata->egress_bandwidth_bps;
+	value.egress_bandwidth_bytes_per_sec = packet_metadata->egress_bandwidth_bytes_per_sec;
 
 	rc = trn_agent_update_packet_metadata(md, &key, &value);
 

--- a/src/include/trn_datamodel.h
+++ b/src/include/trn_datamodel.h
@@ -87,7 +87,7 @@ struct packet_metadata_key_t {
 struct packet_metadata_t {
 	__u32 pod_label_value;
 	__u32 namespace_label_value;
-	__u64 egress_bandwidth_bps;
+	__u64 egress_bandwidth_bytes_per_sec;
 } __attribute__((packed, aligned(4)));
 
 struct network_key_t {
@@ -206,7 +206,7 @@ enum conn_status {
 };
 
 struct edt_config_t {
-	__u64 bps;
+	__u64 bytes_per_sec;
 	__u64 t_last;
 	__u64 t_horizon_drop;
 } __attribute__((packed));

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -86,7 +86,7 @@ struct rpc_trn_packet_metadata_t {
        uint64_t tunid;
        uint32_t pod_label_value;
        uint32_t namespace_label_value;
-       uint64_t egress_bandwidth_bps;
+       uint64_t egress_bandwidth_bytes_per_sec;
 };
 
 /* Defines a unique key to get/delete an packet metadata */

--- a/src/xdp/shared_map_defs.h
+++ b/src/xdp/shared_map_defs.h
@@ -160,13 +160,3 @@ struct bpf_map_def SEC("maps") ing_pod_and_namespace_label_policy_map = {
 	.map_flags = 0,
 };
 BPF_ANNOTATE_KV_PAIR(ing_pod_and_namespace_label_policy_map, struct pod_and_namespace_label_policy_t, __u64);
-
-// TC eBPF EDT configuration map
-struct bpf_map_def SEC("maps") edt_config_map = {
-    .type        = BPF_MAP_TYPE_HASH,
-    .key_size    = sizeof(int),
-    .value_size  = sizeof(struct edt_config_t),
-    .max_entries = 1,
-    .map_flags   = 0,
-};
-BPF_ANNOTATE_KV_PAIR(edt_config_map, struct edt_config_t, __u64);

--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -159,12 +159,12 @@ static __inline int trn_encapsulate(struct transit_packet *pkt,
 
 	int pod_label_value = 0;
 	int namespace_label_value = 0;
-	__u64 egress_bw_bps = 0;
+	__u64 egress_bw_bytes_per_sec = 0;
 	packet_metadata = bpf_map_lookup_elem(&packet_metadata_map, &packet_metadata_key);
 	if (packet_metadata) {
 		pod_label_value = packet_metadata->pod_label_value;
 		namespace_label_value = packet_metadata->namespace_label_value;
-		egress_bw_bps = packet_metadata->egress_bandwidth_bps;
+		egress_bw_bytes_per_sec = packet_metadata->egress_bandwidth_bytes_per_sec;
 	}
 
 	/* Readjust the packet size to fit the outer headers */
@@ -236,7 +236,7 @@ static __inline int trn_encapsulate(struct transit_packet *pkt,
 	pkt->ip->ttl = pkt->inner_ttl;
 
 	// Non-zero egress bandwidth configuration => low priority Pod
-	if (egress_bw_bps > 0) {
+	if (egress_bw_bytes_per_sec > 0) {
 		pkt->ip->tos |= IPTOS_MINCOST;
 	}
 	// Support low priority traffic classification from Pod

--- a/src/xdp/trn_edt_tc_maps.h
+++ b/src/xdp/trn_edt_tc_maps.h
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/**
+ * @file trn_edt_tc_maps.h
+ * @author Vinay Kulkarni (@vinaykul)
+ *
+ * @brief EDT (Earliest Departure Time) rate-limiting eBFP program
+ *
+ * @copyright Copyright (c) 2021 The Authors.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#pragma once
+
+#include <linux/bpf.h>
+#include "extern/bpf_helpers.h"
+#include "trn_datamodel.h"
+
+// TC eBPF EDT configuration map
+struct bpf_map_def SEC("maps") edt_config_map = {
+    .type        = BPF_MAP_TYPE_HASH,
+    .key_size    = sizeof(unsigned int),
+    .value_size  = sizeof(struct edt_config_t),
+    .max_entries = 1,
+    .map_flags   = 0,
+};
+BPF_ANNOTATE_KV_PAIR(edt_config_map, struct edt_config_t, __u64);


### PR DESCRIPTION
What does this change do?
This PR fixes egress bandwidth in Mizar code to use bytes per second instead of bits per second to align with the unit used by K8s annotation. 
It also uses the droplet host IP as key for the EDT rate-limiting BFP map.

Why is it needed?
This is a clean consistent way to manage bandwidth units, and use a key that can work for multiple NIC scenarios (when we do that in the future)

How was this tested?
Manual E2E testing. (Unit tests are already in with previous PR

Are there any user facing / API changes?
No.