### PR TITLE
Fix Mizar single yaml deployment SSH issue and add feature-gate for eBPF EDT QoS feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,6 @@ clean::
 	rm -rf build/tests/*
 	rm -f *.gcov
 
-.PHONY: test
-test:: lcov functest
-
 .PHONY: unittest
 unittest::
 

--- a/etc/deploy/deploy.mizar.yaml
+++ b/etc/deploy/deploy.mizar.yaml
@@ -1,4 +1,3 @@
----
 # mizar CRD bouncers.mizar.com
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -444,24 +443,27 @@ spec:
       hostNetwork: true
       hostPID: true
       initContainers:
-        - image: mizarnet/mizar:0.8
-          name: node-init
-          command: [./node-init.sh]
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - name: mizar
-              mountPath: /home
-      containers:
-        - image: mizarnet/dropletd:0.8
-          name: mizar-daemon
-          securityContext:
-            privileged: true
-      volumes:
+      - name: node-init
+        image: mizarnet/mizar:0.8
+        command: [./node-init.sh]
+        securityContext:
+          privileged: true
+        volumeMounts:
         - name: mizar
-          hostPath:
-            path: /var
-            type: Directory
+          mountPath: /home
+      containers:
+      - name: mizar-daemon
+        image: mizarnet/dropletd:0.8
+        env:
+        - name: FEATUREGATE_BWQOS
+          value: 'false'
+        securityContext:
+          privileged: true
+      volumes:
+      - name: mizar
+        hostPath:
+          path: /var
+          type: Directory
 ---
 # mizar deployment of operator
 apiVersion: apps/v1
@@ -486,7 +488,10 @@ spec:
       terminationGracePeriodSeconds: 0
       hostNetwork: true
       containers:
-        - image: mizarnet/endpointopr:0.8
-          name: mizar-operator
-          securityContext:
-            privileged: true
+      - name: mizar-operator
+        image: mizarnet/endpointopr:0.8
+        env:
+        - name: FEATUREGATE_BWQOS
+          value: 'false'
+        securityContext:
+          privileged: true

--- a/etc/deploy/dev.daemon.deploy.yaml
+++ b/etc/deploy/dev.daemon.deploy.yaml
@@ -19,7 +19,6 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
 # THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -43,7 +42,10 @@ spec:
       hostNetwork: true
       hostPID: true
       containers:
-        - image: localhost:5000/dropletd:latest
-          name: mizar-daemon
-          securityContext:
-            privileged: true
+      - name: mizar-daemon
+        image: localhost:5000/dropletd:latest
+        env:
+        - name: FEATUREGATE_BWQOS
+          value: 'true'
+        securityContext:
+          privileged: true

--- a/etc/deploy/dev.operator.deploy.yaml
+++ b/etc/deploy/dev.operator.deploy.yaml
@@ -38,7 +38,10 @@ spec:
       terminationGracePeriodSeconds: 0
       hostNetwork: true
       containers:
-        - image: localhost:5000/endpointopr:latest
-          name: mizar-operator
-          securityContext:
-            privileged: true
+      - name: mizar-operator
+        image: localhost:5000/endpointopr:latest
+        env:
+        - name: FEATUREGATE_BWQOS
+          value: 'true'
+        securityContext:
+          privileged: true

--- a/etc/docker/node-init.sh
+++ b/etc/docker/node-init.sh
@@ -32,6 +32,7 @@ nsenter -t 1 -m -u -n -i apt-get update -y && nsenter -t 1 -m -u -n -i apt-get i
     iproute2  \
     net-tools \
     iputils-ping \
+    bridge-utils \
     ethtool \
     curl \
     python3.7 \

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -164,8 +164,11 @@ class InterfaceServer(InterfaceServiceServicer):
         # Network namespace operations (Move these to the CNI)
 
         veth_peer_index = get_iface_index(interface.veth.peer, self.iproute)
-        mzbr_index = get_iface_index(CONSTANTS.MIZAR_BRIDGE, self.iproute)
-        self.iproute.link('set', index=veth_peer_index, master=mzbr_index, state='up', mtu=9000)
+        if os.getenv('FEATUREGATE_BWQOS', 'false').lower() in ('false', '0'):
+            self.iproute.link('set', index=veth_peer_index, state='up', mtu=9000)
+        else:
+            mzbr_index = get_iface_index(CONSTANTS.MIZAR_BRIDGE, self.iproute)
+            self.iproute.link('set', index=veth_peer_index, master=mzbr_index, state='up', mtu=9000)
 
         # Configure the Transit Agent
         self._ConfigureTransitAgent(interface)

--- a/src/xdp/trn_edt_tc.c
+++ b/src/xdp/trn_edt_tc.c
@@ -67,7 +67,7 @@
 #endif
 
 
-static inline int edt_schedule_departure(struct __sk_buff *skb, __u32 saddr)
+static __ALWAYS_INLINE__ int edt_schedule_departure(struct __sk_buff *skb, __u32 saddr)
 {
 	unsigned int key = saddr;
 	struct edt_config_t *ec;

--- a/src/xdp/trn_transit_xdp.c
+++ b/src/xdp/trn_transit_xdp.c
@@ -73,6 +73,13 @@ static __inline int trn_rewrite_remote_mac(struct transit_packet *pkt)
 
 	trn_set_src_mac(pkt->data, pkt->eth->h_dest);
 	trn_set_dst_mac(pkt->data, remote_ep->mac);
+
+	if (pkt->ip->tos & IPTOS_MINCOST) {
+		bpf_debug("[Transit:0x%x] Low priority pkt saddr:%x -> daddr:%x - XDP_PASS\n",
+			(pkt->itf_ipv4), pkt->ip->saddr, pkt->ip->daddr);
+		return XDP_PASS;
+	}
+
 	return XDP_TX;
 }
 


### PR DESCRIPTION
What does this change do?
This PR fixes issue that caused ssh connectivity to break due to eBPF EDT bandwidth QoS feature.
It also adds a feature-gate to control whether EDT QoS feature is enabled or disabled. (It is currently default disabled for single-yaml deployment but enabled for kind-setup.)
There are also some misc cleanups and housekeeping changes along with this.

Why is it needed?
Fixes issue https://github.com/CentaurusInfra/mizar/issues/501

How was this tested?
Manual testing:
- In kind-setup, deployed cluster and verified with testpod.yaml that bandwidth is policed by eBFP EDT program when map is configured with a rate-limit.
- In AWS (kubeadm setup), verified with testpod.yanl: 
  - with FEATUREGATE_BWQOS set to false, netpod1/2/3 send/recv traffic without any rate limiting.
  - with FEATUREGATE_BWQOS set to true, netpod1/2/3 send/recv traffic with bandwidth policing when eBFP map is configured with a bandwidth limit.


Are there any user facing / API changes?
No.