### PR TITLE
Fix for mizar CNI deployment issue on Ubuntu 20.04

### DIFF
--- a/etc/docker/node-init.sh
+++ b/etc/docker/node-init.sh
@@ -24,6 +24,19 @@
 
 cp -rf /var/mizar /home/
 mkdir -p /etc/cni/net.d
+# check if python is installed ,if yes and check version and install dev pkgs accordingly
+pyversion="3.7"
+version=$(nsenter -t 1 -m -u -n -i python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
+parsedVersion=$(echo "${version//./}")
+if [[ -z "$version" ]] ; then
+  echo "No Python!"
+  # continue with 3.7
+elif [[ "$parsedVersion" -gt "37" ]] ; then
+  echo "Valid version $version"
+  pyversion=$version
+fi
+echo "python "$pyversion
+
 nsenter -t 1 -m -u -n -i apt-get update -y && nsenter -t 1 -m -u -n -i apt-get install -y \
     sudo \
     rpcbind \
@@ -35,16 +48,19 @@ nsenter -t 1 -m -u -n -i apt-get update -y && nsenter -t 1 -m -u -n -i apt-get i
     bridge-utils \
     ethtool \
     curl \
-    python3.7 \
+    python$pyversion \
     lcov \
-    python3.7-dev \
+    python$pyversion-dev \
     python3-apt \
+    python3-testresources \
     libcmocka-dev \
     python3-pip && \
-nsenter -t 1 -m -u -n -i  update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 && \
-nsenter -t 1 -m -u -n -i  update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2 && \
-nsenter -t 1 -m -u -n -i  update-alternatives --set python3 /usr/bin/python3.7 && \
-nsenter -t 1 -m -u -n -i  ln -snf /usr/lib/python3/dist-packages/apt_pkg.cpython-36m-x86_64-linux-gnu.so /usr/lib/python3/dist-packages/apt_pkg.so && \
+if [[ "$parsedVersion" -lt "37" ]] ; then
+  nsenter -t 1 -m -u -n -i update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 &&
+  nsenter -t 1 -m -u -n -i update-alternatives --install /usr/bin/python3 python3 /usr/bin/python$pyversion 2 &&
+  nsenter -t 1 -m -u -n -i update-alternatives --set python3 /usr/bin/python$pyversion &&
+  nsenter -t 1 -m -u -n -i ln -snf /usr/lib/python3/dist-packages/apt_pkg.cpython-36m-x86_64-linux-gnu.so /usr/lib/python3/dist-packages/apt_pkg.so
+fi
 nsenter -t 1 -m -u -n -i mkdir -p /opt/cni/bin && \
 nsenter -t 1 -m -u -n -i mkdir -p /etc/cni/net.d && \
 nsenter -t 1 -m -u -n -i pip3 install --upgrade protobuf && \


### PR DESCRIPTION
**What type of PR is this?**

bug fix
 
**What this PR does / why we need it**:

 - This PR fixes the issue of mizar CNI deployment on Ubuntu 20.04.
 - This will enable to use Python dynamically according to Python version present in OS (3.7<)

**Which issue(s) this PR fixes**:
Fixes #509
 
**How was this tested?**:
Manual Tested:

- In Ubuntu 20.04 and Ubuntu 18.04, tested on single and multi node clusters of k8s (using kubeadm).
- In kind environment on Ubuntu 18.04.