### PR TITLE
Mizar CI Updates

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -1,4 +1,7 @@
-# Mizar kind e2e test workflow
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 The Authors.
+
+# Authors: Phu Tran          <@phudtran>
 
 name: CI
 on:
@@ -16,6 +19,8 @@ jobs:
       matrix:
         python-version: ['3.8.0']
     steps:
+      - name: Permissions
+        run: sudo chown -R $USER:$USER /home/
       - uses: actions/checkout@v2
       - name: Update apt-get
         run: sudo apt-get update
@@ -46,8 +51,8 @@ jobs:
           chmod +x ./kubectl
           sudo mv ./kubectl /usr/local/bin/kubectl
           git submodule update --init --recursive
-      - name: Update Kernel and Linux Headers
-        run: printf 'y\nn\n' | sudo ./kernelupdate.sh
+      # - name: Update Kernel and Linux Headers
+      #   run: printf 'y\nn\n' | sudo ./kernelupdate.sh
       - name: Compile mizar
         run: sudo make clean && make
       - name: Make unittest
@@ -80,3 +85,85 @@ jobs:
       #   if: ${{ failure() }}
       #   uses: mxschmitt/action-tmate@v3
       #   timeout-minutes: 15
+      - name: Cleanup Kind
+        if: ${{ always() }}
+        run: sudo kind delete cluster
+      # Kubeadm tests
+      - name: Start kubeadm
+        run: sudo kubeadm init --pod-network-cidr 20.0.0.0/16
+      - name: kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          yes | sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+          sudo chown $(id -u):$(id -g) $HOME/.kube/config
+      - name: Join workers
+        run: |
+          ssh ciw1 "sudo $(sudo kubeadm token create --print-join-command)"
+          ssh ciw2 "sudo $(sudo kubeadm token create --print-join-command)"
+      - name: build container images
+        run: |
+          sudo docker build -t mizar:0.8 -f etc/docker/mizar.Dockerfile .
+          sudo docker build -t dropletd:0.8 -f etc/docker/daemon.Dockerfile .
+          sudo docker build -t endpointopr:0.8 -f etc/docker/operator.Dockerfile .
+
+          ssh ciw1 "sudo rm -rf ~/mizar"
+          ssh ciw2 "sudo rm -rf ~/mizar"
+
+          scp -r ~/actions-runner/_work/mizar/mizar ciw1:
+          scp -r ~/actions-runner/_work/mizar/mizar ciw2:
+
+          ssh ciw1 "cd mizar && make"
+          ssh ciw2 "cd mizar && make"
+
+          ssh ciw1 "cd ~/mizar && sudo docker build -t mizar:0.8 -f ~/mizar/etc/docker/mizar.Dockerfile ."
+          ssh ciw1 "cd ~/mizar && sudo docker build -t dropletd:0.8 -f ~/mizar/etc/docker/daemon.Dockerfile ."
+          ssh ciw1 "cd ~/mizar && sudo docker build -t endpointopr:0.8 -f ~/mizar/etc/docker/operator.Dockerfile ."
+    
+          ssh ciw2 "cd ~/mizar && sudo docker build -t mizar:0.8 -f ~/mizar/etc/docker/mizar.Dockerfile ."
+          ssh ciw2 "cd ~/mizar && sudo docker build -t dropletd:0.8 -f ~/mizar/etc/docker/daemon.Dockerfile ."
+          ssh ciw2 "cd ~/mizar && sudo docker build -t endpointopr:0.8 -f ~/mizar/etc/docker/operator.Dockerfile ."
+      - name: deploy mizar
+        run: kubectl create -f etc/deploy/deploy.mizar.ci.yaml
+      - name: check ready
+        run: source install/common.sh && check_all_ready
+      - name: run tests
+        run: sudo make e2efunctest
+      - name: Test failure, Dump Operator and daemon Logs
+        if: ${{ failure() }}
+        run: sudo kubectl get pods | grep mizar-operator | awk '{print $1}' | xargs -i kubectl logs {} && kubectl get pods | grep mizar-daemon | awk '{print $1}' | xargs -i kubectl logs {}
+      # Always pass cleanup stage
+      - name: cleanup kubeadm
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          yes | sudo kubeadm reset
+          ssh ciw1 "yes | sudo kubeadm reset"
+          ssh ciw2 "yes | sudo kubeadm reset"
+      - name: cleanup interfaces
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          sudo ip l delete $(ip l | grep -Po "(br-\w+)(?=:)")
+          for name in $(ip l |  grep -Po '(veth-\w+)(?=@)'); do sudo ip l delete $name; done
+          ssh ciw1 "ip l |  grep -Po '(veth-\w+)(?=@)' | awk '{print $1}' | xargs -i sudo ip l delete {}"
+          ssh ciw2 "ip l |  grep -Po '(veth-\w+)(?=@)' | awk '{print $1}' | xargs -i sudo ip l delete {}"
+      - name: cleanup net namespaces
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          sudo ip -all netns delete
+          ssh ciw1 "sudo ip -all netns delete"
+          ssh ciw2 "sudo ip -all netns delete"
+      - name: cleanup docker containers and images
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          sudo docker stop $(docker ps -aq) && docker system prune -f
+          sudo docker rmi -f $(docker images -a -q)
+          sudo docker volume rm $(docker volume ls -qf dangling=true)
+          ssh ciw1 "sudo docker stop $(docker ps -aq) && docker system prune -f"
+          ssh ciw1 "sudo docker rmi -f $(docker images -a -q)"
+          ssh ciw1 "sudo docker volume rm $(docker volume ls -qf dangling=true)"
+          ssh ciw2 "sudo docker stop $(docker ps -aq) && docker system prune -f"
+          ssh ciw2 "sudo docker rmi -f $(docker images -a -q)"
+          ssh ciw2 "sudo docker volume rm $(docker volume ls -qf dangling=true)"

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -67,7 +67,7 @@ jobs:
         if: ${{ failure() }}
         run: sudo kubectl get pods | grep mizar-operator | awk '{print $1}' | xargs -i kubectl logs {} && kubectl get pods | grep mizar-daemon | awk '{print $1}' | xargs -i kubectl logs {}
       - name: Setup tmate ssh session
-        if: ${{ failure() }}
+        if: always()
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: 15
       # - name: Run kind e2e test

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: self-hosted
     strategy:
       matrix:
         python-version: ['3.8.0']
@@ -20,7 +20,8 @@ jobs:
       - name: Update apt-get
         run: sudo apt-get update
       - name: Install packages
-        run: sudo apt-get install -y build-essential clang-7 llvm-7 libelf-dev python3.8 python3-pip libcmocka-dev lcov python3.8-dev python3-apt pkg-config
+      # Remove docker.io if running on github actions hosted.
+        run: sudo apt-get install -y build-essential clang-7 llvm-7 libelf-dev python3.8 python3-pip libcmocka-dev lcov python3.8-dev python3-apt pkg-config docker.io
       - name: Python3.6
         run: sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
       - name: Python3.8
@@ -28,7 +29,7 @@ jobs:
       - name: Python3.8 default
         run: sudo update-alternatives --set python3 /usr/bin/python3.8
       - name: Python3.8 symlink fix
-        run: sudo ln -s /usr/lib/python3/dist-packages/apt_pkg.cpython-36m-x86_64-linux-gnu.so /usr/lib/python3/dist-packages/apt_pkg.so
+        run: sudo ln -snf /usr/lib/python3/dist-packages/apt_pkg.cpython-36m-x86_64-linux-gnu.so /usr/lib/python3/dist-packages/apt_pkg.so
       - name: Update pip
         run: python3 -m pip install --upgrade pip
       - name: Install python packages
@@ -66,15 +67,15 @@ jobs:
       - name: Cluster deployment failure, Dump Operator and daemon Logs
         if: ${{ failure() }}
         run: sudo kubectl get pods | grep mizar-operator | awk '{print $1}' | xargs -i kubectl logs {} && kubectl get pods | grep mizar-daemon | awk '{print $1}' | xargs -i kubectl logs {}
-      - name: Setup tmate ssh session
-        if: always()
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 15
-      # - name: Run kind e2e test
-      #   run: sudo make e2efunctest
-      # - name: Test failure, Dump Operator and daemon Logs
-      #   if: ${{ failure() }}
-      #   run: sudo kubectl get pods | grep mizar-operator | awk '{print $1}' | xargs -i kubectl logs {} && kubectl get pods | grep mizar-daemon | awk '{print $1}' | xargs -i kubectl logs {}
+      # - name: Setup tmate ssh session
+      #   if: always()
+      #   uses: mxschmitt/action-tmate@v3
+      #   timeout-minutes: 15
+      - name: Run kind e2e test
+        run: sudo make e2efunctest
+      - name: Test failure, Dump Operator and daemon Logs
+        if: ${{ failure() }}
+        run: sudo kubectl get pods | grep mizar-operator | awk '{print $1}' | xargs -i kubectl logs {} && kubectl get pods | grep mizar-daemon | awk '{print $1}' | xargs -i kubectl logs {}
       # - name: Setup tmate ssh session
       #   if: ${{ failure() }}
       #   uses: mxschmitt/action-tmate@v3

--- a/etc/deploy/deploy.mizar.ci.yaml
+++ b/etc/deploy/deploy.mizar.ci.yaml
@@ -1,0 +1,497 @@
+# mizar CRD bouncers.mizar.com
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bouncers.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Bouncer
+    plural: bouncers
+    singular: bouncer
+    shortNames:
+      - bncr
+      - bncrs
+  additionalPrinterColumns:
+    - name: vpc
+      type: string
+      priority: 0
+      JSONPath: .spec.vpc
+      description: The VPC of the divider
+    - name: net
+      type: string
+      priority: 0
+      JSONPath: .spec.net
+      description: The Network of the bouncer
+    - name: Ip
+      type: string
+      priority: 0
+      JSONPath: .spec.ip
+      description: The IP of the droplet
+    - name: Mac
+      type: string
+      priority: 0
+      JSONPath: .spec.mac
+      description: The mac address of the divider's droplet
+    - name: Droplet
+      type: string
+      priority: 0
+      JSONPath: .spec.droplet
+      description: The name of the droplet resource
+    - name: Status
+      type: string
+      priority: 0
+      JSONPath: .spec.status
+      description: The Current Status of the divider
+    - name: CreateTime
+      type: string
+      priority: 0
+      JSONPath: .spec.createtime
+      description: Time the object is created
+    - name: ProvisionDelay
+      type: string
+      priority: 0
+      JSONPath: .spec.provisiondelay
+      description: Time to provision an object from creation
+---
+# mizar CRD dividers.mizar.com
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: dividers.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Divider
+    plural: dividers
+    singular: divider
+    shortNames:
+      - divd
+      - divds
+  additionalPrinterColumns:
+    - name: vpc
+      type: string
+      priority: 0
+      JSONPath: .spec.vpc
+      description: The VPC of the divider
+    - name: Ip
+      type: string
+      priority: 0
+      JSONPath: .spec.ip
+      description: The IP of the divider's droplet
+    - name: Mac
+      type: string
+      priority: 0
+      JSONPath: .spec.mac
+      description: The mac address of the divider's droplet
+    - name: Droplet
+      type: string
+      priority: 0
+      JSONPath: .spec.droplet
+      description: The name of the droplet resource
+    - name: Status
+      type: string
+      priority: 0
+      JSONPath: .spec.status
+      description: The Current Status of the divider
+    - name: CreateTime
+      type: string
+      priority: 0
+      JSONPath: .spec.createtime
+      description: Time the object is created
+    - name: ProvisionDelay
+      type: string
+      priority: 0
+      JSONPath: .spec.provisiondelay
+      description: Time to provision an object from creation
+---
+# mizar CRD droplets.mizar.com
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: droplets.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Droplet
+    plural: droplets
+    singular: droplet
+    shortNames:
+      - drp
+      - drps
+  additionalPrinterColumns:
+    - name: Mac
+      type: string
+      priority: 0
+      JSONPath: .spec.mac
+      description: The mac address of the endpoint
+    - name: Ip
+      type: string
+      priority: 0
+      JSONPath: .spec.ip
+      description: The IP of the endpoint
+    - name: Status
+      type: string
+      priority: 0
+      JSONPath: .spec.status
+      description: The Current Status of the droplet
+    - name: Interface
+      type: string
+      priority: 0
+      JSONPath: .spec.itf
+      description: The main interface of the droplet
+    - name: CreateTime
+      type: string
+      priority: 0
+      JSONPath: .spec.createtime
+      description: Time the object is created
+    - name: ProvisionDelay
+      type: string
+      priority: 0
+      JSONPath: .spec.provisiondelay
+      description: Time to provision an object from creation
+---
+# mizar CRD endpoints.mizar.com
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: endpoints.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Endpoint
+    plural: endpoints
+    singular: endpoint
+    shortNames:
+      - ep
+      - eps
+  additionalPrinterColumns:
+    - name: Type
+      type: string
+      priority: 0
+      JSONPath: .spec.type
+      description: The type of the endpoint
+    - name: Mac
+      type: string
+      priority: 0
+      JSONPath: .spec.mac
+      description: The mac address of the endpoint
+    - name: Ip
+      type: string
+      priority: 0
+      JSONPath: .spec.ip
+      description: The IP of the endpoint
+    - name: Gw
+      type: string
+      priority: 0
+      JSONPath: .spec.gw
+      description: The GW of the endpoint
+    - name: Prefix
+      type: string
+      priority: 0
+      JSONPath: .spec.prefix
+      description: The network prefix of the endpoint
+    - name: Status
+      type: string
+      priority: 0
+      JSONPath: .spec.status
+      description: The Current Provisioning Status of the endpoint
+    - name: Network
+      type: string
+      priority: 0
+      JSONPath: .spec.net
+      description: The network of the endpoint
+    - name: Vpc
+      type: string
+      priority: 0
+      JSONPath: .spec.vpc
+      description: The vpc of the endpoint
+    - name: Vni
+      type: string
+      priority: 0
+      JSONPath: .spec.vni
+      description: The VNI of the VPC
+    - name: Droplet
+      type: string
+      priority: 0
+      JSONPath: .spec.droplet
+      description: The droplet hosting the endpoint
+    - name: Interface
+      type: string
+      priority: 0
+      JSONPath: .spec.itf
+      description: The interface name of the endpoint
+    - name: Veth
+      type: string
+      priority: 0
+      JSONPath: .spec.veth
+      description: The veth peer interface name of the endpoint
+    - name: Netns
+      type: string
+      priority: 0
+      JSONPath: .spec.netns
+      description: The netns of the endpoint
+    - name: HostIp
+      type: string
+      priority: 0
+      JSONPath: .spec.hostip
+      description: The Host IP of the endpoint
+    - name: HostMac
+      type: string
+      priority: 0
+      JSONPath: .spec.hostmac
+      description: The Host MAC of the endpoint
+    - name: CreateTime
+      type: string
+      priority: 0
+      JSONPath: .spec.createtime
+      description: Time the object is created
+    - name: ProvisionDelay
+      type: string
+      priority: 0
+      JSONPath: .spec.provisiondelay
+      description: Time to provision an object from creation
+    - name: CniDelay
+      type: string
+      priority: 0
+      JSONPath: .spec.cnidelay
+      description: Time to setup endpoint on droplet
+    - name: Pod
+      type: string
+      priority: 0
+      JSONPath: .spec.pod
+      description: The pod associated with the endpoint
+---
+# mizar CRD subnets.mizar.com
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: subnets.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Subnet
+    plural: subnets
+    singular: subnet
+    shortNames:
+      - subnet
+      - subnets
+  additionalPrinterColumns:
+    - name: Ip
+      type: string
+      priority: 0
+      JSONPath: .spec.ip
+      description: The IP of the NET CIDR block
+    - name: Prefix
+      type: string
+      priority: 0
+      JSONPath: .spec.prefix
+      description: The prefix of the NET CIDR block
+    - name: Vni
+      type: string
+      priority: 0
+      JSONPath: .spec.vni
+      description: The VNI of the VPC
+    - name: Vpc
+      type: string
+      priority: 0
+      JSONPath: .spec.vpc
+      description: The name of the VPC
+    - name: Status
+      type: string
+      priority: 0
+      JSONPath: .spec.status
+      description: The Current Provisioning Status of the net
+    - name: Bouncers
+      type: integer
+      priority: 0
+      JSONPath: .spec.bouncers
+      description: The number of bouncers of the Net
+    - name: CreateTime
+      type: string
+      priority: 0
+      JSONPath: .spec.createtime
+      description: Time the object is created
+    - name: ProvisionDelay
+      type: string
+      priority: 0
+      JSONPath: .spec.provisiondelay
+      description: Time to provision an object from creation
+---
+# mizar CRD vpcs.mizar.com
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: vpcs.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Vpc
+    plural: vpcs
+    singular: vpc
+    shortNames:
+      - vpc
+      - vpcs
+  additionalPrinterColumns:
+    - name: Ip
+      type: string
+      priority: 0
+      JSONPath: .spec.ip
+      description: The IP of the VPC CIDR block
+    - name: Prefix
+      type: string
+      priority: 0
+      JSONPath: .spec.prefix
+      description: The prefix of the VPC CIDR block
+    - name: Vni
+      type: string
+      priority: 0
+      JSONPath: .spec.vni
+      description: The VNI of the VPC
+    - name: Dividers
+      type: integer
+      priority: 0
+      JSONPath: .spec.dividers
+      description: The number of dividers of the VPC
+    - name: Status
+      type: string
+      priority: 0
+      JSONPath: .spec.status
+      description: The Current Provisioning Status of the net
+    - name: CreateTime
+      type: string
+      priority: 0
+      JSONPath: .spec.createtime
+      description: Time the object is created
+    - name: ProvisionDelay
+      type: string
+      priority: 0
+      JSONPath: .spec.provisiondelay
+      description: Time to provision an object from creation
+---
+# mizar service account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mizar-operator
+---
+# mizar cluster role binding
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mizar-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: mizar-operator
+    namespace: default
+---
+# mizar daemon set of node agents
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: mizar-daemon
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      job: mizar-daemon
+  template:
+    metadata:
+      labels:
+        job: mizar-daemon
+    spec:
+      tolerations:
+        # The daemon shall run on the master node
+        - effect: NoSchedule
+          operator: Exists
+      serviceAccountName: mizar-operator
+      terminationGracePeriodSeconds: 0
+      hostNetwork: true
+      hostPID: true
+      initContainers:
+      - name: node-init
+        image: mizar:0.8
+        command: [./node-init.sh]
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: mizar
+          mountPath: /home
+      containers:
+      - name: mizar-daemon
+        image: dropletd:0.8
+        env:
+        - name: FEATUREGATE_BWQOS
+          value: 'false'
+        securityContext:
+          privileged: true
+      volumes:
+      - name: mizar
+        hostPath:
+          path: /var
+          type: Directory
+---
+# mizar deployment of operator
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mizar-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mizar-operator
+  template:
+    metadata:
+      labels:
+        app: mizar-operator
+        mizar: operator
+    spec:
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      serviceAccountName: mizar-operator
+      terminationGracePeriodSeconds: 0
+      hostNetwork: true
+      containers:
+      - name: mizar-operator
+        image: endpointopr:0.8
+        env:
+        - name: FEATUREGATE_BWQOS
+          value: 'false'
+        securityContext:
+          privileged: true

--- a/install/common.sh
+++ b/install/common.sh
@@ -85,7 +85,22 @@ function common:check_mizar_ready {
     fi
 }
 
-
+function check_all_ready {
+    timeout=360
+    KUBECTL_LOG="/tmp/${USER}_kubetctl.err"
+    end=$((SECONDS + $timeout))
+    echo -n "Waiting for cluster to come up."
+    while [[ $SECONDS -lt $end ]]; do
+        common:check_mizar_ready || break
+    done
+    echo
+    if [[ $SECONDS -lt $end ]]; then
+        echo "Cluster now ready!"
+    else
+        echo "ERROR: Cluster setup timed out after $timeout seconds!"
+        exit 1
+    fi
+}
 
 # Polymorphism implementation: There are multiple environment adaptors. Each one is implementation differently based on environment, but share same function.
 function common:source_environment_adaptor {    

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     },
     install_requires=[
         'PyYAML',
+        'setuptools',
         'kopf',
         'netaddr',
         'ipaddress',
@@ -21,6 +22,7 @@ setup(
         'grpcio',
         'scapy',
         'protobuf',
-        'fs'
+        'fs',
+        'grpcio_tools'
     ]
 )

--- a/teste2e/common/helper.py
+++ b/teste2e/common/helper.py
@@ -6,8 +6,6 @@ from netaddr import *
 logger = logging.getLogger("transit_test")
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
 
-TEST_CLUSTER = 'kind'
-
 
 def run_cmd(cmd_list):
     result = subprocess.Popen(cmd_list, shell=True, stdout=subprocess.PIPE)

--- a/teste2e/common/k8s.py
+++ b/teste2e/common/k8s.py
@@ -20,19 +20,20 @@ class k8sCluster:
     def _init(self):
         logger.info("Check or start existing cluster")
         if not self.is_running(self):
-            self.start_cluster(self)
+            logger.info("Starting Kind cluster!")
+            self.start_kind_cluster(self)
         else:
             logger.info("Test cluster is already running")
 
-    def start_cluster(self):
+    def start_kind_cluster(self):
         logger.info("Start test cluster")
         run_cmd("./kind-setup.sh dev 2")
 
     def is_running(self):
-        ret, val = run_cmd("kind get clusters")
-        return val.strip() == TEST_CLUSTER
+        ret, val = run_cmd("kubectl cluster-info | grep -c 'running'")
+        return int(val.strip()) == 2
 
-    def delete_cluster(self):
+    def delete_kind_cluster(self):
         logger.info("Delete test cluster")
         run_cmd("kind delete cluster")
 
@@ -71,7 +72,7 @@ class k8sApi:
             },
             'spec': {
                 'containers': [{
-                    'image': 'localhost:5000/testpod:latest',
+                    'image': 'mizarnet/testpod:latest',
                     'name': 'box1'
                 }]
             }

--- a/teste2e/test_basic_simple_endpoint.py
+++ b/teste2e/test_basic_simple_endpoint.py
@@ -15,9 +15,10 @@ class test_basic_simple_endpoint(unittest.TestCase):
         self.ep2 = self.api.create_pod(self.test_name + "ep2")
 
     def tearDown(self):
-        logger.info("Tearing down endpoints....")
-        self.api.delete_pod(self.test_name + "ep1")
-        self.api.delete_pod(self.test_name + "ep2")
+        pass
+        # logger.info("Tearing down endpoints....")
+        # self.api.delete_pod(self.test_name + "ep1")
+        # self.api.delete_pod(self.test_name + "ep2")
 
     def test_basic_simple_endpoint(self):
         do_common_tests(self, self.ep1, self.ep2)


### PR DESCRIPTION
This PR does the following

- Enables mizar icmp, udp, tcp, and http test on Kind and KubeADM 3-node cluster