### PR TITLE
Fix instructions and bootstrap script to address kind deployment failure

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -64,7 +64,6 @@ if [ ! -f /usr/local/bin/kind ]; then
 fi
 
 git submodule update --init --recursive
-make
 
 kernel_ver=`uname -r`
 echo "Running kernel version: $kernel_ver"

--- a/docs/user/getting_started.md
+++ b/docs/user/getting_started.md
@@ -23,52 +23,72 @@ THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 # Basic Usage
 
-To start running Mizar, first you will need a Kubernetes cluster. Running Mizar will  install experimental features on your cluster. **It is recommended that you use a test cluster to run Mizar.**
+To run Mizar, you will need a Kubernetes cluster.
+**NOTE: Running Mizar will install experimental features on your cluster. It is recommended that you use a test cluster to run Mizar.**
+
+There are two ways to explore Mizar with Kubernetes:
+1. Create a new Kubernetes cluster using Kind (Kubernetes in Docker)
+2. Deploy on an existing Kubernetes cluster (e.g. A cluster created with kubeadm)
+
+The recommended way to try out Mizar is with Kind. Kind can be used to run a simulated multi-node Kubernetes cluster
+using Docker containers locally on your machine.
+
 
 ## Prerequisites
 
-### Kind (Kubernetes in Docker)
+### System Requirements
 
-**Note**: As of writing this, there is an error in the installation instructions for Kind.
-The commands below can be used to download and install the latest release binary for Kind.
+* Mizar scripts have been tested with Ubuntu 18.04.05.
+* It is recommended that the nodes have atleast 4 CPUs, 16G memory, and 200Gb disk space.
+
+To get the Mizar repository from github:
+```bash
+git clone https://github.com/centaurus-cloud/mizar
+```
+
+### Bootstraping nodes for Mizar
+
+* Enter the mizar directory and run the bootstrap script:
+```bash
+./bootstrap.sh
+```
+
+  * This script will install the neccessary components to compile Mizar, and run it's unit tests. These include
+    * [Clang-7](https://clang.llvm.org) (For code compilation)
+    * [Llvm-7](https://llvm.org) (For code compilation)
+    * [Cmocka](https://cmocka.org) (For unit testing)
+    * [Build Essentials](https://packages.ubuntu.com/xenial/build-essential) (For code compilation)
+    * [Python](https://www.python.org) (For running the management plane and tests)
+    * [Docker](https://www.docker.com) (For management plane and tests)
+    * There is also an optional kernel update included in the script if you wish to update to a compatible version
+
+
+## Creating a new Kind cluster with Mizar
+
+**Note**: Before proceeding with the setup script below, please make sure you have [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) and [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) installed.
+Validate your kind and kubectl installations by running:
+
+```bash
+kind --version
+```
+
+```bash
+kubectl version --client
+```
+
+If bootstrap script encountered errors in the installation of Kind, the commands below can be used to download and install the latest release binary for Kind.
 
 MacOS/Linux
-```
+```bash
 ver=$(curl -s https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
 curl -Lo kind "https://github.com/kubernetes-sigs/kind/releases/download/$ver/kind-$(uname)-amd64"
 chmod +x kind
 mv kind /usr/local/bin
 ```
 
-The recommended way to try out Mizar is with Kind.
-Kind can be used to run a multi-node Kubernetes cluster with Docker containers locally on your machine.
-You can find [instructions for installing Kind on it's official site here.](https://kind.sigs.k8s.io/docs/user/quick-start/)
-
-* Enter the mizar directory and run the ```bootstrap.sh``` script.
-    * This script will install the neccessary components to compile Mizar, and run it's unit tests. These include
-        * [Clang-7](https://clang.llvm.org) (For code compilation)
-        * [Llvm-7](https://llvm.org) (For code compilation)
-         * [Cmocka](https://cmocka.org) (For unit testing)
-        * [Build Essentials](https://packages.ubuntu.com/xenial/build-essential) (For code compilation)
-        * [Python](https://www.python.org) (For running the management plane and tests)
-        * [Docker](https://www.docker.com) (For management plane and tests)
-    * There is also an optional kernel update included in the script if you wish to update to a compatible version
-
-#### New Kind Cluster
-**Note**: Before proceeding with the setup script below, please make sure you have [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) and [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) installed.
-Validate your kind and kubectl installations by running:
-
-```
-$ kind --version
-
-$ kubectl version --client
-```
-
-If you are testing out Mizar with Kind, a script has been included to setup a local Kubernetes cluster, and install all of the components needed to run Mizar.
-Simply run the script below in the Mizar directory.
-
-```
-$ ./kind-setup.sh
+To bring up a Kind clutster with Mizar, do:
+```bash
+./kind-setup.sh
 ```
 
 This script does the following:
@@ -80,27 +100,18 @@ This script does the following:
 * Deploy the Mizar Daemon
 * Install the Mizar CNI Plugin
 
-### Install Mizar as Kubernetes CNI plugin
-Mizar can be installed as network plugin to any Kubernetes cluster. Below has been verified to work for Ubuntu 20.04.1 LTS (on AWS EC2 VM).
+
+## Install Mizar on an existing Kubernetes cluster
+
+Mizar can be installed as network plugin to any Kubernetes cluster. Below has been verified to work for Ubuntu 18.04.05 LTS (on AWS EC2 VM).
 
 If a Kuberneetes cluster has kube-proxy daemonSet running, the simple one line would have Mizar installed:
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/CentaurusInfra/mizar/dev-next/etc/deploy/deploy.mizar.components.yaml
+kubectl apply -f https://raw.githubusercontent.com/CentaurusInfra/mizar/dev-next/etc/deploy/deploy.mizar.yaml
 ```
 
-If the cluster has no kube-proxy (e.g. cluster being started using kubeadm init --skip-phases=addon/kube-proxy), you need to run below first:
-```bash
-kubectl create configmap mizar-k8s-config --from-literal=k8sapihost="<kube-api-server-ip>" --from-literal=k8sapiport="<kube-api-server-port>"
-```
-where the kube-api-server-ip and kube-api-server-port can be identified by ```kubectl get endpoint kubernetes```,
-then run following command to have Mizar plugin installed
-```bash
-kubectl apply -f https://raw.githubusercontent.com/CentaurusInfra/mizar/dev-next/etc/deploy/deploy.mizar.components.direct-api-access.yaml
-```
+**Note**: For TCP to function properly, you will need to update your Kernel version to at least 5.6-rc2 on every node. A script, ```kernel_update.sh``` is provided in the Mizar repo to download and update your machine's kernel if you do not wish to build the kernel source code yourself.
 
-### Linux Kernel Update
-
-For TCP to function properly, you will need to update your Kernel version to at least 5.6-rc2 on every node. A script, ```kernel_update.sh``` is provided in the Mizar repo to download and update your machine's kernel if you do not wish to build the kernel source code yourself.
 
 ## Running Mizar Management Plane
 
@@ -112,46 +123,44 @@ There are two states for the resources listed below. *Init* and *Provisioned*. W
 
 You can inspect the following resources by running the commands below with ```kubectl```.
 
-
  * Get all VPCs in the cluster
 
-```
-$ kubectl get vpcs
+```bash
+kubectl get vpcs
 ```
 
  * Get all Networks in the cluster
 
-```
-$ kubectl get subnets
+```bash
+kubectl get subnets
 ```
 
  * Get all Dividers in the cluster
 
-```
-$ kubectl get dividers
+```bash
+kubectl get dividers
 ```
 
  * Get all Bouncers in the cluster
 
-```
-$ kubectl get bouncers
+```bash
+kubectl get bouncers
 ```
 
  * Get all endpoints in the cluster
 
-```
-$ kubectl get endpoints
+```bash
+kubectl get endpoints
 ```
 
 For futhure information on the operations taking place, please look at the logs for the Mizar-Operator, and Mizar-Daemon pods with kubectl.
-
 
 ### Creating an endpoint
 
 Now that the steps above have been completed, simply create a deployment of any kind to test out the network functionality of Mizar.
 A sample deployment with nginx has been included below.
 
-```
+```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -172,9 +181,11 @@ spec:
           ports:
             - containerPort: 80
 ```
+
 Note: To deploy, simply copy this to a file and run
-```
-$ kubectl create -f file_name_here.yaml
+
+```bash
+kubectl create -f file_name_here.yaml
 ```
 
 With 10 replicas as shown in the example, we have Mizar 10 simple endpoints. These endpoints will be a part of the default Network **net0** which itself is part of the default VPC **vpc0**.
@@ -185,7 +196,7 @@ Try out your favorite network test to see the capabilities of Mizar!
 
 If a user wishes to create a new VPC instead of using the initially provided default one, they just need to deploy a yaml file with their desired VPC specifications. A sample has been included below.
 
-```
+```yaml
 apiVersion: mizar.com/v1
 kind: Vpc
 metadata:
@@ -197,9 +208,11 @@ spec:
   dividers: 10
   status: "Init"
 ```
+
 Note: To deploy, simply copy this to a file and run
-```
-$ kubectl create -f file_name_here.yaml
+
+```bash
+kubectl create -f file_name_here.yaml
 ```
 
 This yaml will create a VPC with CIDR range 20.0.0.0/16, a VNI of 1, and 10 initial Dividers.
@@ -208,9 +221,9 @@ This yaml will create a VPC with CIDR range 20.0.0.0/16, a VNI of 1, and 10 init
 
 If a user wishes to create a new Network instead of using the initially provided default one, they just need to deploy a yaml file with their desired Network specifications. A sample has been included below.
 
-```
+```yaml
 apiVersion: mizar.com/v1
-kind: Net
+kind: Subnet
 metadata:
   name: net2
 spec:
@@ -221,9 +234,11 @@ spec:
   vpc: "vpc2"
   status: "Init"
 ```
+
 Note: To deploy, simply copy this to a file and run
-```
-$ kubectl create -f file_name_here.yaml
+
+```bash
+kubectl create -f file_name_here.yaml
 ```
 
 This yaml will create a Network with CIDR range 20.0.20.0/24,a VNI of 1, and 10 initial Bouncers. Notice that the Network's VNI is 1. This Network belongs to the VPC with VNI 1. Thus, its CIDR range is also a subset of the VPC with VNI 1.


### PR DESCRIPTION
KubeEdge team hit issues following our getting started guide, which is outdated, and does not have a good flow. I tried it out and based on my experience, I made the following changes:

- There is no need to run 'make' in bootstrap, so removed it.
- Cleaned up the getting started guide for better flow and readability.
  - Please see: https://github.com/vinaykul/mizar/blob/dev-next/docs/user/getting_started.md