### PR TITLE
Fix for deploying Arktos cluster with Mizar as default CNI plugin

### DIFF
--- a/etc/deploy/deploy.mizar.yaml
+++ b/etc/deploy/deploy.mizar.yaml
@@ -487,6 +487,16 @@ spec:
       serviceAccountName: mizar-operator
       terminationGracePeriodSeconds: 0
       hostNetwork: true
+      initContainers:
+      - name: daemon-init
+        image: mizarnet/endpointopr:0.8
+        command: ["python3"]
+        args: ["/var/mizar/etc/docker/daemon-check.py"]
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: mizar
+          mountPath: /home
       containers:
       - name: mizar-operator
         image: mizarnet/endpointopr:0.8
@@ -495,3 +505,8 @@ spec:
           value: 'false'
         securityContext:
           privileged: true
+      volumes:
+      - name: mizar
+        hostPath:
+          path: /var
+          type: Directory

--- a/etc/deploy/deploy.mizar.yaml
+++ b/etc/deploy/deploy.mizar.yaml
@@ -492,8 +492,6 @@ spec:
         image: mizarnet/endpointopr:0.8
         command: ["python3"]
         args: ["/var/mizar/etc/docker/daemon-check.py"]
-        securityContext:
-          privileged: true
         volumeMounts:
         - name: mizar
           mountPath: /home

--- a/etc/docker/daemon-check.py
+++ b/etc/docker/daemon-check.py
@@ -1,0 +1,17 @@
+from kubernetes import client, config
+import time
+
+
+def daemon_check():
+    config.load_incluster_config()
+    apps = client.AppsV1Api()
+    while True:
+        daemon_status = apps.read_namespaced_daemon_set_status('mizar-daemon', 'default')
+        if daemon_status.status.number_ready >= 1:
+            print('waiting daemon to get ready ...')
+            break
+        time.sleep(1)
+
+
+if __name__ == '__main__':
+    daemon_check()


### PR DESCRIPTION
**What type of PR is this?**
Fixes

**What this PR does / why we need it**:
- Using PR [#1114](https://github.com/CentaurusInfra/arktos/pull/1114), after Arktos cluster gets running, it takes a while to start the mizar-daemon, and once it gets running, we need to delete the mizar-operator pod for the first time. After CNI deployment, VPC and subnet are stuck in init state. Once the mizar-operator pod is recreated, all the network resources gets in provisioned state.
- Once we redeploy the cluster, all the network resources gets provisioned.
- This PR will resolve the above issue to avoid deletion of the mizar-operator pod for the first time.
