### PR TITLE
Configuration of eBPF maps for EDT bandwidth rate-limiting

### DIFF
--- a/mizar/common/constants.py
+++ b/mizar/common/constants.py
@@ -43,6 +43,7 @@ class CONSTANTS:
     MIZAR_BRIDGE = "mzbr0"
     MIZAR_EGRESS_BW_TAG = "mizar.com/egress-bandwidth"
     MIZAR_INGRESS_BW_TAG = "mizar.com/ingress-bandwidth"
+    MIZAR_DEFAULT_EGRESS_BW_LIMIT_PCT = 30
 
 
 class OBJ_STATUS:

--- a/src/cli/trn_cli.c
+++ b/src/cli/trn_cli.c
@@ -72,6 +72,9 @@ static const struct cmd {
 	{ "delete-namespace-label-policy", trn_cli_delete_transit_namespace_label_policy_subcmd },
 	{ "update-pod-and-namespace-label-policy", trn_cli_update_transit_pod_and_namespace_label_policy_subcmd },
 	{ "delete-pod-and-namespace-label-policy", trn_cli_delete_transit_pod_and_namespace_label_policy_subcmd },
+	{ "update-bw-qos-config", trn_cli_update_bw_qos_config_subcmd },
+	{ "delete-bw-qos-config", trn_cli_delete_bw_qos_config_subcmd },
+	{ "get-bw-qos-config", trn_cli_get_bw_qos_config_subcmd },
 	{ 0 },
 };
 

--- a/src/cli/trn_cli.h
+++ b/src/cli/trn_cli.h
@@ -100,6 +100,10 @@ int trn_cli_parse_pod_and_namespace_label_policy(const cJSON *jsonobj,
 					       struct rpc_trn_pod_and_namespace_label_policy_t *ppo);
 int trn_cli_parse_pod_and_namespace_label_policy_key(const cJSON *jsonobj,
 						   struct rpc_trn_pod_and_namespace_label_policy_key_t *ppo_key);
+int trn_cli_parse_bw_qos_config(const cJSON *jsonobj,
+			struct rpc_trn_bw_qos_config_t *bw_qos_config);
+int trn_cli_parse_bw_qos_config_key(const cJSON *jsonobj,
+			struct rpc_trn_bw_qos_config_key_t *bw_qos_config_key);
 
 int trn_cli_update_port_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_update_vpc_subcmd(CLIENT *clnt, int argc, char *argv[]);
@@ -148,6 +152,10 @@ int trn_cli_delete_transit_namespace_label_policy_subcmd(CLIENT *clnt, int argc,
 int trn_cli_update_transit_pod_and_namespace_label_policy_subcmd(CLIENT *clnt, int argc, char *argv[]);
 int trn_cli_delete_transit_pod_and_namespace_label_policy_subcmd(CLIENT *clnt, int argc, char *argv[]);
 
+int trn_cli_update_bw_qos_config_subcmd(CLIENT *clnt, int argc, char *argv[]);
+int trn_cli_delete_bw_qos_config_subcmd(CLIENT *clnt, int argc, char *argv[]);
+int trn_cli_get_bw_qos_config_subcmd(CLIENT *clnt, int argc, char *argv[]);
+
 void dump_vpc(struct rpc_trn_vpc_t *vpc);
 void dump_net(struct rpc_trn_network_t *net);
 void dump_ep(struct rpc_trn_endpoint_t *ep);
@@ -160,4 +168,5 @@ void dump_protocol_port_policy(struct rpc_trn_vsip_ppo_t *ppo);
 void dump_pod_label_policy(struct rpc_trn_pod_label_policy_t *ppo);
 void dump_namespace_label_policy(struct rpc_trn_namespace_label_policy_t *ppo);
 void dump_pod_and_namespace_label_policy(struct rpc_trn_pod_and_namespace_label_policy_t *ppo);
+void dump_bw_qos_config(struct rpc_trn_bw_qos_config_t *bw_qos_config);
 uint32_t parse_ip_address(const cJSON *ipobj);

--- a/src/cli/trn_cli_bw_qos.c
+++ b/src/cli/trn_cli_bw_qos.c
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/**
+ * @file trn_cli_bw_qos.c
+ * @author Vinay Kulkarni		(@vinaykul)
+ *
+ * @brief Transit Agent cli subcommands related to Bandwidth QoS configuration
+ *
+ * @copyright Copyright (c) 2021 The Authors.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+#include "trn_cli.h"
+
+int trn_cli_update_bw_qos_config_subcmd(CLIENT *clnt, int argc, char *argv[])
+{
+	ketopt_t om = KETOPT_INIT;
+	cJSON *json_str = NULL;
+	struct cli_conf_data_t conf;
+
+	if (trn_cli_read_conf_str(&om, argc, argv, &conf)) {
+		return -EINVAL;
+	}
+
+	char *buf = conf.conf_str;
+	json_str = trn_cli_parse_json(buf);
+	if (json_str == NULL) {
+		return -EINVAL;
+	}
+
+	int *rc;
+	rpc_trn_bw_qos_config_t bw_qos_config;
+	char rpc[] = "update_bw_qos_config_1";
+	bw_qos_config.interface = conf.intf;
+
+	int err = trn_cli_parse_bw_qos_config(json_str, &bw_qos_config);
+	cJSON_Delete(json_str);
+	json_str = NULL;
+	if (err != 0) {
+		print_err("Error: parsing bandwidth qos config.\n");
+		return -EINVAL;
+	}
+
+	rc = update_bw_qos_config_1(&bw_qos_config, clnt);
+	if (rc == (int *)NULL) {
+		print_err("Error: call failed: update_bw_qos_config_1.\n");
+		return -EINVAL;
+	}
+	if (*rc != 0) {
+		print_err("Error: %s fatal error, see transitd logs for details.\n",
+				rpc);
+		return -EINVAL;
+	}
+
+	print_msg("update_bw_qos_config_1 successfully updated egress bw limit %lu bytes/sec on interface %s saddr 0x%x.\n",
+			bw_qos_config.egress_bandwidth_bytes_per_sec, bw_qos_config.interface, bw_qos_config.saddr);
+	return 0;
+}
+
+int trn_cli_delete_bw_qos_config_subcmd(CLIENT *clnt, int argc, char *argv[])
+{
+	ketopt_t om = KETOPT_INIT;
+	struct cli_conf_data_t conf;
+	cJSON *json_str = NULL;
+
+	if (trn_cli_read_conf_str(&om, argc, argv, &conf)) {
+		return -EINVAL;
+	}
+
+	char *buf = conf.conf_str;
+	json_str = trn_cli_parse_json(buf);
+	if (json_str == NULL) {
+		return -EINVAL;
+	}
+
+	int *rc;
+	rpc_trn_bw_qos_config_key_t key;
+	char rpc[] = "delete_bw_qos_config_1";
+	key.interface = conf.intf;
+
+	int err = trn_cli_parse_bw_qos_config_key(json_str, &key);
+	cJSON_Delete(json_str);
+	if (err != 0) {
+		print_err("Error: parsing bw qos config key.\n");
+		return -EINVAL;
+	}
+
+	rc = delete_bw_qos_config_1(&key, clnt);
+	if (rc == (int *)NULL) {
+		print_err("Error: call failed: delete_bw_qos_config_1.\n");
+		return -EINVAL;
+	}
+	if (*rc != 0) {
+		print_err("Error: %s fatal error, see transitd logs for details.\n",
+				rpc);
+		return -EINVAL;
+	}
+
+	print_msg("delete_bw_qos_config_1 successfully deleted bw qos config on interface %s.\n",
+			key.interface);
+	return 0;
+}
+
+int trn_cli_get_bw_qos_config_subcmd(CLIENT *clnt, int argc, char *argv[])
+{
+	ketopt_t om = KETOPT_INIT;
+	struct cli_conf_data_t conf;
+	cJSON *json_str = NULL;
+
+	if (trn_cli_read_conf_str(&om, argc, argv, &conf)) {
+		return -EINVAL;
+	}
+
+	char *buf = conf.conf_str;
+	json_str = trn_cli_parse_json(buf);
+	if (json_str == NULL) {
+		return -EINVAL;
+	}
+
+	int *rc;
+	struct rpc_trn_bw_qos_config_key_t bwqoskey;
+	struct rpc_trn_bw_qos_config_t *bwqoscfg;
+	char rpc[] = "get_bw_qos_config_1";
+	bwqoskey.interface = conf.intf;
+
+	int err = trn_cli_parse_bw_qos_config_key(json_str, &bwqoskey);
+	cJSON_Delete(json_str);
+	if (err != 0) {
+		print_err("Error: parsing bw qos config key.\n");
+		return -EINVAL;
+	}
+
+	bwqoscfg = get_bw_qos_config_1(&bwqoskey, clnt);
+	if (bwqoscfg == NULL || strlen(bwqoscfg->interface) == 0) {
+		print_err("RPC Error: client call failed: get_bw_qos_config_1.\n");
+		return -EINVAL;
+	}
+
+	dump_bw_qos_config(bwqoscfg);
+	print_msg("getbw_qos_config_1 successfully queried for saddr 0x%x, interface %s.\n",
+			bwqoscfg->saddr, bwqoscfg->interface);
+	return 0;
+}
+
+void dump_bw_qos_config(struct rpc_trn_bw_qos_config_t *bw_qos_config)
+{
+	print_msg("Interface: %s\n", bw_qos_config->interface);
+	print_msg("Source Address: 0x%x\n", bw_qos_config->saddr);
+	print_msg("Egress Bandwidth: %lu bytes/sec\n", bw_qos_config->egress_bandwidth_bytes_per_sec);
+}

--- a/src/cli/trn_cli_common.c
+++ b/src/cli/trn_cli_common.c
@@ -1154,6 +1154,53 @@ int trn_cli_parse_pod_and_namespace_label_policy_key(const cJSON *jsonobj,
 	return 0;
 }
 
+int trn_cli_parse_bw_qos_config(const cJSON *jsonobj, struct rpc_trn_bw_qos_config_t *bw_qos_config)
+{
+	cJSON *saddr = cJSON_GetObjectItem(jsonobj, "src_addr");
+	cJSON *egress_bandwidth_value = cJSON_GetObjectItem(jsonobj, "egress_bandwidth_bytes_per_sec");
+
+	if (cJSON_IsString(saddr)) {
+		struct in_addr inaddr;
+		inet_pton(AF_INET, saddr->valuestring, &inaddr);
+		bw_qos_config->saddr = htonl(inaddr.s_addr);
+	} else if (cJSON_IsNumber(saddr)) {
+		bw_qos_config->saddr = htonl((unsigned int)saddr->valueint);
+	} else {
+		print_err("Error: trn_cli_parse_bw_qos_config saddr Error\n");
+		return -EINVAL;
+	}
+
+	if (egress_bandwidth_value == NULL) {
+		bw_qos_config->egress_bandwidth_bytes_per_sec = 0;
+	} else if (cJSON_IsString(egress_bandwidth_value)) {
+		bw_qos_config->egress_bandwidth_bytes_per_sec = atoi(egress_bandwidth_value->valuestring);
+	} else if (cJSON_IsNumber(egress_bandwidth_value)) {
+		bw_qos_config->egress_bandwidth_bytes_per_sec = egress_bandwidth_value->valueint;
+	} else {
+		print_err("Error: trn_cli_parse_bw_qos_config egress_bandwidth_value Error\n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+int trn_cli_parse_bw_qos_config_key(const cJSON *jsonobj,
+			 struct rpc_trn_bw_qos_config_key_t *bw_qos_config_key)
+{
+	cJSON *saddr = cJSON_GetObjectItem(jsonobj, "src_addr");
+
+	if (cJSON_IsString(saddr)) {
+		bw_qos_config_key->saddr = atoi(saddr->valuestring);
+	} else if (cJSON_IsNumber(saddr)) {
+		bw_qos_config_key->saddr = saddr->valueint;
+	} else {
+		print_err("Error: trn_cli_parse_bw_qos_config_key saddr Error\n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 uint32_t parse_ip_address(const cJSON *ipobj)
 {
 	struct sockaddr_in sa;

--- a/src/dmn/trn_transit_xdp_usr.h
+++ b/src/dmn/trn_transit_xdp_usr.h
@@ -265,3 +265,13 @@ int trn_update_transit_pod_and_namespace_label_policy_map(struct user_metadata_t
 
 int trn_delete_transit_pod_and_namespace_label_policy_map(struct user_metadata_t *md,
 						        struct pod_and_namespace_label_policy_t *policy);
+
+int trn_update_bw_qos_config(struct user_metadata_t *md,
+				struct bw_qos_config_key_t *bwqoskey,
+				struct bw_qos_config_t *bwqoscfg);
+
+int trn_delete_bw_qos_config(struct user_metadata_t *md, struct bw_qos_config_key_t *bwqoskey);
+
+int trn_get_bw_qos_config(struct user_metadata_t *md,
+				struct bw_qos_config_key_t *bwqoskey,
+				struct bw_qos_config_t *bwqoscfg);

--- a/src/include/trn_datamodel.h
+++ b/src/include/trn_datamodel.h
@@ -205,8 +205,12 @@ enum conn_status {
 	FLAG_REEVAL 	= 1 << 2,	// need to re-evaluate allow/deny traffic
 };
 
-struct edt_config_t {
-	__u64 bytes_per_sec;
+struct bw_qos_config_key_t {
+	__u32 saddr;
+} __attribute__((packed));
+
+struct bw_qos_config_t {
+	__u64 egress_bandwidth_bytes_per_sec;
 	__u64 t_last;
 	__u64 t_horizon_drop;
 } __attribute__((packed));

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -272,6 +272,19 @@ struct rpc_trn_pod_and_namespace_label_policy_key_t {
        uint32_t namespace_label_value;
 };
 
+/* Defines a struct to configure EDT bandwidth limits */
+struct rpc_trn_bw_qos_config_t {
+       string interface<20>;
+       uint32_t saddr;
+       uint64_t egress_bandwidth_bytes_per_sec;
+};
+
+/* Defines a unique key to get/delete EDT bandwith configuration */
+struct rpc_trn_bw_qos_config_key_t {
+       string interface<20>;
+       uint32_t saddr;
+};
+
 /*----- Protocol. -----*/
 
 program RPC_TRANSIT_REMOTE_PROTOCOL {
@@ -327,6 +340,9 @@ program RPC_TRANSIT_REMOTE_PROTOCOL {
                 int UPDATE_TRANSIT_POD_AND_NAMESPACE_LABEL_POLICY(rpc_trn_pod_and_namespace_label_policy_t) = 41;
                 int DELETE_TRANSIT_POD_AND_NAMESPACE_LABEL_POLICY(rpc_trn_pod_and_namespace_label_policy_key_t) = 42;
 
+                int UPDATE_BW_QOS_CONFIG(rpc_trn_bw_qos_config_t) = 43;
+                int DELETE_BW_QOS_CONFIG(rpc_trn_bw_qos_config_key_t) = 44;
+                rpc_trn_bw_qos_config_t GET_BW_QOS_CONFIG(rpc_trn_bw_qos_config_key_t) = 45;
           } = 1;
 
 } =  0x20009051;

--- a/src/xdp/trn_bw_qos_config_maps.h
+++ b/src/xdp/trn_bw_qos_config_maps.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 /**
- * @file trn_edt_tc_maps.h
+ * @file trn_bw_qos_config_maps.h
  * @author Vinay Kulkarni (@vinaykul)
  *
  * @brief EDT (Earliest Departure Time) rate-limiting eBFP program
@@ -25,15 +25,15 @@
 #pragma once
 
 #include <linux/bpf.h>
+#include "extern/bpf_elf.h"
 #include "extern/bpf_helpers.h"
 #include "trn_datamodel.h"
 
-// TC eBPF EDT configuration map
-struct bpf_map_def SEC("maps") edt_config_map = {
+// TC eBPF Bandwidth QoS configuration map
+struct bpf_elf_map SEC("maps") bw_qos_config_map = {
     .type        = BPF_MAP_TYPE_HASH,
-    .key_size    = sizeof(unsigned int),
-    .value_size  = sizeof(struct edt_config_t),
-    .max_entries = 1,
-    .map_flags   = 0,
+    .size_key    = sizeof(struct bw_qos_config_key_t),
+    .size_value  = sizeof(struct bw_qos_config_t),
+    .max_elem    = 1,
+    .pinning     = PIN_GLOBAL_NS,
 };
-BPF_ANNOTATE_KV_PAIR(edt_config_map, struct edt_config_t, __u64);


### PR DESCRIPTION
What does this change do?
This change is to allow configuration of rate-limiting bandwidth value into the eBPF maps that is used by the EDT rate-limiting eBPF program.
Why is it needed? 
This is part of the bandwidth QoS management feature that enables a user process to dynamically configure the limit for low priority traffic based on the monitored usage by high-priority traffic.
How was this tested?
Ping tests and traffic stream tesets.
