### PR TITLE
Fix for containerd restart issue while deploying the Mizar YAML

### DIFF
--- a/etc/docker/node-init.sh
+++ b/etc/docker/node-init.sh
@@ -63,12 +63,12 @@ if [[ "$parsedVersion" -lt "37" ]] ; then
 fi
 nsenter -t 1 -m -u -n -i mkdir -p /opt/cni/bin && \
 nsenter -t 1 -m -u -n -i mkdir -p /etc/cni/net.d && \
+nsenter -t 1 -m -u -n -i ln -snf /var/mizar/mizar/cni.py /opt/cni/bin/mizarcni && \
 nsenter -t 1 -m -u -n -i pip3 install --upgrade protobuf && \
 nsenter -t 1 -m -u -n -i pip3 install --ignore-installed /var/mizar/ && \
 nsenter -t 1 -m -u -n -i ln -snf /sys/fs/bpf /bpffs && \
 nsenter -t 1 -m -u -n -i ln -snf /var/mizar/build/bin /trn_bin && \
 nsenter -t 1 -m -u -n -i ln -snf /var/mizar/build/xdp /trn_xdp && \
-nsenter -t 1 -m -u -n -i ln -snf /var/mizar/etc/cni/10-mizarcni.conf /etc/cni/net.d/10-mizarcni.conf && \
-nsenter -t 1 -m -u -n -i ln -snf /var/mizar/mizar/cni.py /opt/cni/bin/mizarcni && \
+nsenter -t 1 -m -u -n -i cp -f /var/mizar/etc/cni/10-mizarcni.conf /etc/cni/net.d/10-mizarcni.conf && \
 nsenter -t 1 -m -u -n -i ln -snf /var/mizar/build/tests/mizarcni.config /etc/mizarcni.config && \
 echo "mizar-complete"


### PR DESCRIPTION
- This PR fixes the containerd restart issue after applying the Mizar single deployment YAML.
- The conf file should be a regular file and it should be generated after the binary is placed in the respective location.
-  We have tested using the modified image of mizar container (c2cengg20190034/mizar:0.9) on OnPrem as well as GCE.