### PR TITLE
Update python_base image to 3.9

### DIFF
--- a/etc/docker/python_base.Dockerfile
+++ b/etc/docker/python_base.Dockerfile
@@ -19,7 +19,7 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
 # THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-FROM python:3.7
+FROM python:3.9
 RUN apt-get update -y
 RUN apt-get install -y net-tools
 RUN apt-get install -y ethtool


### PR DESCRIPTION
Updated python_base image to fix iproute 2 installation bug.