### PR TITLE
 Fix for bootstrap.sh script to update kernel headers to the latest kernel if ver>=5.6.0

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,6 +11,7 @@ logout_needed=false
 
 sudo apt-get update
 sudo apt-get install -y \
+sudo apt-get install linux-headers-$(uname-r)\
     build-essential \
     clang-7 \
     llvm-7 \
@@ -66,23 +67,42 @@ fi
 git submodule update --init --recursive
 
 kernel_ver=`uname -r`
+kernel_hed=`sudo apt search linux-headers-$(uname -r)`
+
 echo "Running kernel version: $kernel_ver"
+echo "..................................."
+echo "Running kernel headers: $kernel_hed"
+
 mj_ver=$(echo $kernel_ver | cut -d. -f1)
 mn_ver=$(echo $kernel_ver | cut -d. -f2)
+mj_hed=$(echo $kernel_hed | cut -d. -f7 | cut -d- -f3)
+mn_hed=$(echo $kernel_hed | cut -d. -f8)
 
-if [[ "$mj_ver" < "5" ]] || [[ "$mn_ver" < "6" ]]; then
-        tput setaf 1
-	echo "Mizar requires an updated kernel: linux-5.6-rc2 for TCP to function correctly. Current version is $kernel_ver"
-
-	read -p "Execute kernel update script (y/n)?" choice
-	tput sgr0
-	case "$choice" in
-	  y|Y ) sh ./kernelupdate.sh;;
-	  n|N ) echo "Please run kernelupdate.sh to download and update the kernel!"; exit;;
-	  * ) echo "Please run kernelupdate.sh to download and update the kernel!"; exit;;
-	esac
+if ([[ "0$mj_ver" -le "04" ]] || [[ "$mn_ver" -le "05" ]]) || ([[ "$mn_ver" -le "5" ]]); then
+    tput setaf 1
+    echo "Mizar requires an updated kernel: linux-5.6 rc2 for TCP to function correctly. Current version is $kernel_ver"
+    read -p "Execute kernel update script (y/n)?" choice
+    tput sgr0
+    case "$choice" in
+      y|Y ) sh ./kernelupdate.sh;;
+      n|N ) echo "Please run kernelupdate.sh to download and update the kernel!"; exit;;
+      * ) echo "Please run kernelupdate.sh to download and update the kernel!";
+ exit;;
+    esac
+elif
+   [[ "0$mj_ver" != "0$mj_hed" ]] || [[ "$mn_ver" != "$mn_hed" ]]; then
+    tput setf 2
+    echo " Update kernel_header..!! "
+    read -p "Execute kernel_header update command (y/n)?" choice
+    tput sgr0
+    case "$choice" in
+      y|Y ) echo `sudo apt-get install linux-headers-$(uname -r)`;;
+      n|N ) echo "Please run kernelheader to download and update
+ the kernel_header!"; exit;;
+      * ) echo "Please run kernelheader to download and update
+ the kernel_header!"; exit;;
+    esac
 fi
-
 if [ "$logout_needed" = true ]; then
     logout
 fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -66,18 +66,23 @@ fi
 git submodule update --init --recursive
 
 kernel_ver=`uname -r`
-kernel_hed=`sudo apt search linux-headers-$(uname -r)`
+kernel_header_ver=`sudo apt search linux-headers-$(uname -r)`
 
 echo "Running kernel version: $kernel_ver"
-echo "..................................."
-echo "Running kernel headers: $kernel_hed"
+echo ".................................................."
+echo "Running kernel header version: $kernel_header_ver"
 
 mj_ver=$(echo $kernel_ver | cut -d. -f1)
 mn_ver=$(echo $kernel_ver | cut -d. -f2)
-mj_hed=$(echo $kernel_hed | cut -d. -f7 | cut -d- -f3)
-mn_hed=$(echo $kernel_hed | cut -d. -f8)
+mj_header_ver=$(echo $kernel_header_ver | cut -d. -f7 | cut -d- -f3)
+mn_header_ver=$(echo $kernel_header_ver | cut -d. -f8)
 
-if ([[ "0$mj_ver" -le "04" ]] || [[ "$mn_ver" -le "05" ]]) || ([[ "$mn_ver" -le "5" ]]); then
+echo "$mj_ver"
+echo "$mn_ver"
+echo "$mj_header_ver"
+echo "$mn_header_ver"
+
+if ( [ "$mj_ver" -le 5 ] && [ "$mn_ver" -le 5 ] ) || ( [ "$mj_ver" -le 4 ] && [ "$mn_ver" -gt 5 ] ) ; then
     tput setaf 1
     echo "Mizar requires an updated kernel: linux-5.6 rc2 for TCP to function correctly. Current version is $kernel_ver"
     read -p "Execute kernel update script (y/n)?" choice
@@ -85,23 +90,15 @@ if ([[ "0$mj_ver" -le "04" ]] || [[ "$mn_ver" -le "05" ]]) || ([[ "$mn_ver" -le 
     case "$choice" in
       y|Y ) sh ./kernelupdate.sh;;
       n|N ) echo "Please run kernelupdate.sh to download and update the kernel!"; exit;;
-      * ) echo "Please run kernelupdate.sh to download and update the kernel!";
- exit;;
+      * ) echo "Please run kernelupdate.sh to download and update the kernel!"; exit;;
     esac
-elif
-   [[ "0$mj_ver" != "0$mj_hed" ]] || [[ "$mn_ver" != "$mn_hed" ]]; then
+elif [[ "$mj_ver" != "$mj_header_ver" ]] || [[ "$mn_ver" != "$mn_header_ver" ]]; then
     tput setf 2
     echo " Update kernel_header..!! "
-    read -p "Execute kernel_header update command (y/n)?" choice
     tput sgr0
-    case "$choice" in
-      y|Y ) echo `sudo apt-get install linux-headers-$(uname -r)`;;
-      n|N ) echo "Please run kernelheader to download and update
- the kernel_header!"; exit;;
-      * ) echo "Please run kernelheader to download and update
- the kernel_header!"; exit;;
-    esac
+    sudo apt-get install linux-headers-$(uname -r)
 fi
+
 if [ "$logout_needed" = true ]; then
     logout
 fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,7 +11,6 @@ logout_needed=false
 
 sudo apt-get update
 sudo apt-get install -y \
-sudo apt-get install linux-headers-$(uname-r)\
     build-essential \
     clang-7 \
     llvm-7 \


### PR DESCRIPTION
**What type of PR is this?**

bug fix

**What this PR does / why we need it:**
This PR will Update kernel headers if kernel version >5.6.0

**Which issue(s) this PR fixes:**
Fixes #507 

**How was this tested?:**
Manual Tested:
we have tested this PR on **GCE** using arktos-up and kind-setup on following kernel version

- v5.6 to v5.13, Mizar pods are in running state ,CRDs are in provision state.
- Pod deployment is created successfully and able to ping each other.
