### PR TITLE
Fix for Issue #485 https://github.com/CentaurusInfra/mizar/issues/485

### DIFF
--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -62,9 +62,10 @@ static __inline int trn_select_transit_switch(struct transit_packet *pkt,
 	*s_port = SPORT_MIN + (inhash % SPORT_BASE);
 
 	if (*s_port < SPORT_MIN || *s_port > SPORT_MAX) {
-		bpf_debug("[Agent:] trn_select_transit_switch (BUG): s_port [%d] "
-			  "is outside of port range [%d - %d]!\n",
-			  *s_port, SPORT_MIN, SPORT_MAX);
+		bpf_debug("[Agent:%ld.0x%x] trn_select_transit_switch (BUG): s_port[%d] "
+			  " is outside of port range!\n",
+			  pkt->agent_ep_tunid, bpf_ntohl(pkt->agent_ep_ipv4),
+			  *s_port);
 		return 1;
 	}
 
@@ -126,9 +127,10 @@ static __inline int trn_encapsulate(struct transit_packet *pkt,
 		__u32 inhash = jhash_2words(in_src_ip, in_dst_ip, INIT_JHASH_SEED);
 		s_port = SPORT_MIN + (inhash % SPORT_BASE);
 		if (s_port < SPORT_MIN || s_port > SPORT_MAX) {
-			bpf_debug("[Agent:] DROP (BUG): s_port [%d] "
-			 			"is outside of port range [%d - %d]!\n",
-			  		s_port, SPORT_MIN, SPORT_MAX);
+			bpf_debug("[Agent:%ld.0x%x] DROP (BUG): s_port[%d] "
+			 		" is outside of port range!\n",
+					pkt->agent_ep_tunid, bpf_ntohl(pkt->agent_ep_ipv4),
+			  		s_port);
 			return XDP_DROP;
 		}
 

--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -446,7 +446,7 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 			  	__LINE__);
 		}
 	}
-	
+
 	return trn_redirect(pkt, pkt->inner_ip->saddr, pkt->inner_ip->daddr);
 }
 

--- a/test/trn_controller/droplet.py
+++ b/test/trn_controller/droplet.py
@@ -16,7 +16,7 @@ import json
 
 
 class droplet:
-    def __init__(self, id, droplet_type='docker', phy_itf='eth0', benchmark=False):
+    def __init__(self, id, droplet_type='docker', phy_itf='eth0', benchmark=True):
         """
         Models a host that runs the transit XDP program. In the
         functional test this is simply a docker container.

--- a/test/trn_controller/droplet.py
+++ b/test/trn_controller/droplet.py
@@ -16,7 +16,7 @@ import json
 
 
 class droplet:
-    def __init__(self, id, droplet_type='docker', phy_itf='eth0', benchmark=True):
+    def __init__(self, id, droplet_type='docker', phy_itf='eth0', benchmark=False):
         """
         Models a host that runs the transit XDP program. In the
         functional test this is simply a docker container.


### PR DESCRIPTION
What does this change do?
This change fixes Issue 485(XDP program fails to load when the benchmark flag is set to True in Mizar kind-setup deployment).

Why is it needed?
We need to be able to turn off debug mode for performance test and in general.

How was this tested?
Tested locally in aws kubeadm 2 node cluster setup. The XDP program was loaded successfully with benchmark=True. Also verified that there's around 30% performance difference with Benchmark=true in tested netperf and ping commands.