### PR TITLE
Add support for predictable interface naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ CFLAGS += -Wall
 CFLAGS += -Wextra
 CFLAGS += -Werror
 CFLAGS += -pedantic -Wpedantic
-CLFAGS += -Wno-cast-function-type -Wno-error=cast-function-type
+#CFLAGS += -Wno-cast-function-type -Wno-error=cast-function-type
 
 CFLAGS += -fno-common
 CFLAGS += -fstrict-aliasing

--- a/mizar/common/common.py
+++ b/mizar/common/common.py
@@ -426,9 +426,24 @@ def conf_list_has_max_elements(conf, conf_list):
         return True
     return False
 
+def get_default_itf():
+    """
+    Assuming "ip route" returns the following format:
+        default via 192.168.189.1 dev ens33 proto dhcp src 192.168.189.2 metric 100
+        172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1
+        ...
+    """
+    default_itf="eth0"
+    ret, data = run_cmd("ip route")
+    data = [i for i in data.split('\n') if i]
+    for line in data:
+        if line.startswith('default'):
+            return line.split()[4]
+    # return  data[0].split()[2] # this should not be reached
+    return default_itf
 
 def get_itf():
-    default_itf = "eth0"
+    default_itf = get_default_itf()
     if "MIZAR_ITF" in os.environ:
         logger.info("MIZAR_ITF env var found!")
         return os.getenv("MIZAR_ITF")

--- a/mizar/daemon/app.py
+++ b/mizar/daemon/app.py
@@ -8,6 +8,7 @@ from concurrent import futures
 from mizar.daemon.interface_service import InterfaceServer
 from mizar.daemon.droplet_service import DropletServer
 from mizar.common.constants import CONSTANTS
+from mizar.common.common import *
 import mizar.proto.interface_pb2_grpc as interface_pb2_grpc
 import mizar.proto.interface_pb2 as interface_pb2
 import mizar.proto.droplet_pb2_grpc as droplet_pb2_grpc
@@ -25,24 +26,26 @@ POOL_WORKERS = 10
 
 def init(benchmark=False):
     # Setup the droplet's host
+    default_itf = get_itf()
+
     script = (f''' bash -c '\
     nsenter -t 1 -m -u -n -i ls -1 /etc/cni/net.d/*conf* | grep -v '10-mizarcni.conf$' | xargs rm -rf && \
     nsenter -t 1 -m -u -n -i /etc/init.d/rpcbind restart && \
     nsenter -t 1 -m -u -n -i /etc/init.d/rsyslog restart && \
     nsenter -t 1 -m -u -n -i sysctl -w net.ipv4.tcp_mtu_probing=2 && \
-    nsenter -t 1 -m -u -n -i ip link set dev eth0 up mtu 9000 && \
+    nsenter -t 1 -m -u -n -i ip link set dev {default_itf} up mtu 9000 && \
     nsenter -t 1 -m -u -n -i mkdir -p /var/run/netns' ''')
 
     r = subprocess.Popen(script, shell=True, stdout=subprocess.PIPE)
     output = r.stdout.read().decode().strip()
     logging.info("Setup done")
 
-    cmd = 'nsenter -t 1 -m -u -n -i ip addr show eth0 | grep "inet\\b" | awk \'{print $2}\''
+    cmd = 'nsenter -t 1 -m -u -n -i ip addr show ' + f'''{default_itf}''' + ' | grep "inet\\b" | awk \'{print $2}\''
     r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
     nodeipmask = r.stdout.read().decode().strip()
     nodeip = nodeipmask.split("/")[0]
 
-    cmd = "nsenter -t 1 -m -u -n -i ip link set dev eth0 xdpgeneric off"
+    cmd = "nsenter -t 1 -m -u -n -i ip link set dev " + f'''{default_itf}''' + " xdpgeneric off"
 
     r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
     output = r.stdout.read().decode().strip()
@@ -67,7 +70,7 @@ def init(benchmark=False):
     }
     config = json.dumps(config)
     cmd = (
-        f'''nsenter -t 1 -m -u -n -i /trn_bin/transit -s {nodeip} load-transit-xdp -i eth0 -j '{config}' ''')
+        f'''nsenter -t 1 -m -u -n -i /trn_bin/transit -s {nodeip} load-transit-xdp -i {default_itf} -j '{config}' ''')
 
     r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
     output = r.stdout.read().decode().strip()
@@ -83,11 +86,13 @@ def init(benchmark=False):
     brcmd = f'''nsenter -t 1 -m -u -n -i sysctl -w net.bridge.bridge-nf-call-iptables=0 && \
         nsenter -t 1 -m -u -n -i ip link add {CONSTANTS.MIZAR_BRIDGE} type bridge && \
         nsenter -t 1 -m -u -n -i ip link set dev {CONSTANTS.MIZAR_BRIDGE} up && \
-        nsenter -t 1 -m -u -n -i ip link set eth0 master {CONSTANTS.MIZAR_BRIDGE} && \
+        nsenter -t 1 -m -u -n -i ip link set {default_itf} master {CONSTANTS.MIZAR_BRIDGE} && \
         nsenter -t 1 -m -u -n -i ip addr add {nodeip} dev {CONSTANTS.MIZAR_BRIDGE} && \
         nsenter -t 1 -m -u -n -i brctl show'''
 
-    rtlistcmd = 'nsenter -t 1 -m -u -n -i ip route list | grep "dev eth0"'
+    dev_default_itf = f'''dev {default_itf}'''
+    rtlistcmd = 'nsenter -t 1 -m -u -n -i ip route list | grep "' + f'''{dev_default_itf}''' +'"'
+
     r = subprocess.Popen(rtlistcmd, shell=True, stdout=subprocess.PIPE)
     rtchanges = []
     while True:
@@ -95,8 +100,8 @@ def init(benchmark=False):
         if not line:
             break
         rt = line.decode().strip()
-        rtkey = rt.partition("dev eth0")[0]
-        rtdesc = rt.partition("dev eth0")[2]
+        rtkey = rt.partition(dev_default_itf)[0]
+        rtdesc = rt.partition(dev_default_itf)[2]
         rnew = 'nsenter -t 1 -m -u -n -i ip route change ' + rtkey + f'''dev {CONSTANTS.MIZAR_BRIDGE}''' + rtdesc
         if 'default' in rt:
             rtchanges.append(rnew)
@@ -122,10 +127,10 @@ def init(benchmark=False):
     logging.info("Mizar bridge setup complete.\n{}\n".format(output))
 
     tcscript = (f''' bash -c '\
-    nsenter -t 1 -m -u -n -i tc qdisc add dev eth0 clsact && \
-    nsenter -t 1 -m -u -n -i tc filter del dev eth0 egress && \
-    nsenter -t 1 -m -u -n -i tc filter add dev eth0 egress bpf da obj {tc_edt_ebpf_path} sec edt && \
-    nsenter -t 1 -m -u -n -i tc filter show dev eth0 egress' ''')
+    nsenter -t 1 -m -u -n -i tc qdisc add dev {default_itf} clsact && \
+    nsenter -t 1 -m -u -n -i tc filter del dev {default_itf} egress && \
+    nsenter -t 1 -m -u -n -i tc filter add dev {default_itf} egress bpf da obj {tc_edt_ebpf_path} sec edt && \
+    nsenter -t 1 -m -u -n -i tc filter show dev {default_itf} egress' ''')
     r = subprocess.Popen(tcscript, shell=True, stdout=subprocess.PIPE)
     output = r.stdout.read().decode().strip()
     logging.info("Load EDT eBPF program done.\n{}\n".format(output))

--- a/mizar/daemon/droplet_service.py
+++ b/mizar/daemon/droplet_service.py
@@ -21,7 +21,7 @@ class DropletServer(droplet_pb2_grpc.DropletServiceServicer):
         r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         self.ip = r.stdout.read().decode().strip()
 
-        cmd = 'ip addr show eth0 | grep "link/ether\\b" | awk \'{print $2}\' | cut -d/ -f1'
+        cmd = 'ip addr show ' + f'''{self.itf}''' + ' | grep "link/ether\\b" | awk \'{print $2}\' | cut -d/ -f1'
         r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         self.mac = r.stdout.read().decode().strip()
 

--- a/mizar/dp/mizar/workflows/builtins/pods/create.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/create.py
@@ -51,6 +51,9 @@ class k8sPodCreate(WorkflowTask):
         if "hostIP" not in self.param.body['status']:
             self.raise_temporary_error("Pod spec not ready.")
 
+        default_itf = get_itf()
+        logger.info("Create.run: get default interface {}".format(default_itf))
+
         spec = {
             'hostIP': self.param.body['status']['hostIP'],
             'name': self.param.name,
@@ -60,7 +63,7 @@ class k8sPodCreate(WorkflowTask):
             'vpc': OBJ_DEFAULTS.default_ep_vpc,
             'subnet': OBJ_DEFAULTS.default_ep_net,
             'phase': self.param.body['status']['phase'],
-            'interfaces': [{'name': 'eth0'}]
+            'interfaces': [{'name': default_itf }]
         }
         if self.param.body['metadata'].get('annotations'):
             if self.param.body['metadata'].get('annotations').get(OBJ_DEFAULTS.mizar_pod_vpc_annotation):

--- a/mizar/obj/endpoint.py
+++ b/mizar/obj/endpoint.py
@@ -47,7 +47,7 @@ class Endpoint:
         self.droplet = ""
         self.droplet_ip = ""
         self.droplet_mac = ""
-        self.droplet_eth = 'eth0'
+        self.droplet_eth = get_itf()
         self.droplet_obj = None
         self.veth_peer = ""
         self.veth_name = ""

--- a/pkg/util/netutil/netutil.go
+++ b/pkg/util/netutil/netutil.go
@@ -112,13 +112,13 @@ func ActivateInterface(
 	}
 
 	strBuilder.WriteString("\nDisable tso for pod")
-	cmdTxt, result, err := executil.Execute("ip", "netns", "exec", netNSFileName, "ethtool", "-K", "eth0", "tso", "off", "gso", "off", "ufo", "off")
+	cmdTxt, result, err := executil.Execute("ip", "netns", "exec", netNSFileName, "ethtool", "-K", ifName, "tso", "off", "gso", "off", "ufo", "off")
 	strBuilder.WriteString(fmt.Sprintf("\nExecuting cmd: \n%s\n%s", cmdTxt, result))
 	if err != nil {
 		return strBuilder.String(), err
 	}
 
-	cmdTxt, result, err = executil.Execute("ip", "netns", "exec", netNSFileName, "ethtool", "--offload", "eth0", "rx", "off", "tx", "off")
+	cmdTxt, result, err = executil.Execute("ip", "netns", "exec", netNSFileName, "ethtool", "--offload", ifName, "rx", "off", "tx", "off")
 	strBuilder.WriteString(fmt.Sprintf("\nExecuting cmd: \n%s\n%s", cmdTxt, result))
 	if err != nil {
 		return strBuilder.String(), err

--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -62,9 +62,10 @@ static __inline int trn_select_transit_switch(struct transit_packet *pkt,
 	*s_port = SPORT_MIN + (inhash % SPORT_BASE);
 
 	if (*s_port < SPORT_MIN || *s_port > SPORT_MAX) {
-		bpf_debug("[Agent:] trn_select_transit_switch (BUG): s_port [%d] "
-			  "is outside of port range [%d - %d]!\n",
-			  *s_port, SPORT_MIN, SPORT_MAX);
+		bpf_debug("[Agent:%ld.0x%x] trn_select_transit_switch (BUG): s_port[%d] "
+			  " is outside of port range!\n",
+			  pkt->agent_ep_tunid, bpf_ntohl(pkt->agent_ep_ipv4),
+			  *s_port);
 		return 1;
 	}
 
@@ -126,9 +127,10 @@ static __inline int trn_encapsulate(struct transit_packet *pkt,
 		__u32 inhash = jhash_2words(in_src_ip, in_dst_ip, INIT_JHASH_SEED);
 		s_port = SPORT_MIN + (inhash % SPORT_BASE);
 		if (s_port < SPORT_MIN || s_port > SPORT_MAX) {
-			bpf_debug("[Agent:] DROP (BUG): s_port [%d] "
-			 			"is outside of port range [%d - %d]!\n",
-			  		s_port, SPORT_MIN, SPORT_MAX);
+			bpf_debug("[Agent:%ld.0x%x] DROP (BUG): s_port[%d] "
+			 		" is outside of port range!\n",
+					pkt->agent_ep_tunid, bpf_ntohl(pkt->agent_ep_ipv4),
+			  		s_port);
 			return XDP_DROP;
 		}
 

--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -446,7 +446,7 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 			  	__LINE__);
 		}
 	}
-	
+
 	return trn_redirect(pkt, pkt->inner_ip->saddr, pkt->inner_ip->daddr);
 }
 

--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -446,7 +446,7 @@ static __inline int trn_process_inner_ip(struct transit_packet *pkt)
 			  	__LINE__);
 		}
 	}
-
+	
 	return trn_redirect(pkt, pkt->inner_ip->saddr, pkt->inner_ip->daddr);
 }
 

--- a/test/trn_controller/droplet.py
+++ b/test/trn_controller/droplet.py
@@ -16,7 +16,7 @@ import json
 
 
 class droplet:
-    def __init__(self, id, droplet_type='docker', phy_itf='eth0', benchmark=False):
+    def __init__(self, id, droplet_type='docker', phy_itf='eth0', benchmark=True):
         """
         Models a host that runs the transit XDP program. In the
         functional test this is simply a docker container.

--- a/test/trn_controller/droplet.py
+++ b/test/trn_controller/droplet.py
@@ -16,7 +16,7 @@ import json
 
 
 class droplet:
-    def __init__(self, id, droplet_type='docker', phy_itf='eth0', benchmark=True):
+    def __init__(self, id, droplet_type='docker', phy_itf='eth0', benchmark=False):
         """
         Models a host that runs the transit XDP program. In the
         functional test this is simply a docker container.

--- a/test/trn_controller/droplet.py
+++ b/test/trn_controller/droplet.py
@@ -9,6 +9,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 from test.trn_controller.common import cidr, logger, run_cmd
+from mizar.common.common import *
 import os
 import docker
 import time
@@ -16,11 +17,13 @@ import json
 
 
 class droplet:
-    def __init__(self, id, droplet_type='docker', phy_itf='eth0', benchmark=False):
+    def __init__(self, id, phy_itf, droplet_type='docker', benchmark=False):
         """
         Models a host that runs the transit XDP program. In the
         functional test this is simply a docker container.
         """
+        if not phy_itf:
+            phy_itf = get_itf()
         self.id = id
         self.droplet_type = droplet_type
         self.container = None
@@ -72,9 +75,7 @@ class droplet:
         self.trn_cli_update_packet_metadata = f'''{self.trn_cli} update-packet-metadata'''
         self.trn_cli_delete_packet_metadata = f'''{self.trn_cli} delete-packet-metadata'''
 
-        self.xdp_path = "/trn_xdp/trn_transit_xdp_ebpf_debug.o"
-        self.agent_xdp_path = "/trn_xdp/trn_agent_xdp_ebpf_debug.o"
-        self.pcap_file = "eth0_transit_pcap"
+        self.pcap_file = f'''{self.phy_itf}_transit_pcap'''
         self.agent_pcap_file = {}
         self.main_bridge = 'br0'
         self.bootstrap()
@@ -521,6 +522,7 @@ ip netns del {ep.ns} \' ''')
     def update_agent_metadata(self, itf, ep, net, expect_fail=False):
         log_string = "[DROPLET {}]: update_agent_metadata on {} for endpoint {}".format(
             self.id, itf, ep.ip)
+        default_itf = get_itf()
         jsonconf = {
             "ep": {
                 "tunnel_id": ep.get_tunnel_id(),
@@ -529,7 +531,7 @@ ip netns del {ep.ns} \' ''')
                 "mac": ep.get_mac(),
                 "veth": ep.get_veth_name(),
                 "remote_ips": ep.get_remote_ips(),
-                "hosted_iface": "eth0"
+                "hosted_iface": default_itf
             },
             "net": {
                 "tunnel_id": net.get_tunnel_id(),
@@ -540,7 +542,7 @@ ip netns del {ep.ns} \' ''')
             "eth": {
                 "ip": self.ip,
                 "mac": self.mac,
-                "iface": "eth0"
+                "iface": default_itf
             }
         }
         jsonconf = json.dumps(jsonconf)
@@ -721,6 +723,7 @@ cp /var/log/syslog /trn_test_out/syslog_{self.ip}
         Assumes "buildbox:v2" image exist and setup on host
         """
         cwd = os.getcwd()
+        default_itf = get_itf()
 
         # get a docker client
         docker_client = docker.from_env()
@@ -745,7 +748,7 @@ cp /var/log/syslog /trn_test_out/syslog_{self.ip}
         # Restart dependancy services
         container.exec_run("/etc/init.d/rpcbind restart")
         container.exec_run("/etc/init.d/rsyslog restart")
-        container.exec_run("ip link set dev eth0 up mtu 9000")
+        local_cmd=f'''ip link set dev {default_itf} up mtu 9000'''
         container.exec_run("sysctl -w net.ipv4.tcp_mtu_probing=2")
 
         # We may need ovs for compatability tests
@@ -780,9 +783,10 @@ cp /var/log/syslog /trn_test_out/syslog_{self.ip}
         self.mac = self.container.attrs['NetworkSettings']['MacAddress']
 
     def start_pcap(self):
-        # Start a pcap to collect packets on eth0
+        # Start a pcap to collect packets on default nic
+        default_itf = get_itf()
         cmd = f''' bash -c \
-'(/mnt/Transit/tools/xdpcap /bpffs/eth0_transit_pcap \
+'(/mnt/Transit/tools/xdpcap /bpffs/{default_itf}_transit_pcap \
 /trn_test_out/\
 droplet_{self.ip}.pcap >/dev/null 2>&1 &\
 )' '''
@@ -833,10 +837,11 @@ droplet_{self.ip}.pcap >/dev/null 2>&1 &\
     def dump_pcap_on_host(self, pcapfile, timeout=5):
         """
         Does tcpdump to a pcap file for "n" seconds on the host veth device
-        corresponding to the eth0 interface inside the docker container.
+        corresponding to the default interface inside the docker container.
         """
-        veth_index = self.run(
-            "cat /sys/class/net/eth0/iflink")[1].strip()
+        default_itf = get_itf()
+        local_cmd = f'''cat /sys/class/net/{default_itf}/iflink'''
+        veth_index = self.run(local_cmd)[1].strip()
         veth = self.run_from_root(
             "grep -l " + veth_index + " /sys/class/net/veth*/ifindex")[1].split("/")[4]
         run_cmd("timeout " + str(timeout) + " tcpdump -nn -A -i " + veth + " -w test/trn_func_tests/output/" +


### PR DESCRIPTION
What does this PR do?
We currently uses hard-coded "eth0" as nic interface in our code which prevents Mizar from running in system whose default interface is not named as eth0, which is the case in later Ubuntu version or other Linux flavors. 

This PR remove hard coded "eth0" from the logic and replaces with the default interface name obtained from the system. It is a fix for issue #519.

How was this tested?
It is tested in an AWS 2 nodes cluster environment with default interface name as "ensxx", the k8s cluster was launched successfully and the default interface name is detected and used in Mizar pods(instead of eth0), the testpods were created successfully and ping-able to each other.

Are there any user facing / API changes?
No.