### PR TITLE
Fix issue 543 go.mod updated for protobuf version after run bootstrap.sh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
 	google.golang.org/grpc v1.39.0
-	google.golang.org/protobuf v1.27.0
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 // indirect
+	google.golang.org/protobuf v1.26.0
 	k8s.io/klog/v2 v2.10.0
 )


### PR DESCRIPTION
What does this PR do?
This is to fix issue 543 go.mod updated for protobuf version after run bootstrap.sh. 
In the file bootstrap.sh and setup-machine-arktos.sh, they both point protobuf version to be 1.26 but in current file go.mod, the version is v1.27.0 which is wrong. We need to change to version to correct one and bring the needed indirect reference, then go.mod won't change after run bootstrap.sh.

How was this tested?
I update the change to a private branch, then find another clean machine, apply the change, and execute ./bootstrap.sh. The go.mod is not updated which proves the change works.

Are there any user facing / API changes?
No.

Closes #543 