### PR TITLE
Zero-initialize UDP checksum (it is optional) in encapsulating GENEVE packet

### DIFF
--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -288,6 +288,7 @@ static __inline int trn_encapsulate(struct transit_packet *pkt,
 	trn_ipv4_csum_inline(pkt->ip, &c_sum);
 	pkt->ip->check = c_sum;
 
+	pkt->udp->check = 0;
 	pkt->udp->source = bpf_htons(s_port); // TODO: a hash value based on inner IP packet
 	pkt->udp->dest = GEN_DSTPORT;
 	pkt->udp->len = bpf_htons(outer_udp_payload);


### PR DESCRIPTION
What does this PR do?
It sets the UDP checksum field in the encapsulating GEVENE outer packet to 0. This is optional and if zero, ignored on receipt. This prevents unexpected errors or drops.