### PR TITLE
Mizar release v0.9

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -107,13 +107,13 @@ jobs:
           ssh ciw2 "sudo $(sudo kubeadm token create --print-join-command)"
       - name: build container images
         run: |
-          sudo docker build -t mizar:0.8 -f etc/docker/mizar.Dockerfile .
-          sudo docker build -t dropletd:0.8 -f etc/docker/daemon.Dockerfile .
-          sudo docker build -t endpointopr:0.8 -f etc/docker/operator.Dockerfile .
+          sudo docker build -t mizar:0.9 -f etc/docker/mizar.Dockerfile .
+          sudo docker build -t dropletd:0.9 -f etc/docker/daemon.Dockerfile .
+          sudo docker build -t endpointopr:0.9 -f etc/docker/operator.Dockerfile .
 
-          sudo docker save mizar:0.8 -o build/bin/mizar.tar
-          sudo docker save dropletd:0.8 -o build/bin/dropletd.tar
-          sudo docker save endpointopr:0.8 -o build/bin/endpointopr.tar
+          sudo docker save mizar:0.9 -o build/bin/mizar.tar
+          sudo docker save dropletd:0.9 -o build/bin/dropletd.tar
+          sudo docker save endpointopr:0.9 -o build/bin/endpointopr.tar
 
           sudo chmod +r build/bin/mizar.tar
           sudo chmod +r build/bin/dropletd.tar

--- a/etc/deploy/deploy.mizar.ci.yaml
+++ b/etc/deploy/deploy.mizar.ci.yaml
@@ -444,7 +444,7 @@ spec:
       hostPID: true
       initContainers:
       - name: node-init
-        image: mizar:0.8
+        image: mizar:0.9
         command: [./node-init.sh]
         securityContext:
           privileged: true
@@ -453,7 +453,7 @@ spec:
           mountPath: /home
       containers:
       - name: mizar-daemon
-        image: dropletd:0.8
+        image: dropletd:0.9
         env:
         - name: FEATUREGATE_BWQOS
           value: 'false'
@@ -489,7 +489,7 @@ spec:
       hostNetwork: true
       containers:
       - name: mizar-operator
-        image: endpointopr:0.8
+        image: endpointopr:0.9
         env:
         - name: FEATUREGATE_BWQOS
           value: 'false'

--- a/etc/deploy/deploy.mizar.yaml
+++ b/etc/deploy/deploy.mizar.yaml
@@ -444,7 +444,7 @@ spec:
       hostPID: true
       initContainers:
       - name: node-init
-        image: mizarnet/mizar:0.8
+        image: mizarnet/mizar:0.9
         command: [./node-init.sh]
         securityContext:
           privileged: true
@@ -453,7 +453,7 @@ spec:
           mountPath: /home
       containers:
       - name: mizar-daemon
-        image: mizarnet/dropletd:0.8
+        image: mizarnet/dropletd:0.9
         env:
         - name: FEATUREGATE_BWQOS
           value: 'false'
@@ -489,7 +489,7 @@ spec:
       hostNetwork: true
       containers:
       - name: mizar-operator
-        image: mizarnet/endpointopr:0.8
+        image: mizarnet/endpointopr:0.9
         env:
         - name: FEATUREGATE_BWQOS
           value: 'false'


### PR DESCRIPTION
This change updates the Mizar container version to release v0.9
Corresponding docker images have already been uploaded to dockerhub.
Tested on a 3 node setup in AWS and locally with kind-setup.sh