### PR TITLE
Fix for Issue #519(Add Mizar support for predictable interface naming)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ CFLAGS += -Wall
 CFLAGS += -Wextra
 CFLAGS += -Werror
 CFLAGS += -pedantic -Wpedantic
-CLFAGS += -Wno-cast-function-type -Wno-error=cast-function-type
+# needed in 20.04
+#CFLAGS += -Wno-cast-function-type -Wno-error=cast-function-type
 
 CFLAGS += -fno-common
 CFLAGS += -fstrict-aliasing

--- a/mizar/common/common.py
+++ b/mizar/common/common.py
@@ -442,8 +442,17 @@ def get_default_itf():
             return line.split()[4]
     return default_itf
 
+def get_bridge_real_itf():
+    cmd = "ls /sys/class/net/" + CONSTANTS.MIZAR_BRIDGE + "/brif"
+    ret, data1 = run_cmd(cmd)
+    data = data1.split()
+    logger.info("Get bridge real interface {}".format(data[0]))
+    return data[0]
+
 def get_itf():
     default_itf = get_default_itf()
+    if default_itf == CONSTANTS.MIZAR_BRIDGE:
+        default_itf = get_bridge_real_itf()
     if "MIZAR_ITF" in os.environ:
         logger.info("MIZAR_ITF env var found!")
         return os.getenv("MIZAR_ITF")

--- a/mizar/common/common.py
+++ b/mizar/common/common.py
@@ -426,9 +426,24 @@ def conf_list_has_max_elements(conf, conf_list):
         return True
     return False
 
+def get_default_itf():
+    """
+    Assuming "ip route" returns the following format:
+        default via 192.168.189.1 dev ens33 proto dhcp src 192.168.189.2 metric 100
+        172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1
+        ...
+    """
+    default_itf="eth0"
+    ret, data = run_cmd("ip route")
+    data = [i for i in data.split('\n') if i]
+    for line in data:
+        if line.startswith('default'):
+            logging.info("default_itf from ip route: {}".format(line.split()[4]))
+            return line.split()[4]
+    return default_itf
 
 def get_itf():
-    default_itf = "eth0"
+    default_itf = get_default_itf()
     if "MIZAR_ITF" in os.environ:
         logger.info("MIZAR_ITF env var found!")
         return os.getenv("MIZAR_ITF")

--- a/mizar/daemon/app.py
+++ b/mizar/daemon/app.py
@@ -8,6 +8,7 @@ from concurrent import futures
 from mizar.daemon.interface_service import InterfaceServer
 from mizar.daemon.droplet_service import DropletServer
 from mizar.common.constants import CONSTANTS
+from mizar.common.common import *
 import mizar.proto.interface_pb2_grpc as interface_pb2_grpc
 import mizar.proto.interface_pb2 as interface_pb2
 import mizar.proto.droplet_pb2_grpc as droplet_pb2_grpc
@@ -25,6 +26,7 @@ POOL_WORKERS = 10
 
 def init(benchmark=False):
     # Setup the droplet's host
+    default_itf = get_itf()
     script = (f''' bash -c '\
     nsenter -t 1 -m -u -n -i ls -1 /etc/cni/net.d/*conf* | grep -v '10-mizarcni.conf$' | xargs rm -rf && \
     nsenter -t 1 -m -u -n -i /etc/init.d/rpcbind restart && \
@@ -37,12 +39,12 @@ def init(benchmark=False):
     output = r.stdout.read().decode().strip()
     logging.info("Setup done")
 
-    cmd = 'nsenter -t 1 -m -u -n -i ip addr show eth0 | grep "inet\\b" | awk \'{print $2}\''
+    cmd = 'nsenter -t 1 -m -u -n -i ip addr show ' + f'''{default_itf}''' + ' | grep "inet\\b" | awk \'{print $2}\''
     r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
     nodeipmask = r.stdout.read().decode().strip()
     nodeip = nodeipmask.split("/")[0]
 
-    cmd = "nsenter -t 1 -m -u -n -i ip link set dev eth0 xdpgeneric off"
+    cmd = "nsenter -t 1 -m -u -n -i ip link set dev " + f'''{default_itf}''' + " xdpgeneric off"
 
     r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
     output = r.stdout.read().decode().strip()
@@ -67,7 +69,7 @@ def init(benchmark=False):
     }
     config = json.dumps(config)
     cmd = (
-        f'''nsenter -t 1 -m -u -n -i /trn_bin/transit -s {nodeip} load-transit-xdp -i eth0 -j '{config}' ''')
+        f'''nsenter -t 1 -m -u -n -i /trn_bin/transit -s {nodeip} load-transit-xdp -i {default_itf} -j '{config}' ''')
 
     r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
     output = r.stdout.read().decode().strip()
@@ -87,7 +89,9 @@ def init(benchmark=False):
         nsenter -t 1 -m -u -n -i ip addr add {nodeip} dev {CONSTANTS.MIZAR_BRIDGE} && \
         nsenter -t 1 -m -u -n -i brctl show'''
 
-    rtlistcmd = 'nsenter -t 1 -m -u -n -i ip route list | grep "dev eth0"'
+    dev_default_itf = f'''dev {default_itf}'''
+    rtlistcmd = 'nsenter -t 1 -m -u -n -i ip route list | grep "' + f'''{dev_default_itf}''' +'"'
+
     r = subprocess.Popen(rtlistcmd, shell=True, stdout=subprocess.PIPE)
     rtchanges = []
     while True:
@@ -95,8 +99,8 @@ def init(benchmark=False):
         if not line:
             break
         rt = line.decode().strip()
-        rtkey = rt.partition("dev eth0")[0]
-        rtdesc = rt.partition("dev eth0")[2]
+        rtkey = rt.partition(dev_default_itf)[0]
+        rtdesc = rt.partition(dev_default_itf)[2]
         rnew = 'nsenter -t 1 -m -u -n -i ip route change ' + rtkey + f'''dev {CONSTANTS.MIZAR_BRIDGE}''' + rtdesc
         if 'default' in rt:
             rtchanges.append(rnew)
@@ -122,10 +126,10 @@ def init(benchmark=False):
     logging.info("Mizar bridge setup complete.\n{}\n".format(output))
 
     tcscript = (f''' bash -c '\
-    nsenter -t 1 -m -u -n -i tc qdisc add dev eth0 clsact && \
-    nsenter -t 1 -m -u -n -i tc filter del dev eth0 egress && \
-    nsenter -t 1 -m -u -n -i tc filter add dev eth0 egress bpf da obj {tc_edt_ebpf_path} sec edt && \
-    nsenter -t 1 -m -u -n -i tc filter show dev eth0 egress' ''')
+    nsenter -t 1 -m -u -n -i tc qdisc add dev {default_itf} clsact && \
+    nsenter -t 1 -m -u -n -i tc filter del dev {default_itf} egress && \
+    nsenter -t 1 -m -u -n -i tc filter add dev {default_itf} egress bpf da obj {tc_edt_ebpf_path} sec edt && \
+    nsenter -t 1 -m -u -n -i tc filter show dev {default_itf} egress' ''')
     r = subprocess.Popen(tcscript, shell=True, stdout=subprocess.PIPE)
     output = r.stdout.read().decode().strip()
     logging.info("Load EDT eBPF program done.\n{}\n".format(output))

--- a/mizar/daemon/app.py
+++ b/mizar/daemon/app.py
@@ -32,7 +32,7 @@ def init(benchmark=False):
     nsenter -t 1 -m -u -n -i /etc/init.d/rpcbind restart && \
     nsenter -t 1 -m -u -n -i /etc/init.d/rsyslog restart && \
     nsenter -t 1 -m -u -n -i sysctl -w net.ipv4.tcp_mtu_probing=2 && \
-    nsenter -t 1 -m -u -n -i ip link set dev eth0 up mtu 9000 && \
+    nsenter -t 1 -m -u -n -i ip link set dev {default_itf} up mtu 9000 && \
     nsenter -t 1 -m -u -n -i mkdir -p /var/run/netns' ''')
 
     r = subprocess.Popen(script, shell=True, stdout=subprocess.PIPE)
@@ -85,7 +85,7 @@ def init(benchmark=False):
     brcmd = f'''nsenter -t 1 -m -u -n -i sysctl -w net.bridge.bridge-nf-call-iptables=0 && \
         nsenter -t 1 -m -u -n -i ip link add {CONSTANTS.MIZAR_BRIDGE} type bridge && \
         nsenter -t 1 -m -u -n -i ip link set dev {CONSTANTS.MIZAR_BRIDGE} up && \
-        nsenter -t 1 -m -u -n -i ip link set eth0 master {CONSTANTS.MIZAR_BRIDGE} && \
+        nsenter -t 1 -m -u -n -i ip link set {default_itf} master {CONSTANTS.MIZAR_BRIDGE} && \
         nsenter -t 1 -m -u -n -i ip addr add {nodeip} dev {CONSTANTS.MIZAR_BRIDGE} && \
         nsenter -t 1 -m -u -n -i brctl show'''
 

--- a/mizar/daemon/app.py
+++ b/mizar/daemon/app.py
@@ -90,7 +90,7 @@ def init(benchmark=False):
         nsenter -t 1 -m -u -n -i brctl show'''
 
     dev_default_itf = f'''dev {default_itf}'''
-    rtlistcmd = 'nsenter -t 1 -m -u -n -i ip route list | grep "' + f'''{dev_default_itf}''' +'"'
+    rtlistcmd = 'nsenter -t 1 -m -u -n -i ip route list | grep "' + f'''{dev_default_itf}''' + '"'
 
     r = subprocess.Popen(rtlistcmd, shell=True, stdout=subprocess.PIPE)
     rtchanges = []

--- a/mizar/daemon/droplet_service.py
+++ b/mizar/daemon/droplet_service.py
@@ -21,7 +21,7 @@ class DropletServer(droplet_pb2_grpc.DropletServiceServicer):
         r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         self.ip = r.stdout.read().decode().strip()
 
-        cmd = 'ip addr show eth0 | grep "link/ether\\b" | awk \'{print $2}\' | cut -d/ -f1'
+        cmd = 'ip addr show ' + f'''{self.itf}''' + ' | grep "link/ether\\b" | awk \'{print $2}\' | cut -d/ -f1'
         r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         self.mac = r.stdout.read().decode().strip()
 

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -37,11 +37,12 @@ class InterfaceServer(InterfaceServiceServicer):
         self.queued_pods = set()  # A set of pods, with queued interfaces (to be consumed)
         self.interfaces_lock = threading.Lock()
 
-        cmd = 'ip addr show eth0 | grep "inet\\b" | awk \'{print $2}\' | cut -d/ -f1'
+        self.itf = get_itf()
+        cmd = 'ip addr show ' + f'''{self.itf}''' + ' | grep "inet\\b" | awk \'{print $2}\' | cut -d/ -f1'
         r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         self.droplet_ip = r.stdout.read().decode().strip()
 
-        cmd = 'ip addr show eth0 | grep "link/ether\\b" | awk \'{print $2}\' | cut -d/ -f1'
+        cmd = 'ip addr show ' + f'''{self.itf}''' + ' | grep "link/ether\\b" | awk \'{print $2}\' | cut -d/ -f1'
         r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         self.droplet_mac = r.stdout.read().decode().strip()
 
@@ -49,8 +50,7 @@ class InterfaceServer(InterfaceServiceServicer):
         r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         self.droplet_name = r.stdout.read().decode().strip()
 
-        self.itf = 'eth0'
-        self.rpc = LocalTransitRpc('127.0.0.1', self.droplet_mac)
+        self.rpc = LocalTransitRpc('127.0.0.1', self.droplet_mac, self.itf)
 
     def __del__(self):
         self.iproute.close()
@@ -338,7 +338,7 @@ class InterfaceServiceClient():
 
 
 class LocalTransitRpc:
-    def __init__(self, ip, mac, itf='eth0', benchmark=False):
+    def __init__(self, ip, mac, itf, benchmark=False):
         self.ip = ip
         self.mac = mac
         self.phy_itf = itf
@@ -465,6 +465,7 @@ class LocalTransitRpc:
 
     def update_agent_metadata(self, interface):
         itf = interface.veth.peer
+        default_itf = get_itf()
         netip = str(ipaddress.ip_interface(
             interface.address.ip_address + '/' + interface.address.ip_prefix).network.network_address)
         bouncers = []
@@ -478,7 +479,7 @@ class LocalTransitRpc:
                 "mac": interface.address.mac,
                 "veth": interface.veth.name,
                 "remote_ips": [interface.droplet.ip_address],
-                "hosted_iface": 'eth0'
+                "hosted_iface": default_itf
             },
             "net": {
                 "tunnel_id": interface.address.tunnel_id,
@@ -489,7 +490,7 @@ class LocalTransitRpc:
             "eth": {
                 "ip": interface.droplet.ip_address,
                 "mac": interface.droplet.mac,
-                "iface": 'eth0'
+                "iface": default_itf
             }
         }
         jsonconf = json.dumps(jsonconf)

--- a/mizar/dp/mizar/workflows/builtins/pods/create.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/create.py
@@ -51,6 +51,9 @@ class k8sPodCreate(WorkflowTask):
         if "hostIP" not in self.param.body['status']:
             self.raise_temporary_error("Pod spec not ready.")
 
+        default_itf = get_itf()
+        logger.info("Create.run: get default interface {}".format(default_itf))
+
         spec = {
             'hostIP': self.param.body['status']['hostIP'],
             'name': self.param.name,
@@ -60,7 +63,7 @@ class k8sPodCreate(WorkflowTask):
             'vpc': OBJ_DEFAULTS.default_ep_vpc,
             'subnet': OBJ_DEFAULTS.default_ep_net,
             'phase': self.param.body['status']['phase'],
-            'interfaces': [{'name': 'eth0'}]
+            'interfaces': [{'name': default_itf }]
         }
         if self.param.body['metadata'].get('annotations'):
             if self.param.body['metadata'].get('annotations').get(OBJ_DEFAULTS.mizar_pod_vpc_annotation):

--- a/mizar/obj/bouncer.py
+++ b/mizar/obj/bouncer.py
@@ -29,7 +29,7 @@ logger = logging.getLogger()
 
 
 class Bouncer(object):
-    def __init__(self, name, obj_api, opr_store, spec=None):
+    def __init__(self, name, obj_api, opr_store, spec=None, benchmark=False):
         self.name = name
         self.obj_api = obj_api
         self.store = opr_store
@@ -46,7 +46,11 @@ class Bouncer(object):
         self.dividers = {}
         self.known_substrates = {}
         self.status = OBJ_STATUS.bouncer_status_init
-        self.scaled_ep_obj = '/trn_xdp/trn_transit_scaled_endpoint_ebpf_debug.o'
+        if benchmark:
+            self.scaled_ep_obj = '/trn_xdp/trn_transit_scaled_endpoint_ebpf.o'
+        else:
+            self.scaled_ep_obj = '/trn_xdp/trn_transit_scaled_endpoint_ebpf_debug.o'
+
         if spec is not None:
             self.set_obj_spec(spec)
 

--- a/mizar/obj/endpoint.py
+++ b/mizar/obj/endpoint.py
@@ -47,7 +47,7 @@ class Endpoint:
         self.droplet = ""
         self.droplet_ip = ""
         self.droplet_mac = ""
-        self.droplet_eth = 'eth0'
+        self.droplet_eth = get_itf()
         self.droplet_obj = None
         self.veth_peer = ""
         self.veth_name = ""

--- a/pkg/util/netutil/netutil.go
+++ b/pkg/util/netutil/netutil.go
@@ -112,13 +112,13 @@ func ActivateInterface(
 	}
 
 	strBuilder.WriteString("\nDisable tso for pod")
-	cmdTxt, result, err := executil.Execute("ip", "netns", "exec", netNSFileName, "ethtool", "-K", "eth0", "tso", "off", "gso", "off", "ufo", "off")
+	cmdTxt, result, err := executil.Execute("ip", "netns", "exec", netNSFileName, "ethtool", "-K", ifName, "tso", "off", "gso", "off", "ufo", "off")
 	strBuilder.WriteString(fmt.Sprintf("\nExecuting cmd: \n%s\n%s", cmdTxt, result))
 	if err != nil {
 		return strBuilder.String(), err
 	}
 
-	cmdTxt, result, err = executil.Execute("ip", "netns", "exec", netNSFileName, "ethtool", "--offload", "eth0", "rx", "off", "tx", "off")
+	cmdTxt, result, err = executil.Execute("ip", "netns", "exec", netNSFileName, "ethtool", "--offload", ifName, "rx", "off", "tx", "off")
 	strBuilder.WriteString(fmt.Sprintf("\nExecuting cmd: \n%s\n%s", cmdTxt, result))
 	if err != nil {
 		return strBuilder.String(), err

--- a/teste2e/common/k8s.py
+++ b/teste2e/common/k8s.py
@@ -135,7 +135,7 @@ class k8sApi:
             resp.update(timeout=1)
             err = resp.read_channel(ERROR_CHANNEL)
             if err:
-                return yaml.load(err)
+                return yaml.safe_load(err)
 
     def pod_exec_stdout(self, name, cmd):
         exec_command = cmd.split()


### PR DESCRIPTION
What does this PR do?
We currently uses hard-coded "eth0" as nic interface in our code which prevents Mizar from running in system whose default interface is not named as eth0, which is the case in the later Ubuntu version or some other Linux flavors.

This PR remove hard coded "eth0" from the logic and replaces with the default interface name obtained from the system. It is a fix for issue #519.

How was this tested?
It passes local kind e2efunctest and it's also tested in an AWS 2 nodes cluster environment with default interface name as "ensxx", the k8s cluster was launched successfully and the default interface name is detected and used in Mizar pods(instead of eth0), the testpods were created successfully and ping-able to each other.

Are there any user facing / API changes?
No.