### PR TITLE
Fix issue 552 Creating, Deleting, and once again creating Pod does not work with Mizar

### DIFF
--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -236,7 +236,7 @@ class InterfaceServer(InterfaceServiceServicer):
         """
         veth_peer_index = get_iface_index(interface.veth.peer, self.iproute)
         self.rpc.unload_transit_agent_xdp(interface)
-        self.iproute.link('del', index=veth_peer_index)
+        self.iproute.link('delete', index=veth_peer_index)
 
     def DeleteInterface(self, request, context):
         """

--- a/pkg/util/netutil/netutil.go
+++ b/pkg/util/netutil/netutil.go
@@ -132,7 +132,8 @@ func DeleteNetNS(netNSName string) {
 	if netNS != nil {
 		netNS.Close()
 	}
-	executil.Execute("ip", "netns", "delete", netNSName)
+	_, netNSFileName := path.Split(netNSName)
+	executil.Execute("ip", "netns", "delete", netNSFileName)
 }
 
 func ParseCIDR(s string) (net.IP, *net.IPNet, error) {

--- a/teste2e/common/k8s.py
+++ b/teste2e/common/k8s.py
@@ -135,7 +135,7 @@ class k8sApi:
             resp.update(timeout=1)
             err = resp.read_channel(ERROR_CHANNEL)
             if err:
-                return yaml.load(err)
+                return yaml.safe_load(err)
 
     def pod_exec_stdout(self, name, cmd):
         exec_command = cmd.split()


### PR DESCRIPTION
What does this PR do?
When deleting pod, the code needs to execute "ip netns delete" against name of network namespace. The issue is that the code should send a name as parameter, but currently it's sending the file name together with folder name. Hence it's failed to delete netns, then pod cannot be created again.
The fix is to remove the folder name, then the netns will be deleted.

How was this tested?
I run the fixed binary in cluster and verified the fix is working. Now the pod can be created, deleted, and then created again without issue.

Are there any user facing / API changes?
No.