### PR TITLE
Print EDT eBPF program trace messages only in debug mode

### DIFF
--- a/etc/deploy/dev.daemon.deploy.yaml
+++ b/etc/deploy/dev.daemon.deploy.yaml
@@ -46,6 +46,6 @@ spec:
         image: localhost:5000/dropletd:latest
         env:
         - name: FEATUREGATE_BWQOS
-          value: 'true'
+          value: 'false'
         securityContext:
           privileged: true

--- a/etc/deploy/dev.operator.deploy.yaml
+++ b/etc/deploy/dev.operator.deploy.yaml
@@ -42,6 +42,6 @@ spec:
         image: localhost:5000/endpointopr:latest
         env:
         - name: FEATUREGATE_BWQOS
-          value: 'true'
+          value: 'false'
         securityContext:
           privileged: true


### PR DESCRIPTION
In EDT eBPF program, the debug print trace is enabled by default. This affects performance benchmarking.

The change fixes this so that only the debug version of the eBPF program binary has tracing enabled.

Also temporarily disabled QoS feature-gate in kind-setup until I've had the chance to figure out intermittent test regression.