### PR TITLE
Fix issue 556: update pip to latest version to install grpcio quickly

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,7 +24,7 @@ sudo apt-get install -y \
     python3-apt \
     pkg-config \
     docker.io
-sudo pip3 install --upgrade pip
+sudo python3 -m pip install --upgrade pip
 
 sudo systemctl unmask docker.service
 sudo systemctl unmask docker.socket

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,6 +24,7 @@ sudo apt-get install -y \
     python3-apt \
     pkg-config \
     docker.io
+sudo pip3 install --upgrade pip
 
 sudo systemctl unmask docker.service
 sudo systemctl unmask docker.socket

--- a/etc/docker/node-init.sh
+++ b/etc/docker/node-init.sh
@@ -55,6 +55,7 @@ nsenter -t 1 -m -u -n -i apt-get update -y && nsenter -t 1 -m -u -n -i apt-get i
     python3-testresources \
     libcmocka-dev \
     python3-pip && \
+nsenter -t 1 -m -u -n -i pip3 install --upgrade pip
 if [[ "$parsedVersion" -lt "37" ]] ; then
   nsenter -t 1 -m -u -n -i update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 &&
   nsenter -t 1 -m -u -n -i update-alternatives --install /usr/bin/python3 python3 /usr/bin/python$pyversion 2 &&

--- a/etc/docker/node-init.sh
+++ b/etc/docker/node-init.sh
@@ -55,7 +55,7 @@ nsenter -t 1 -m -u -n -i apt-get update -y && nsenter -t 1 -m -u -n -i apt-get i
     python3-testresources \
     libcmocka-dev \
     python3-pip && \
-nsenter -t 1 -m -u -n -i pip3 install --upgrade pip
+nsenter -t 1 -m -u -n -i python3 -m pip install --upgrade pip
 if [[ "$parsedVersion" -lt "37" ]] ; then
   nsenter -t 1 -m -u -n -i update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 &&
   nsenter -t 1 -m -u -n -i update-alternatives --install /usr/bin/python3 python3 /usr/bin/python$pyversion 2 &&

--- a/etc/docker/python_base.Dockerfile
+++ b/etc/docker/python_base.Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get install -y net-tools
 RUN apt-get install -y ethtool
 RUN apt-get install -y iproute2
 RUN apt-get install -y sudo
+RUN python3 -m pip install --upgrade pip
 RUN pip3 install PyYAML
 RUN pip3 install kopf
 RUN pip3 install netaddr

--- a/install/environment_adaptors/default_adaptor.sh
+++ b/install/environment_adaptors/default_adaptor.sh
@@ -119,7 +119,7 @@ function install_dependencies_to_remote {
 
     kubectl exec $pod_name -- nsenter -t 1 -m -u -n -i apt-get update -y
     kubectl exec $pod_name -- nsenter -t 1 -m -u -n -i apt-get install -y sudo rpcbind rsyslog libelf-dev iproute2 net-tools iputils-ping ethtool curl python3 python3-pip
-    kubectl exec $pod_name -- nsenter -t 1 -m -u -n -i pip3 install --upgrade pip
+    kubectl exec $pod_name -- nsenter -t 1 -m -u -n -i python3 -m pip install --upgrade pip
     kubectl exec $pod_name -- nsenter -t 1 -m -u -n -i mkdir -p /opt/cni/bin
     #kubectl exec $pod_name -- nsenter -t 1 -m -u -n -i rm -rf /etc/cni/net.d
     kubectl exec $pod_name -- nsenter -t 1 -m -u -n -i mkdir -p /etc/cni/net.d

--- a/install/environment_adaptors/default_adaptor.sh
+++ b/install/environment_adaptors/default_adaptor.sh
@@ -119,6 +119,7 @@ function install_dependencies_to_remote {
 
     kubectl exec $pod_name -- nsenter -t 1 -m -u -n -i apt-get update -y
     kubectl exec $pod_name -- nsenter -t 1 -m -u -n -i apt-get install -y sudo rpcbind rsyslog libelf-dev iproute2 net-tools iputils-ping ethtool curl python3 python3-pip
+    kubectl exec $pod_name -- nsenter -t 1 -m -u -n -i pip3 install --upgrade pip
     kubectl exec $pod_name -- nsenter -t 1 -m -u -n -i mkdir -p /opt/cni/bin
     #kubectl exec $pod_name -- nsenter -t 1 -m -u -n -i rm -rf /etc/cni/net.d
     kubectl exec $pod_name -- nsenter -t 1 -m -u -n -i mkdir -p /etc/cni/net.d

--- a/k8s/kind/kindnode.Dockerfile
+++ b/k8s/kind/kindnode.Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get install -y curl
 RUN apt-get install -y python3
 RUN apt-get install -y python3-pip
 RUN apt-get install -y tcpdump
-RUN pip3 install --upgrade pip
+RUN python3 -m pip install --upgrade pip
 RUN pip3 install PyYAML
 RUN pip3 install kopf
 RUN pip3 install netaddr

--- a/k8s/kind/kindnode.Dockerfile
+++ b/k8s/kind/kindnode.Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get install -y curl
 RUN apt-get install -y python3
 RUN apt-get install -y python3-pip
 RUN apt-get install -y tcpdump
+RUN pip3 install --upgrade pip
 RUN pip3 install PyYAML
 RUN pip3 install kopf
 RUN pip3 install netaddr

--- a/scripts/01_preinstall.sh
+++ b/scripts/01_preinstall.sh
@@ -12,7 +12,7 @@ sudo apt-get install -y \
     lcov \
     docker.io \
     openvswitch-switch
-sudo pip3 install --upgrade pip
+sudo python3 -m pip install --upgrade pip
 
 sudo pip3 install netaddr docker
 

--- a/scripts/01_preinstall.sh
+++ b/scripts/01_preinstall.sh
@@ -12,6 +12,7 @@ sudo apt-get install -y \
     lcov \
     docker.io \
     openvswitch-switch
+sudo pip3 install --upgrade pip
 
 sudo pip3 install netaddr docker
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -18,6 +18,6 @@ RUN apt-get update -y && apt-get install -y \
         libcmocka-dev \
         lcov \
         sudo
-RUN pip3 install --upgrade pip
+RUN python3 -m pip install --upgrade pip
 
 RUN pip3 install httpserver netaddr

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -18,5 +18,6 @@ RUN apt-get update -y && apt-get install -y \
         libcmocka-dev \
         lcov \
         sudo
+RUN pip3 install --upgrade pip
 
 RUN pip3 install httpserver netaddr

--- a/setup-machine-arktos.sh
+++ b/setup-machine-arktos.sh
@@ -120,6 +120,7 @@ sudo apt-get install -y \
     lcov \
     protobuf-compiler \
     libprotobuf-dev
+sudo pip3 install --upgrade pip
 
 GO111MODULE="on" go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
 GO111MODULE="on" go get google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1

--- a/setup-machine-arktos.sh
+++ b/setup-machine-arktos.sh
@@ -120,7 +120,7 @@ sudo apt-get install -y \
     lcov \
     protobuf-compiler \
     libprotobuf-dev
-sudo pip3 install --upgrade pip
+sudo python3 -m pip install --upgrade pip
 
 GO111MODULE="on" go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
 GO111MODULE="on" go get google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -18,5 +18,5 @@ RUN apt-get update -y && apt-get install -y \
         netcat \
         libcmocka-dev \
         lcov
-RUN pip3 install --upgrade pip
+RUN python3 -m pip install --upgrade pip
 RUN pip3 install httpserver netaddr

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -18,4 +18,5 @@ RUN apt-get update -y && apt-get install -y \
         netcat \
         libcmocka-dev \
         lcov
+RUN pip3 install --upgrade pip
 RUN pip3 install httpserver netaddr


### PR DESCRIPTION
What does this PR do?
Currently there is issue 556 Mizar yaml takes excessive time to deploy on first time deployment on fresh VM. The reason is that pip is spending a lot of time to install grpcio. According to https://github.com/grpc/grpc/issues/22815, the issue can be fixed if update pip to latest version.

How was this tested?
Deployed to a new aws e2e test environment and verify the issue is gone.

Are there any user facing / API changes?
No.