### PR TITLE
Set default traffic QoS class/priority in agent eBPF program to premium/high.

### DIFF
--- a/mizar/common/constants.py
+++ b/mizar/common/constants.py
@@ -105,6 +105,7 @@ class OBJ_DEFAULTS:
     ep_type_gateway = 'gateway'
     droplet_eps = [ep_type_simple, ep_type_host]
 
+    mizar_daemon_service_port = 50051
     mizar_service_annotation_key = "service.beta.kubernetes.io/mizar-scaled-endpoint-type"
     mizar_service_annotation_val = "scaled-endpoint"
 

--- a/mizar/daemon/app.py
+++ b/mizar/daemon/app.py
@@ -7,7 +7,7 @@ from google.protobuf import empty_pb2
 from concurrent import futures
 from mizar.daemon.interface_service import InterfaceServer
 from mizar.daemon.droplet_service import DropletServer
-from mizar.common.constants import CONSTANTS
+from mizar.common.constants import CONSTANTS, OBJ_DEFAULTS
 from mizar.common.common import *
 import mizar.proto.interface_pb2_grpc as interface_pb2_grpc
 import mizar.proto.interface_pb2 as interface_pb2
@@ -179,9 +179,10 @@ def serve():
         InterfaceServer(), server
     )
 
-    server.add_insecure_port('[::]:50051')
+    addr = "[::]:{}".format(OBJ_DEFAULTS.mizar_daemon_service_port)
+    server.add_insecure_port(addr)
     server.start()
-    logger.info("Transit daemon is ready")
+    logger.info("Transit daemon is ready and listening on {}".format(addr))
     try:
         while True:
             time.sleep(100000)

--- a/mizar/daemon/droplet_service.py
+++ b/mizar/daemon/droplet_service.py
@@ -9,6 +9,7 @@ import grpc
 from concurrent import futures
 from google.protobuf import empty_pb2
 from mizar.common.common import get_itf
+from mizar.common.constants import OBJ_DEFAULTS
 
 logger = logging.getLogger()
 
@@ -47,7 +48,8 @@ class DropletServer(droplet_pb2_grpc.DropletServiceServicer):
 
 class DropletClient():
     def __init__(self, ip):
-        self.channel = grpc.insecure_channel('{}:50051'.format(ip))
+        addr = '{}:{}'.format(ip, OBJ_DEFAULTS.mizar_daemon_service_port)
+        self.channel = grpc.insecure_channel(addr)
         self.stub = droplet_pb2_grpc.DropletServiceStub(self.channel)
 
     def GetDropletInfo(self):

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -313,7 +313,8 @@ class InterfaceServer(InterfaceServiceServicer):
 
 class InterfaceServiceClient():
     def __init__(self, ip):
-        self.channel = grpc.insecure_channel('{}:50051'.format(ip))
+        addr = '{}:{}'.format(ip, OBJ_DEFAULTS.mizar_daemon_service_port)
+        self.channel = grpc.insecure_channel(addr)
         self.stub = InterfaceServiceStub(self.channel)
 
     def InitializeInterfaces(self, interfaces_list):

--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -175,7 +175,7 @@ static __inline int trn_encapsulate(struct transit_packet *pkt,
 	int pod_label_value = 0;
 	int namespace_label_value = 0;
 	__u64 egress_bw_bytes_per_sec = 0;
-	__u32 pod_network_class_priority = BESTEFFORT | PRIORITY_MEDIUM;
+	__u32 pod_network_class_priority = PREMIUM | PRIORITY_HIGH;
 	packet_metadata = bpf_map_lookup_elem(&packet_metadata_map, &packet_metadata_key);
 	if (packet_metadata) {
 		pod_label_value = packet_metadata->pod_label_value;


### PR DESCRIPTION
What does this PR do?
This changes the default traffic classification for egress traffic QoS classification in agent XDP program to premium/high so that uses the XDP_REDIRECT path as default. This is a potential fix for an issue in Mizar-Arktos integration.
There's also a minor cleanup change.

How was this tested?
kind-setup and ping tests.

Are there any user facing / API changes?
No.