### PR TITLE
Fixed the issue #573 to add v1.6.4 to goconvey in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -72,7 +72,7 @@ export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
 sudo apt-get install -y protobuf-compiler libprotobuf-dev
 GO111MODULE="on" go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
 GO111MODULE="on" go get google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
-GO111MODULE="on" go get github.com/smartystreets/goconvey
+GO111MODULE="on" go get github.com/smartystreets/goconvey@v1.6.4
 
 git submodule update --init --recursive
 


### PR DESCRIPTION
Please refer to the issue https://github.com/CentaurusInfra/mizar/issues/573

We don't have go installed at beginning.  When we ran bootstrap.sh and got the following error.
```bash
build github.com/smartystreets/goconvey: cannot load embed: malformed module path "embed": missing dot in first path element
```
We added the goconvey version 1.6.4 and verify the change by the following steps
1. Remove all the directory in the directory ~/go/pkg/mod
2. Run bootstrap.sh and found
```bash
go: finding github.com/smartystreets/goconvey v1.6.4
go: downloading github.com/smartystreets/goconvey v1.6.4
```
3. Check the directory ~/go/pkg/mod again and found that goconvey v1.6.4 has been added.
```bash
ubuntu@ip-172-30-0-62:~/go/pkg/mod/github.com/smartystreets$ ls
assertions@v0.0.0-20180927180507-b2de0cb4f26d  goconvey@v1.6.4
```