### PR TITLE
Use premium/high as default DSCP code in agent XDP/eBFP program.

### DIFF
--- a/mizar/arktos/arktos_service.py
+++ b/mizar/arktos/arktos_service.py
@@ -22,6 +22,7 @@ import logging
 import grpc
 import json
 from mizar.proto.builtins_pb2_grpc import BuiltinsServiceServicer, BuiltinsServiceStub
+from mizar.common.constants import OBJ_DEFAULTS
 from mizar.common.workflow import *
 from mizar.dp.mizar.operators.vpcs.vpcs_operator import *
 from mizar.proto.builtins_pb2 import *
@@ -300,7 +301,8 @@ class ArktosService(BuiltinsServiceServicer):
 
 class ArktosServiceClient():
     def __init__(self, ip):
-        self.channel = grpc.insecure_channel('{}:50052'.format(ip))
+        addr = '{}:{}'.format(ip, OBJ_DEFAULTS.mizar_operator_arktos_service_port)
+        self.channel = grpc.insecure_channel(addr)
         self.stub_builtins = BuiltinsServiceStub(self.channel)
 
     def CreatePod(self, BuiltinsPodMessage):

--- a/mizar/common/constants.py
+++ b/mizar/common/constants.py
@@ -106,6 +106,7 @@ class OBJ_DEFAULTS:
     droplet_eps = [ep_type_simple, ep_type_host]
 
     mizar_daemon_service_port = 50051
+    mizar_operator_arktos_service_port = 50052
     mizar_service_annotation_key = "service.beta.kubernetes.io/mizar-scaled-endpoint-type"
     mizar_service_annotation_val = "scaled-endpoint"
 

--- a/mizar/operator.py
+++ b/mizar/operator.py
@@ -104,9 +104,10 @@ def grpc_server():
     builtins_pb2_grpc.add_BuiltinsServiceServicer_to_server(
         ArktosService(), server
     )
-    server.add_insecure_port('[::]:50052')
+    addr = "[::]:{}".format(OBJ_DEFAULTS.mizar_operator_arktos_service_port)
+    server.add_insecure_port(addr)
     server.start()
-    logger.info("Running gRPC server for Network Controller!")
+    logger.info("Operator running gRPC server for Arktos Network Controller on {}".format(addr))
     server.wait_for_termination()
 
 

--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -253,7 +253,7 @@ static __inline int trn_encapsulate(struct transit_packet *pkt,
 	pkt->ip->saddr = metadata->eth.ip;
 	pkt->ip->ttl = pkt->inner_ttl;
 
-	__u8 dscp_code = 0;
+	__u8 dscp_code = DSCP_PREMIUM_HIGH;
 	switch (pod_network_class_priority) {
 	case (PREMIUM|PRIORITY_HIGH):
 		dscp_code = DSCP_PREMIUM_HIGH;
@@ -280,7 +280,7 @@ static __inline int trn_encapsulate(struct transit_packet *pkt,
 		dscp_code = DSCP_BESTEFFORT_LOW;
 		break;
 	default:
-		dscp_code = 0;
+		dscp_code = DSCP_PREMIUM_HIGH;
 	}
 	pkt->ip->tos = dscp_code << 2;
 


### PR DESCRIPTION
Fix the default DSCP code in the agent XDP program to premium/high to preserve the behavior that existed before Pod QoS feature was implemented.

Tested with multi-node K8s cluster and Kind cluster - tested for CRDs provisioning and ping connectivity.