### PR TITLE
[Fornax-Mizar-Integration] control plan changes 

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -7,11 +7,11 @@ name: CI
 on:
   push:
     branches:
-      - dev-next
+      - dev-next-fornax
       - 'CentaurusInfra/mizar'
   pull_request:
     branches:
-      - dev-next
+      - dev-next-fornax
       - 'CentaurusInfra/mizar'
   workflow_dispatch:
 jobs:

--- a/cli/mizarapi.py
+++ b/cli/mizarapi.py
@@ -26,14 +26,15 @@ class MizarApi:
         logger.info("Delete a vpc!!!")
         self.delete_obj(name, "vpcs")
 
-    def create_net(self, name, ip, prefix, vpc, vni, bouncers=1):
+    def create_net(self, name, ip, prefix, vpc, vni, bouncers=1, external=False):
         logger.info("Creating subnet {}".format(name))
         spec = {
             "ip": ip,
             "prefix": prefix,
             "vni": vni,
             "vpc": vpc,
-            "bouncers": bouncers
+            "bouncers": bouncers,
+            "external": external
         }
         self.create_obj(name, "Subnet", spec, "subnets")
 

--- a/cli/mizarapi.py
+++ b/cli/mizarapi.py
@@ -11,12 +11,13 @@ class MizarApi:
         config.load_kube_config()
         self.obj_api = client.CustomObjectsApi()
 
-    def create_vpc(self, name, ip, prefix, dividers=1):
+    def create_vpc(self, name, ip, prefix, dividers=1, vni=None):
         logger.info("Creating VPC {}".format(name))
         spec = {
             "ip": ip,
             "prefix": prefix,
             "dividers": dividers,
+            "vni": vni,
         }
         self.create_obj(name, "Vpc", spec, "vpcs")
 

--- a/cli/mizarapi.py
+++ b/cli/mizarapi.py
@@ -27,7 +27,7 @@ class MizarApi:
         logger.info("Delete a vpc!!!")
         self.delete_obj(name, "vpcs")
 
-    def create_net(self, name, ip, prefix, vpc, vni, bouncers=1, external=False):
+    def create_net(self, name, ip, prefix, vpc, vni, bouncers=1, remoteDeployed=False):
         logger.info("Creating subnet {}".format(name))
         spec = {
             "ip": ip,
@@ -35,7 +35,7 @@ class MizarApi:
             "vni": vni,
             "vpc": vpc,
             "bouncers": bouncers,
-            "external": external
+            "remoteDeployed": remoteDeployed
         }
         self.create_obj(name, "Subnet", spec, "subnets")
 

--- a/etc/crds/subnets.crd.yaml
+++ b/etc/crds/subnets.crd.yaml
@@ -58,6 +58,11 @@ spec:
       priority: 0
       JSONPath: .spec.vpc
       description: The name of the VPC
+    - name: External
+      type: boolean
+      priority: 0
+      JSONPath: .spec.external
+      description: The flag whether the subnet belongs to an external cluster or not
     - name: Status
       type: string
       priority: 0

--- a/etc/crds/subnets.crd.yaml
+++ b/etc/crds/subnets.crd.yaml
@@ -58,11 +58,11 @@ spec:
       priority: 0
       JSONPath: .spec.vpc
       description: The name of the VPC
-    - name: External
+    - name: RemoteDeployed
       type: boolean
       priority: 0
-      JSONPath: .spec.external
-      description: The flag whether the subnet belongs to an external cluster or not
+      JSONPath: .spec.remoteDeployed
+      description: The flag whether the subnet belongs to an remote cluster or not
     - name: Status
       type: string
       priority: 0

--- a/mizar/common/common.py
+++ b/mizar/common/common.py
@@ -461,13 +461,13 @@ def get_itf():
     else:
         return default_itf
 
-def get_portal_host(core_api):
-    # Read portal_host_ip from configmap
-    portal_host_config = kube_read_config_map(core_api,  "portal-host-config", "default")
-    portal_host_ip = ""
-    if portal_host_config:
-        portal_host_ip = portal_host_config.data["portal_host_ip"]
-        logger.info("The portal host ip is {}".format(portal_host_ip))
+def get_cluster_gateway_host_ip(core_api):
+    # Read gateway_host_ip from configmap
+    cluster_gateway_config = kube_read_config_map(core_api,  "cluster-gateway-config", "default")
+    gateway_host_ip = ""
+    if cluster_gateway_config:
+        gateway_host_ip = cluster_gateway_config.data["gateway_host_ip"]
+        logger.info("The gateway host ip is {}".format(gateway_host_ip))
     else:
-        logger.info("No portal host is configured.")
-    return portal_host_ip
+        logger.info("No gateway host is configured.")
+    return gateway_host_ip

--- a/mizar/common/common.py
+++ b/mizar/common/common.py
@@ -460,3 +460,14 @@ def get_itf():
         return os.getenv("MIZAR_ITF")
     else:
         return default_itf
+
+def get_portal_host(core_api):
+    # Read portal_host_ip from configmap
+    portal_host_config = kube_read_config_map(core_api,  "portal-host-config", "default")
+    portal_host_ip = ""
+    if portal_host_config:
+        portal_host_ip = portal_host_config.data["portal_host_ip"]
+        logger.info("The portal host ip is {}".format(portal_host_ip))
+    else:
+        logger.info("No portal host is configured.")
+    return portal_host_ip

--- a/mizar/common/constants.py
+++ b/mizar/common/constants.py
@@ -65,6 +65,7 @@ class OBJ_STATUS:
     vpc_status_allocated = 'Alloc'
     vpc_status_ready = 'Ready'
     vpc_status_provisioned = obj_provisioned
+    vpc_status_error = 'Error'
 
     droplet_status_init = obj_init
     droplet_status_allocated = 'Alloc'

--- a/mizar/common/constants.py
+++ b/mizar/common/constants.py
@@ -65,7 +65,7 @@ class OBJ_STATUS:
     vpc_status_allocated = 'Alloc'
     vpc_status_ready = 'Ready'
     vpc_status_provisioned = obj_provisioned
-    vpc_status_error = 'Error'
+    vpc_status_duplicate_vni_error = 'DuplicateVni'
 
     droplet_status_init = obj_init
     droplet_status_allocated = 'Alloc'

--- a/mizar/common/rpc.py
+++ b/mizar/common/rpc.py
@@ -319,7 +319,7 @@ class TrnRpc:
             "nip": net.get_nip(),
             "prefixlen": net.get_prefixlen(),
             "switches_ips": net.get_bouncers_ips(),
-            "external": net.get_external(),
+            "remote_deployed": net.get_remote_deployed(),
             "cluster_gateway": net.get_cluster_gateway()
         }
         jsonconf = json.dumps(jsonconf)

--- a/mizar/common/rpc.py
+++ b/mizar/common/rpc.py
@@ -318,7 +318,9 @@ class TrnRpc:
             "tunnel_id": net.vni,
             "nip": net.get_nip(),
             "prefixlen": net.get_prefixlen(),
-            "switches_ips": net.get_bouncers_ips()
+            "switches_ips": net.get_bouncers_ips(),
+            "external": net.get_external(),
+            "portal_host": net.get_portal_host()
         }
         jsonconf = json.dumps(jsonconf)
         cmd = f'''{self.trn_cli_update_net} \'{jsonconf}\''''

--- a/mizar/common/rpc.py
+++ b/mizar/common/rpc.py
@@ -320,7 +320,7 @@ class TrnRpc:
             "prefixlen": net.get_prefixlen(),
             "switches_ips": net.get_bouncers_ips(),
             "external": net.get_external(),
-            "portal_host": net.get_portal_host()
+            "cluster_gateway": net.get_cluster_gateway()
         }
         jsonconf = json.dumps(jsonconf)
         cmd = f'''{self.trn_cli_update_net} \'{jsonconf}\''''

--- a/mizar/dp/mizar/operators/dividers/dividers_operator.py
+++ b/mizar/dp/mizar/operators/dividers/dividers_operator.py
@@ -45,6 +45,7 @@ class DividerOperator(object):
         logger.info(kwargs)
         self.store = OprStore()
         config.load_incluster_config()
+        self.core_api = client.CoreV1Api()
         self.obj_api = client.CustomObjectsApi()
 
     def query_existing_dividers(self):
@@ -77,6 +78,8 @@ class DividerOperator(object):
             d.update_net(net)
 
     def delete_bouncer_from_dividers(self, bouncer, net):
+        net.set_portal_host(get_portal_host(self.core_api))
+
         dividers = self.store.get_dividers_of_vpc(bouncer.vpc).values()
         for d in dividers:
             d.update_net(net, False)
@@ -88,6 +91,8 @@ class DividerOperator(object):
             d.update_net(net)
 
     def delete_net(self, net):
+        net.set_portal_host(get_portal_host(self.core_api))
+
         dividers = self.store.get_dividers_of_vpc(net.vpc).values()
         for d in dividers:
             d.delete_net(net)

--- a/mizar/dp/mizar/operators/dividers/dividers_operator.py
+++ b/mizar/dp/mizar/operators/dividers/dividers_operator.py
@@ -73,26 +73,26 @@ class DividerOperator(object):
         div.update_obj()
 
     def update_divider_with_bouncers(self, bouncer, net):
+        net.set_cluster_gateway(get_cluster_gateway_host_ip(self.core_api))
+
         dividers = self.store.get_dividers_of_vpc(bouncer.vpc).values()
         for d in dividers:
             d.update_net(net)
 
     def delete_bouncer_from_dividers(self, bouncer, net):
-        net.set_portal_host(get_portal_host(self.core_api))
-
         dividers = self.store.get_dividers_of_vpc(bouncer.vpc).values()
         for d in dividers:
             d.update_net(net, False)
 
     def update_net(self, net, dividers=None):
+        net.set_cluster_gateway(get_cluster_gateway_host_ip(self.core_api))
+
         if not dividers:
             dividers = self.store.get_dividers_of_vpc(net.vpc).values()
         for d in dividers:
             d.update_net(net)
 
     def delete_net(self, net):
-        net.set_portal_host(get_portal_host(self.core_api))
-
         dividers = self.store.get_dividers_of_vpc(net.vpc).values()
         for d in dividers:
             d.delete_net(net)
@@ -100,6 +100,7 @@ class DividerOperator(object):
     def delete_nets_from_divider(self, nets, divider):
         for net in nets:
             divider.delete_net(net)
+
 
     def update_vpc(self, bouncer):
         dividers = self.store.get_dividers_of_vpc(bouncer.vpc).values()

--- a/mizar/dp/mizar/operators/droplets/droplets_operator.py
+++ b/mizar/dp/mizar/operators/droplets/droplets_operator.py
@@ -98,10 +98,10 @@ class DropletOperator(object):
         subnets = self.store.get_nets_in_vpc(bouncer.vpc)
         # remove portal hosts from the droplet set
         cluster_gateway_droplet = ""
-        external_subnet_ips = set()
+        remote_deployed_subnet_ips = set()
         for subnet in subnets.values():
-            if subnet.external:
-                external_subnet_ips.add(subnet.ip)
+            if subnet.remote_deployed:
+                remote_deployed_subnet_ips.add(subnet.ip)
                 logger.info("A subnet ip {} for subnet {} has been added.".format( subnet.ip, subnet.name))
 
         for dd in droplets:
@@ -113,10 +113,10 @@ class DropletOperator(object):
             droplets.remove(cluster_gateway_droplet)
             logger.info("The cluster gateway droplet {} has been removed.".format(cluster_gateway_droplet))
 
-        if bouncer.get_nip() in external_subnet_ips and cluster_gateway_droplet != "":
-            # for external subnets, use the cluster gateway host instead of picking a host as bouncer
+        if bouncer.get_nip() in remote_deployed_subnet_ips and cluster_gateway_droplet != "":
+            # for remote deployed subnets, use the cluster gateway host instead of picking a host as bouncer
             d = cluster_gateway_droplet
-            logger.info("external subnet, using cluster gateway droplet {}".format(d.ip))
+            logger.info("remote deployed subnet, using cluster gateway droplet {}".format(d.ip))
         else:
             d = random.sample(droplets, 1)[0]
 

--- a/mizar/dp/mizar/operators/droplets/droplets_operator.py
+++ b/mizar/dp/mizar/operators/droplets/droplets_operator.py
@@ -93,11 +93,11 @@ class DropletOperator(object):
         droplets = set(self.store.get_all_droplets())
         if len(droplets) == 0:
             return False
-        # Read portal_host_ip from configmap
-        portal_host_ip = get_portal_host(self.core_api)
+        # Read cluster_gateway_host_ip from configmap
+        cluster_gateway_host_ip = get_cluster_gateway_host_ip(self.core_api)
         subnets = self.store.get_nets_in_vpc(bouncer.vpc)
         # remove portal hosts from the droplet set
-        portal_droplet = ""
+        cluster_gateway_droplet = ""
         external_subnet_ips = set()
         for subnet in subnets.values():
             if subnet.external:
@@ -105,18 +105,18 @@ class DropletOperator(object):
                 logger.info("A subnet ip {} for subnet {} has been added.".format( subnet.ip, subnet.name))
 
         for dd in droplets:
-            if dd.ip == portal_host_ip:
-                portal_droplet = dd
-                logger.info("A droplet {} has been added as portal.".format(dd.ip))
+            if dd.ip == cluster_gateway_host_ip:
+                cluster_gateway_droplet = dd
+                logger.info("A droplet {} has been added as cluster gateway.".format(dd.ip))
 
-        if portal_droplet != "":
-            droplets.remove(portal_droplet)
-            logger.info("The portal droplet {} has been removed.".format(portal_droplet))
+        if cluster_gateway_droplet != "":
+            droplets.remove(cluster_gateway_droplet)
+            logger.info("The cluster gateway droplet {} has been removed.".format(cluster_gateway_droplet))
 
-        if bouncer.get_nip() in external_subnet_ips and portal_droplet != "":
-            # for external subnets, use the portal host instead of picking a host as bouncer
-            d = portal_droplet
-            logger.info("external subnet, using portal droplet {}".format(d.ip))
+        if bouncer.get_nip() in external_subnet_ips and cluster_gateway_droplet != "":
+            # for external subnets, use the cluster gateway host instead of picking a host as bouncer
+            d = cluster_gateway_droplet
+            logger.info("external subnet, using cluster gateway droplet {}".format(d.ip))
         else:
             d = random.sample(droplets, 1)[0]
 
@@ -128,18 +128,18 @@ class DropletOperator(object):
         if len(droplets) == 0:
             return False
 
-        # Read portal_host_ip from configmap
-        portal_host_ip = get_portal_host(self.core_api)
+        # Read cluster_gateway_host_ip from configmap
+        cluster_gateway_host_ip = get_cluster_gateway_host_ip(self.core_api)
 
-        portal_droplet = ""
+        cluster_gateway_droplet = ""
         for dd in droplets:
-            if dd.ip == portal_host_ip:
-                portal_droplet = dd
-                logger.info("The portal droplet {} has been added.".format(dd.ip))
-        if portal_droplet != "":
-            droplets.remove(portal_droplet)
+            if dd.ip == cluster_gateway_host_ip:
+                cluster_gateway_droplet = dd
+                logger.info("The cluster gateway droplet {} has been added.".format(dd.ip))
+        if cluster_gateway_droplet != "":
+            droplets.remove(cluster_gateway_droplet)
 
-        # All the droplets have been removed as portal host droplet
+        # All the droplets have been removed as cluster gateway  host droplet
         if len(droplets) == 0:
             return False
 

--- a/mizar/dp/mizar/operators/nets/nets_operator.py
+++ b/mizar/dp/mizar/operators/nets/nets_operator.py
@@ -134,3 +134,7 @@ class NetOperator(object):
     def deallocate_endpoint(self, ep):
         n = self.store.get_net(ep.net)
         n.deallocate_ip(ep.ip)
+
+    def process_external_change(self, net, new):
+        logger.info("Update external to {} for net: {}".format(new, net.name))
+        net.set_external(new)

--- a/mizar/dp/mizar/operators/nets/nets_operator.py
+++ b/mizar/dp/mizar/operators/nets/nets_operator.py
@@ -135,6 +135,6 @@ class NetOperator(object):
         n = self.store.get_net(ep.net)
         n.deallocate_ip(ep.ip)
 
-    def process_external_change(self, net, new):
-        logger.info("Update external to {} for net: {}".format(new, net.name))
-        net.set_external(new)
+    def process_remote_deployed_change(self, net, new):
+        logger.info("Update remote_deployed to {} for net: {}".format(new, net.name))
+        net.set_remote_deployed(new)

--- a/mizar/dp/mizar/operators/vpcs/vpcs_operator.py
+++ b/mizar/dp/mizar/operators/vpcs/vpcs_operator.py
@@ -121,8 +121,20 @@ class VpcOperator(object):
         # TODO: There is a tiny chance of collision here, not to worry about now
         if vpc.name == OBJ_DEFAULTS.default_ep_vpc:
             return OBJ_DEFAULTS.default_vpc_vni
-        vpc.set_vni(str(uuid.uuid4().int & (1 << 24)-1))
+        # If the vni is not set, a random vni will be allocated instead.
+        if vpc.vni is None:
+            vpc.set_vni(str(uuid.uuid4().int & (1 << 24)-1))
 
     def deallocate_vni(self, vpc):
         # TODO: Keep track of VNI allocation
         pass
+
+    def set_vpc_error(self, vpc):
+        vpc.set_status(OBJ_STATUS.vpc_status_error)
+        vpc.update_obj()
+
+    def is_vni_duplicated(self, vpc):
+        for item in self.store.vpcs_store.values():
+            if item.vni == vpc.vni and item.name != vpc.name:
+                return True
+        return False

--- a/mizar/dp/mizar/operators/vpcs/vpcs_operator.py
+++ b/mizar/dp/mizar/operators/vpcs/vpcs_operator.py
@@ -129,8 +129,8 @@ class VpcOperator(object):
         # TODO: Keep track of VNI allocation
         pass
 
-    def set_vpc_error(self, vpc):
-        vpc.set_status(OBJ_STATUS.vpc_status_error)
+    def set_vpc_duplicate_vni_error(self, vpc):
+        vpc.set_status(OBJ_STATUS.vpc_status_duplicate_vni_error)
         vpc.update_obj()
 
     def is_vni_duplicated(self, vpc):

--- a/mizar/dp/mizar/workflows/nets/provisioned.py
+++ b/mizar/dp/mizar/workflows/nets/provisioned.py
@@ -51,3 +51,5 @@ class NetProvisioned(WorkflowTask):
         logger.info("diff_field:{}, from:{}, to:{}".format(field, old, new))
         if field[0] == 'spec' and field[1] == 'bouncers':
             return nets_opr.process_bouncer_change(net, int(old), int(new))
+        if field[0] == 'spec' and field[1] == 'external':
+            return nets_opr.process_external_change(net, new)

--- a/mizar/dp/mizar/workflows/nets/provisioned.py
+++ b/mizar/dp/mizar/workflows/nets/provisioned.py
@@ -51,5 +51,5 @@ class NetProvisioned(WorkflowTask):
         logger.info("diff_field:{}, from:{}, to:{}".format(field, old, new))
         if field[0] == 'spec' and field[1] == 'bouncers':
             return nets_opr.process_bouncer_change(net, int(old), int(new))
-        if field[0] == 'spec' and field[1] == 'external':
-            return nets_opr.process_external_change(net, new)
+        if field[0] == 'spec' and field[1] == 'remoteDeployed':
+            return nets_opr.process_remote_deployed_change(net, new)

--- a/mizar/dp/mizar/workflows/vpcs/create.py
+++ b/mizar/dp/mizar/workflows/vpcs/create.py
@@ -44,7 +44,7 @@ class VpcCreate(WorkflowTask):
             v = vpcs_opr.get_vpc_stored_obj(self.param.name, self.param.spec)
         if vpcs_opr.is_vni_duplicated(v):
             # Set vpc status to error instead of raising errors since the latter does not trigger the workflow in future
-            vpcs_opr.set_vpc_error(v)
+            vpcs_opr.set_vpc_duplicate_vni_error(v)
         else:
             if len(droplets_opr.store.get_all_droplets()) == 0:
                 self.raise_temporary_error(

--- a/mizar/obj/net.py
+++ b/mizar/obj/net.py
@@ -46,7 +46,7 @@ class Net(object):
         self.status = OBJ_STATUS.net_status_init
         self.ip = OBJ_DEFAULTS.default_net_ip
         self.prefix = OBJ_DEFAULTS.default_net_prefix
-        self.external = False
+        self.remote_deployed = False
         self.cluster_gateway = ""
         if spec is not None:
             self.set_obj_spec(spec)
@@ -67,7 +67,7 @@ class Net(object):
             "vpc": self.vpc,
             "bouncers": self.n_bouncers,
             "status": self.status,
-            "external": self.external,
+            "remote_deployed": self.remote_deployed,
             "cluster_gateway": self.cluster_gateway
         }
 
@@ -82,7 +82,7 @@ class Net(object):
         self.ip = get_spec_val('ip', spec, OBJ_DEFAULTS.default_net_ip)
         self.prefix = get_spec_val(
             'prefix', spec, OBJ_DEFAULTS.default_net_prefix)
-        self.external = bool(get_spec_val('external', spec))
+        self.remote_deployed = bool(get_spec_val('remoteDeployed', spec))
         self.cluster_gateway = get_spec_val('cluster_gateway', spec)
 
     # K8s APIs
@@ -126,8 +126,8 @@ class Net(object):
     def get_gw_ip(self):
         return str(self.cidr.get_ip(1))
 
-    def set_external(self, external):
-        self.external = external
+    def set_remote_deployed(self, remote_deployed):
+        self.remote_deployed = remote_deployed
 
     def set_cluster_gateway(self, cluster_gateway):
         self.cluster_gateway = cluster_gateway
@@ -148,8 +148,8 @@ class Net(object):
                 bouncer_ips.append(b.ip)
         return bouncer_ips
 
-    def get_external(self):
-        return bool(self.external)
+    def get_remote_deployed(self):
+        return bool(self.remote_deployed)
 
     def get_cluster_gateway(self):
         return str(self.cluster_gateway)

--- a/mizar/obj/net.py
+++ b/mizar/obj/net.py
@@ -46,6 +46,8 @@ class Net(object):
         self.status = OBJ_STATUS.net_status_init
         self.ip = OBJ_DEFAULTS.default_net_ip
         self.prefix = OBJ_DEFAULTS.default_net_prefix
+        self.external = False
+        self.portal_host = ""
         if spec is not None:
             self.set_obj_spec(spec)
         if self.prefix == "":
@@ -64,7 +66,9 @@ class Net(object):
             "vni": self.vni,
             "vpc": self.vpc,
             "bouncers": self.n_bouncers,
-            "status": self.status
+            "status": self.status,
+            "external": self.external,
+            "portal_host": self.portal_host
         }
 
         return self.obj
@@ -78,6 +82,8 @@ class Net(object):
         self.ip = get_spec_val('ip', spec, OBJ_DEFAULTS.default_net_ip)
         self.prefix = get_spec_val(
             'prefix', spec, OBJ_DEFAULTS.default_net_prefix)
+        self.external = bool(get_spec_val('external', spec))
+        self.portal_host = get_spec_val('portal_host', spec)
 
     # K8s APIs
     def get_name(self):
@@ -120,6 +126,12 @@ class Net(object):
     def get_gw_ip(self):
         return str(self.cidr.get_ip(1))
 
+    def set_external(self, external):
+        self.external = external
+
+    def set_portal_host(self, portal_host):
+        self.portal_host = portal_host
+
     def get_tunnel_id(self):
         return str(self.vni)
 
@@ -135,6 +147,12 @@ class Net(object):
             if b.ip not in bouncer_ips:
                 bouncer_ips.append(b.ip)
         return bouncer_ips
+
+    def get_external(self):
+        return bool(self.external)
+
+    def get_portal_host(self):
+        return str(self.portal_host)
 
     def create_bouncer(self):
         u = str(uuid.uuid4())

--- a/mizar/obj/net.py
+++ b/mizar/obj/net.py
@@ -47,7 +47,7 @@ class Net(object):
         self.ip = OBJ_DEFAULTS.default_net_ip
         self.prefix = OBJ_DEFAULTS.default_net_prefix
         self.external = False
-        self.portal_host = ""
+        self.cluster_gateway = ""
         if spec is not None:
             self.set_obj_spec(spec)
         if self.prefix == "":
@@ -68,7 +68,7 @@ class Net(object):
             "bouncers": self.n_bouncers,
             "status": self.status,
             "external": self.external,
-            "portal_host": self.portal_host
+            "cluster_gateway": self.cluster_gateway
         }
 
         return self.obj
@@ -83,7 +83,7 @@ class Net(object):
         self.prefix = get_spec_val(
             'prefix', spec, OBJ_DEFAULTS.default_net_prefix)
         self.external = bool(get_spec_val('external', spec))
-        self.portal_host = get_spec_val('portal_host', spec)
+        self.cluster_gateway = get_spec_val('cluster_gateway', spec)
 
     # K8s APIs
     def get_name(self):
@@ -129,8 +129,8 @@ class Net(object):
     def set_external(self, external):
         self.external = external
 
-    def set_portal_host(self, portal_host):
-        self.portal_host = portal_host
+    def set_cluster_gateway(self, cluster_gateway):
+        self.cluster_gateway = cluster_gateway
 
     def get_tunnel_id(self):
         return str(self.vni)
@@ -151,8 +151,8 @@ class Net(object):
     def get_external(self):
         return bool(self.external)
 
-    def get_portal_host(self):
-        return str(self.portal_host)
+    def get_cluster_gateway(self):
+        return str(self.cluster_gateway)
 
     def create_bouncer(self):
         u = str(uuid.uuid4())

--- a/mizar/obj/tests/test_vpc_with_dup_vni.yaml
+++ b/mizar/obj/tests/test_vpc_with_dup_vni.yaml
@@ -1,0 +1,10 @@
+apiVersion: mizar.com/v1
+kind: Vpc
+metadata:
+  name: vpc11
+spec:
+  vni: 10
+  ip: "192.168.11.0"
+  prefix: "24"
+  dividers: 1
+  status: "Init"

--- a/mizar/obj/tests/test_vpc_with_no_vni.yaml
+++ b/mizar/obj/tests/test_vpc_with_no_vni.yaml
@@ -1,0 +1,9 @@
+apiVersion: mizar.com/v1
+kind: Vpc
+metadata:
+  name: vpc12
+spec:
+  ip: "192.168.12.0"
+  prefix: "24"
+  dividers: 1
+  status: "Init"

--- a/mizar/obj/tests/test_vpc_with_vni.yaml
+++ b/mizar/obj/tests/test_vpc_with_vni.yaml
@@ -1,0 +1,10 @@
+apiVersion: mizar.com/v1
+kind: Vpc
+metadata:
+  name: vpc10
+spec:
+  vni: 10
+  ip: "192.168.10.0"
+  prefix: "24"
+  dividers: 1
+  status: "Init"

--- a/teste2e/common/k8s.py
+++ b/teste2e/common/k8s.py
@@ -1,3 +1,4 @@
+import time
 import yaml
 from teste2e.common.helper import *
 from cli.mizarapi import *
@@ -49,16 +50,24 @@ class k8sApi:
         self.operator_pod_name = run_cmd_text(
             "kubectl get pods | grep mizar-operator | awk '{print $1}'")
 
-    def create_vpc(self, name, ip, prefix, dividers=1):
-        self.api.create_vpc(name, ip, prefix, dividers)
+    def create_vpc(self, name, ip, prefix, dividers=1, vni=None):
+        self.api.create_vpc(name, ip, prefix, dividers, vni)
 
-    def create_net(self, name, ip, prefix, vpc, vni, bouncers=1):
-        self.api.create_net(name, ip, prefix, vpc, vni, bouncers)
+    def create_net(self, name, ip, prefix, vpc, vni, bouncers=1, external=False):
+        self.api.create_net(name, ip, prefix, vpc, vni, bouncers, external)
 
     def get_vpc(self, name):
         vpc = self.api.get_vpc(name)
         while vpc["status"] != OBJ_STATUS.obj_provisioned:
             vpc = self.api.get_vpc(name)
+        return vpc
+
+    def get_vpc_with_status_timeout(self, name, status=OBJ_STATUS.obj_provisioned, timeout=60):
+        timeout_start = time.time()
+        while  time.time() < timeout_start + timeout:
+            vpc = self.api.get_vpc(name)
+            if vpc["status"] == status:
+                return vpc
         return vpc
 
     def get_net(self, name):

--- a/teste2e/common/k8s.py
+++ b/teste2e/common/k8s.py
@@ -53,8 +53,8 @@ class k8sApi:
     def create_vpc(self, name, ip, prefix, dividers=1, vni=None):
         self.api.create_vpc(name, ip, prefix, dividers, vni)
 
-    def create_net(self, name, ip, prefix, vpc, vni, bouncers=1, external=False):
-        self.api.create_net(name, ip, prefix, vpc, vni, bouncers, external)
+    def create_net(self, name, ip, prefix, vpc, vni, bouncers=1, remote_deployed=False):
+        self.api.create_net(name, ip, prefix, vpc, vni, bouncers, remote_deployed)
 
     def get_vpc(self, name):
         vpc = self.api.get_vpc(name)

--- a/teste2e/test_basic_vpc.py
+++ b/teste2e/test_basic_vpc.py
@@ -1,5 +1,6 @@
 
 import unittest
+from mizar.common.constants import *
 from teste2e.common.k8s import *
 from teste2e.common.helper import *
 
@@ -11,14 +12,30 @@ class test_basic_vpc(unittest.TestCase):
         self.cluster = k8sCluster()
         self.api = k8sApi()
         vpc_name = "vpc1"
+        vpc_name_with_empty_vni = "vpc2"
+        vpc_name_with_dup_vni = "vpc3"
+        vni = 10
         subnet_name = "net1"
         subnet2_name = "net2"
         self.vpc = self.api.create_vpc(vpc_name, "12.0.0.0", "8")
+        
+        # Test vpc creation with empty vni
+        self.api.create_vpc(vpc_name_with_empty_vni, "13.0.0.0", "8", 1, None)
+        vpc_with_empty_vni = self.api.get_vpc_with_status_timeout(vpc_name_with_empty_vni)
+        self.assertNotEqual(vpc_with_empty_vni["vni"], None, "The vni shall not be none.")
+        self.assertEqual(vpc_with_empty_vni["status"], OBJ_STATUS.obj_provisioned, "The status shall be provisioned.")
+
+        # Test vpc creation with duplicate vni
+        self.vpc_with_dup_vni = self.api.create_vpc(vpc_name_with_dup_vni, "14.0.0.0", "8", 1, vpc_with_empty_vni["vni"])
+        vpc_with_dup_vni = self.api.get_vpc_with_status_timeout(vpc_name_with_dup_vni, OBJ_STATUS.vpc_status_duplicate_vni_error)
+        self.assertEqual(vpc_with_dup_vni["status"], OBJ_STATUS.vpc_status_duplicate_vni_error, "The status shall be duplicate vni error.")
+
         vpc = self.api.get_vpc(vpc_name)
+
         self.subnet1 = self.api.create_net(
             subnet_name, "12.2.0.0", "16", vpc_name, vpc["vni"])
         self.subnet2 = self.api.create_net(
-            subnet2_name, "12.4.0.0", "16", vpc_name, vpc["vni"])
+            subnet2_name, "12.4.0.0", "16", vpc_name, vpc["vni"], 1, False)
         self.api.get_net(subnet_name)
         self.api.get_net(subnet2_name)
         self.ep1 = self.api.create_pod(


### PR DESCRIPTION
There are two major changes.

**Add a new VNI field in yaml files to create VPC using predefined VNI**

If you don't have any vni settings, it will have a random vni set as usual. 
If there is duplicated vni, the vpc status will be updated to Error.

a. Run the following command to create a vpc with customized vni.  
```bash
kubectl apply -f mizar/obj/tests/test_vpc_with_vni.yaml
```
And you will get the following vpc with vni 10
```bash
ubuntu@ip-172-30-0-62:~/mizar$ kubectl get vpcs vpc10
NAME    IP             PREFIX   VNI   DIVIDERS   STATUS        CREATETIME   PROVISIONDELAY
vpc10   192.168.10.0   24       10    1          Provisioned
```
b. Run the following command to create a vpc with a duplicated vni.  
```bash
kubectl apply -f mizar/obj/tests/test_vpc_with_dup_vni.yaml
```
And you will get the following vpc whose status is Error
```bash
ubuntu@ip-172-30-0-62:~/mizar$ kubectl get vpcs vpc11
NAME    IP             PREFIX   VNI   DIVIDERS   STATUS   CREATETIME   PROVISIONDELAY
vpc11   192.168.11.0   24       10    1          Duplicate vni
```
c. Run the following command to create a vpc without vni 
```bash
kubectl apply -f mizar/obj/tests/test_vpc_with_no_vni.yaml
```
And you will get the following vpc whose vni has been set to a random number
```bash
ubuntu@ip-172-30-0-62:~/mizar$ kubectl get vpcs vpc12
NAME    IP             PREFIX   VNI       DIVIDERS   STATUS        CREATETIME   PROVISIONDELAY
vpc12   192.168.10.0   24       2771449   1          Provisioned
```

**Added portal host to configmap**

```bash
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: cluster-gateway-config
  namespace: default
data:
  gateway_host_ip: 172.31.15.208
EOF
```

Verify the config has been added successfully
```bash
root@ip-172-31-2-32:~/mizar_cluster_scripts# kubectl get configmap cluster-gateway-config -o json
{
    "apiVersion": "v1",
    "data": {
        "gateway_host_ip": "172.31.15.208"
    },
    "kind": "ConfigMap",
    "metadata": {
        "annotations": {
            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"portal_host_ip\":\"172.31.15.208\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"name\":\"cluster-gateway-config\",\"namespace\":\"default\"}}\n"
        },
        "creationTimestamp": "2021-12-10T20:40:09Z",
        "name": "cluster-gateway-config",
        "namespace": "default",
        "resourceVersion": "1226",
        "uid": "a344336f-c954-4b9b-a4fa-acbd1e2ec363"
    }
}
```

The host 172.31.15.208 has been added as cluster gateway. So that all the subnets in the cluster, which external flag is false) won't use the host to create bouncers
```bash
root@ip-172-31-2-32:~/mizar_cluster_scripts# kubectl get subnet net1
NAME   IP            PREFIX   VNI   VPC    STATUS        EXTERNAL   BOUNCERS   CREATETIME   PROVISIONDELAY
net1   192.168.0.0   24       2     vpc1   Provisioned   false      1

root@ip-172-31-2-32:~/mizar_cluster_scripts# kubectl get  bouncers
NAME                                          VPC    NET    IP              MAC                 DROPLET            STATUS        CREATETIME                   PROVISIONDELAY
net1-b-31c84764-d798-4213-8b6c-c062994367bd   vpc1   net1   172.31.15.85    0a:a7:d2:0e:4b:bb   ip-172-31-15-85    Provisioned   2021-12-10T20:40:10.791154   0.591665
```

If a subnet external flag is true, it will use the given cluster gateway as bouncers
```bash
root@ip-172-31-2-32:~/mizar_cluster_scripts# kubectl get subnet net2
NAME   IP              PREFIX   VNI   VPC    STATUS        EXTERNAL   BOUNCERS   CREATETIME   PROVISIONDELAY
net2   192.168.122.0   24       2     vpc1   Provisioned   true       1

root@ip-172-31-2-32:~/mizar_cluster_scripts# kubectl get  bouncers
NAME                                          VPC    NET    IP              MAC                 DROPLET            STATUS        CREATETIME                   PROVISIONDELAY
net2-b-f0b83bb9-1c4b-4b44-942b-44f7bb722c73   vpc1   net2   172.31.15.208   0a:c5:74:b5:4b:65   ip-172-31-15-208   Provisioned   2021-12-10T20:40:10.948333   0.675322
```

