### PR TITLE
Arktos Integration Update

### DIFF
--- a/mizar/arktos/arktos_service.py
+++ b/mizar/arktos/arktos_service.py
@@ -54,26 +54,26 @@ class ArktosService(BuiltinsServiceServicer):
         param.body['metadata']['namespace'] = request.namespace
         param.body['status']['phase'] = request.phase
         param.body['metadata']['tenant'] = request.tenant
-        if request.annotations[OBJ_DEFAULTS.mizar_ep_vpc_annotation]:
-            logger.info("VPC annotation {}").format(
-                request.annotations[OBJ_DEFAULTS.mizar_ep_vpc_annotation])
+        if request.vpc:
+            logger.info("VPC annotation {}".format(
+                request.vpc))
         else:
             logger.info("VPC annotation is NONE")
             return ReturnCode(
                 code=CodeType.PERM_ERROR,
                 message="Missing VPC annotation"
             )
-        if request.annotations[OBJ_DEFAULTS.mizar_ep_subnet_annotation]:
-            logger.info("Subnet annotation {}").format(
-                request.annotations[OBJ_DEFAULTS.mizar_ep_subnet_annotation])
+        if request.subnet:
+            logger.info("Subnet annotation {}".format(
+                request.subnet))
         else:
             logger.info("subnet annotation is NONE")
             return ReturnCode(
                 code=CodeType.PERM_ERROR,
                 message="Missing Subnet annotation"
             )
-        param.body['metadata']['annotations'][OBJ_DEFAULTS.mizar_ep_vpc_annotation] = request.annotations[OBJ_DEFAULTS.mizar_ep_vpc_annotation]
-        param.body['metadata']['annotations'][OBJ_DEFAULTS.mizar_ep_subnet_annotation] = request.annotations[OBJ_DEFAULTS.mizar_ep_subnet_annotation]
+        param.body['metadata']['annotations'][OBJ_DEFAULTS.mizar_ep_vpc_annotation] = request.vpc
+        param.body['metadata']['annotations'][OBJ_DEFAULTS.mizar_ep_subnet_annotation] = request.subnet
 
         param.extra = {}
         store.update_pod_namespace_store(param.name, param.namespace)
@@ -274,22 +274,22 @@ class ArktosService(BuiltinsServiceServicer):
         return self.CreateNamespace(request, context)
 
     def UpdatePod(self, request, context):
-        if request.annotations[OBJ_DEFAULTS.mizar_ep_vpc_annotation]:
-            logger.info("POD_UPDATE vpc annotation {}").format(
-                request.annotations[OBJ_DEFAULTS.mizar_ep_vpc_annotation])
+        if request.vpc:
+            logger.info("POD_UPDATE vpc annotation {}".format(
+                request.vpc))
         else:
             logger.info("POD_UPDATE vpc annotation is NONE")
             return ReturnCode(
-                code=CodeType.PERM_ERROR,
+                code=CodeType.TEMP_ERROR,
                 message="Missing VPC annotation"
             )
-        if request.annotations[OBJ_DEFAULTS.mizar_ep_subnet_annotation]:
-            logger.info("POD_UPDATE subnet annotation {}").format(
-                request.annotations[OBJ_DEFAULTS.mizar_ep_subnet_annotation])
+        if request.subnet:
+            logger.info("POD_UPDATE subnet annotation {}".format(
+                request.subnet))
         else:
             logger.info("POD_UPDATE subnet annotation is NONE")
             return ReturnCode(
-                code=CodeType.PERM_ERROR,
+                code=CodeType.TEMP_ERROR,
                 message="Missing Subnet annotation"
             )
         return self.CreatePod(request, context)

--- a/mizar/arktos/arktos_service.py
+++ b/mizar/arktos/arktos_service.py
@@ -54,8 +54,27 @@ class ArktosService(BuiltinsServiceServicer):
         param.body['metadata']['namespace'] = request.namespace
         param.body['status']['phase'] = request.phase
         param.body['metadata']['tenant'] = request.tenant
+        if request.annotations[OBJ_DEFAULTS.mizar_ep_vpc_annotation]:
+            logger.info("VPC annotation {}").format(
+                request.annotations[OBJ_DEFAULTS.mizar_ep_vpc_annotation])
+        else:
+            logger.info("VPC annotation is NONE")
+            return ReturnCode(
+                code=CodeType.PERM_ERROR,
+                message="Missing VPC annotation"
+            )
+        if request.annotations[OBJ_DEFAULTS.mizar_ep_subnet_annotation]:
+            logger.info("Subnet annotation {}").format(
+                request.annotations[OBJ_DEFAULTS.mizar_ep_subnet_annotation])
+        else:
+            logger.info("subnet annotation is NONE")
+            return ReturnCode(
+                code=CodeType.PERM_ERROR,
+                message="Missing Subnet annotation"
+            )
         param.body['metadata']['annotations'][OBJ_DEFAULTS.mizar_ep_vpc_annotation] = request.annotations[OBJ_DEFAULTS.mizar_ep_vpc_annotation]
         param.body['metadata']['annotations'][OBJ_DEFAULTS.mizar_ep_subnet_annotation] = request.annotations[OBJ_DEFAULTS.mizar_ep_subnet_annotation]
+
         param.extra = {}
         store.update_pod_namespace_store(param.name, param.namespace)
         logger.info("===request.labels is {}===".format(request.labels))
@@ -255,6 +274,24 @@ class ArktosService(BuiltinsServiceServicer):
         return self.CreateNamespace(request, context)
 
     def UpdatePod(self, request, context):
+        if request.annotations[OBJ_DEFAULTS.mizar_ep_vpc_annotation]:
+            logger.info("POD_UPDATE vpc annotation {}").format(
+                request.annotations[OBJ_DEFAULTS.mizar_ep_vpc_annotation])
+        else:
+            logger.info("POD_UPDATE vpc annotation is NONE")
+            return ReturnCode(
+                code=CodeType.PERM_ERROR,
+                message="Missing VPC annotation"
+            )
+        if request.annotations[OBJ_DEFAULTS.mizar_ep_subnet_annotation]:
+            logger.info("POD_UPDATE subnet annotation {}").format(
+                request.annotations[OBJ_DEFAULTS.mizar_ep_subnet_annotation])
+        else:
+            logger.info("POD_UPDATE subnet annotation is NONE")
+            return ReturnCode(
+                code=CodeType.PERM_ERROR,
+                message="Missing Subnet annotation"
+            )
         return self.CreatePod(request, context)
 
     def UpdateNode(self, request, context):

--- a/mizar/arktos/arktos_service.py
+++ b/mizar/arktos/arktos_service.py
@@ -182,6 +182,9 @@ class ArktosService(BuiltinsServiceServicer):
         param.name = request.name
         param.body['metadata'] = {}
         param.body["metadata"]["namespace"] = request.namespace
+        param.body['metadata']['tenant'] = request.tenant
+        logger.info("Service Endpoint name {} namespace {} tenant {}".format(
+            request.name, request.namespace, request.tenant))
         ips = json.loads(request.backend_ips_json)
         ports = json.loads(request.ports_json)
         param.extra = {}

--- a/mizar/arktos/arktos_service.py
+++ b/mizar/arktos/arktos_service.py
@@ -58,10 +58,17 @@ class ArktosService(BuiltinsServiceServicer):
         param.body['metadata']['annotations'][OBJ_DEFAULTS.mizar_ep_subnet_annotation] = request.annotations[OBJ_DEFAULTS.mizar_ep_subnet_annotation]
         param.extra = {}
         store.update_pod_namespace_store(param.name, param.namespace)
-        if request.labels is not None and len(request.labels) != 0:
-            param.body['metadata']['labels'] = json.loads(request.labels)
+        logger.info("===request.labels is {}===".format(request.labels))
+        try:
+            labels = json.loads(request.labels)
+        except ValueError as e:
+            logger.info(
+                "Client sent invalid JSON for pod labels: {}".format(request.labels))
+            labels = None
+        if labels:
+            param.body['metadata']['labels'] = labels
             logger.info("Labels for pod {} from Arktos Service are {}".format(
-                request.name, request.labels))
+                request.name, labels))
             diff_item = []
             diff_item.append('add')
             diff_item.append(tuple())
@@ -74,7 +81,7 @@ class ArktosService(BuiltinsServiceServicer):
             # new
             new_dict = {}
             new_dict['metadata'] = {}
-            new_dict['metadata']['labels'] = json.loads(request.labels)
+            new_dict['metadata']['labels'] = labels
             diff_item.append(new_dict)
             diff_items = []
             diff_items.append(tuple(diff_item))

--- a/mizar/common/constants.py
+++ b/mizar/common/constants.py
@@ -112,8 +112,8 @@ class OBJ_DEFAULTS:
 
     arktos_pod_label = "arktos.futurewei.com/network"
     arktos_pod_annotation = "arktos.futurewei.com/nic"
-    mizar_pod_vpc_annotation = "mizar.com/vpc"
-    mizar_pod_subnet_annotation = "mizar.com/subnet"
+    mizar_ep_vpc_annotation = "mizar.com/vpc"
+    mizar_ep_subnet_annotation = "mizar.com/subnet"
 
     # 5 minutes of retries
     kopf_max_retries = 15

--- a/mizar/dp/mizar/workflows/builtins/pods/create.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/create.py
@@ -78,12 +78,12 @@ class k8sPodCreate(WorkflowTask):
                     subnet_name = self.param.body['metadata'].get(
                         'annotations').get(OBJ_DEFAULTS.mizar_ep_subnet_annotation)
                     subnet = net_opr.store.get_net(subnet_name)
-                    if subnet.vpc != vpc_name:
-                        self.raise_temporary_error("Subnet {} of pod {} does not belong to VPC {}".format(
-                            subnet_name, self.param.name, vpc_name))
                     if not subnet:
                         self.raise_temporary_error(
                             "Subnet {} of pod {} does not exist!".format(subnet_name, self.param.name))
+                    if subnet.vpc != vpc_name:
+                        self.raise_temporary_error("Subnet {} of pod {} does not belong to VPC {}".format(
+                            subnet_name, self.param.name, vpc_name))
                 else:
                     subnets = list(net_opr.store.get_nets_in_vpc(vpc_name))
                     if subnets:

--- a/mizar/dp/mizar/workflows/builtins/pods/triggers.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/triggers.py
@@ -50,5 +50,5 @@ async def builtins_on_pod_delete(body, spec, **kwargs):
     param.namespace = kwargs['namespace']
     param.body = body
     param.spec = spec
-    param.diff = [("remove", (), body, None)]   
+    param.diff = [("remove", (), body, None)]
     run_workflow(wffactory().k8sPodDelete(param=param))

--- a/mizar/dp/mizar/workflows/builtins/services/create.py
+++ b/mizar/dp/mizar/workflows/builtins/services/create.py
@@ -67,7 +67,7 @@ class k8sServiceCreate(WorkflowTask):
                     subnets = list(net_opr.store.get_nets_in_vpc(vpc_name))
                     if subnets:
                         subnet_name = subnets[0]
-                        logger.info("Subnet not specified, allocating service {} in subnet {} for VPC {}".format(
+                        logger.info("Subnet specified, allocating service {} in subnet {} for VPC {}".format(
                             self.param.name, subnet_name, vpc_name))
                     else:
                         self.raise_temporary_error(

--- a/mizar/dp/mizar/workflows/nets/create.py
+++ b/mizar/dp/mizar/workflows/nets/create.py
@@ -26,6 +26,7 @@ from mizar.dp.mizar.operators.dividers.dividers_operator import *
 from mizar.dp.mizar.operators.bouncers.bouncers_operator import *
 from mizar.dp.mizar.operators.endpoints.endpoints_operator import *
 from mizar.dp.mizar.operators.droplets.droplets_operator import *
+from mizar.dp.mizar.operators.vpcs.vpcs_operator import *
 
 logger = logging.getLogger()
 
@@ -34,6 +35,7 @@ dividers_opr = DividerOperator()
 bouncers_opr = BouncerOperator()
 endpoints_opr = EndpointOperator()
 droplets_opr = DropletOperator()
+vpcs_opr = VpcOperator()
 
 
 class NetCreate(WorkflowTask):
@@ -52,6 +54,11 @@ class NetCreate(WorkflowTask):
         if len(droplets_opr.store.get_all_droplets()) == 0:
             self.raise_temporary_error(
                 "Task: {} Net: {} No droplets available.".format(self.__class__.__name__, n.name))
+        vpc = vpcs_opr.store.get_vpc(n.vpc)
+        if not vpc:
+            self.raise_temporary_error(
+                "Task: {} Net: {} VPC {} not yet created".format(self.__class__.__name__, n.name, n.vpc))
+        n.set_vni(vpc.vni)
         if len(dividers_opr.store.get_dividers_of_vpc(n.vpc)) < 1:
             self.raise_temporary_error(
                 "Task: {} Net: {} Dividers not available".format(self.__class__.__name__, n.name))

--- a/mizar/proto/mizar/proto/builtins.proto
+++ b/mizar/proto/mizar/proto/builtins.proto
@@ -53,7 +53,8 @@ message BuiltinsPodMessage {
   string labels = 5;
   string arktos_network = 6;
   string phase = 7;
-  repeated InterfacesMessage interfaces = 8;
+  repeated InterfacesMessage interfaces = 8 ;
+  map<string, string> annotations = 9;
 }
 
 message BuiltinsServiceMessage {

--- a/mizar/proto/mizar/proto/builtins.proto
+++ b/mizar/proto/mizar/proto/builtins.proto
@@ -54,7 +54,8 @@ message BuiltinsPodMessage {
   string arktos_network = 6;
   string phase = 7;
   repeated InterfacesMessage interfaces = 8 ;
-  map<string, string> annotations = 9;
+  string vpc = 9;
+  string subnet = 10;
 }
 
 message BuiltinsServiceMessage {

--- a/mizar/store/operator_store.py
+++ b/mizar/store/operator_store.py
@@ -39,7 +39,6 @@ class OprStore(object):
         self.droplets_store = {}
 
         self.vpcs_store = {}
-        self.arktosnet_vpc_store = {}
         self.nets_vpc_store = {}
         self.nets_store = {}
 
@@ -98,15 +97,6 @@ class OprStore(object):
     def get_vpc(self, name):
         if name in self.vpcs_store:
             return self.vpcs_store[name]
-        return None
-
-    def update_arktosnet_vpc(self, a, v):
-        if v in self.vpcs_store:
-            self.arktosnet_vpc_store[a] = v
-
-    def get_vpc_in_arktosnet(self, name):
-        if name in self.arktosnet_vpc_store:
-            return self.arktosnet_vpc_store[name]
         return None
 
     def contains_vpc(self, name):
@@ -345,18 +335,20 @@ class OprStore(object):
 
     def get_or_add_pod_label_value(self, label_combination):
         if label_combination not in self.pod_label_value_store:
-            self.pod_label_value_store[label_combination] = len(self.pod_label_value_store)
+            self.pod_label_value_store[label_combination] = len(
+                self.pod_label_value_store)
             logger.info("Added pod_label_value {} for {}."
-                .format(self.pod_label_value_store[label_combination], label_combination))
+                        .format(self.pod_label_value_store[label_combination], label_combination))
         return self.pod_label_value_store[label_combination]
 
     def get_or_add_namespace_label_value(self, label_combination):
         if label_combination not in self.namespace_label_value_store:
-            self.namespace_label_value_store[label_combination] = len(self.namespace_label_value_store)
+            self.namespace_label_value_store[label_combination] = len(
+                self.namespace_label_value_store)
             logger.info("Added namespace_label_value {} for {}."
-                .format(self.namespace_label_value_store[label_combination], label_combination))
+                        .format(self.namespace_label_value_store[label_combination], label_combination))
         return self.namespace_label_value_store[label_combination]
-    
+
     def get_old_pod_labels(self, pod_name):
         labels_dict = {}
         if pod_name in self.pod_label_store:

--- a/teste2e/common/k8s.py
+++ b/teste2e/common/k8s.py
@@ -95,7 +95,7 @@ class k8sApi:
             }
         }
         if not subnet:
-            del pod_manifest["metadata"]["annotations"][OBJ_DEFAULTS.mizar_pod_subnet_annotation]
+            del pod_manifest["metadata"]["annotations"][OBJ_DEFAULTS.mizar_ep_subnet_annotation]
         resp = self.k8sapi.create_namespaced_pod(
             body=pod_manifest, namespace='default')
 

--- a/teste2e/common/k8s.py
+++ b/teste2e/common/k8s.py
@@ -80,8 +80,8 @@ class k8sApi:
             'metadata': {
                     'name': name,
                     'annotations': {
-                        OBJ_DEFAULTS.mizar_pod_vpc_annotation: vpc,
-                        OBJ_DEFAULTS.mizar_pod_subnet_annotation: subnet,
+                        OBJ_DEFAULTS.mizar_ep_vpc_annotation: vpc,
+                        OBJ_DEFAULTS.mizar_ep_subnet_annotation: subnet,
                     },
                 'labels': {
                         'scaledep': scaledep


### PR DESCRIPTION
This PR adds the following:

1. Removes pod to VPC/Subnet allocation in the arktos service via labels.
2. Adds pod to VPC/Subnet allocation in the arktos via annotations.
3. Removes Mizar's handling of Arktos Networks based upon this [this design document](https://github.com/CentaurusInfra/arktos/blob/poc-2022-01-30/docs/design-proposals/multi-tenancy/multi-tenancy-network-mizar-integration.md#pod-creation-default-wf) 
4. Adds support for service to VPC/subnet allocation via labels.