### PR TITLE
Fix issue 588: Once pod creating failed, it will fail all the way

### DIFF
--- a/cmd/mizarcni/app/worker.go
+++ b/cmd/mizarcni/app/worker.go
@@ -99,12 +99,6 @@ func DoCmdDel(netVariables *object.NetVariables, stdinData []byte) (string, erro
 	}
 	strBuilder.WriteString(fmt.Sprintf("Network variables: %s", netVariables))
 
-	strBuilder.WriteString(fmt.Sprintf("\nDeleting interface for %s/%s", netVariables.K8sPodNamespace, netVariables.K8sPodName))
-	err := grpcclientutil.DeleteInterface(*netVariables)
-	if err != nil {
-		return strBuilder.String(), err
-	}
-
 	strBuilder.WriteString(fmt.Sprintf("\nDeleting network namespace %s for interface of %s/%s", netVariables.NetNS, netVariables.K8sPodNamespace, netVariables.K8sPodName))
 	netutil.DeleteNetNS(netVariables.NetNS)
 

--- a/cmd/mizarcni/app/worker_test.go
+++ b/cmd/mizarcni/app/worker_test.go
@@ -224,37 +224,5 @@ func Test_DoCmdDel(t *testing.T) {
 			So(info, ShouldBeEmpty)
 			So(err, ShouldEqual, expectedError)
 		})
-
-		Convey("Given DeleteInterface error, got expected result", func() {
-			expectedError := errors.New("Expected Error")
-			patches := ApplyFunc(netvariablesutil.LoadCniConfig, func(_ *object.NetVariables, _ []byte) error {
-				return nil
-			})
-			patches.ApplyFunc(grpcclientutil.DeleteInterface, func(_ object.NetVariables) error {
-				return expectedError
-			})
-			defer patches.Reset()
-
-			info, err := app.DoCmdDel(&netVariables, nil)
-			So(info, ShouldContainSubstring, "Network variables")
-			So(info, ShouldContainSubstring, "Deleting interface")
-			So(err, ShouldEqual, expectedError)
-		})
-
-		Convey("Given no error, got expected result", func() {
-			patches := ApplyFunc(netvariablesutil.LoadCniConfig, func(_ *object.NetVariables, _ []byte) error {
-				return nil
-			})
-			patches.ApplyFunc(grpcclientutil.DeleteInterface, func(_ object.NetVariables) error {
-				return nil
-			})
-			defer patches.Reset()
-
-			info, err := app.DoCmdDel(&netVariables, nil)
-			So(info, ShouldContainSubstring, "Network variables")
-			So(info, ShouldContainSubstring, "Deleting interface")
-			So(info, ShouldContainSubstring, "Deleting network namespace")
-			So(err, ShouldBeNil)
-		})
 	})
 }

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -240,21 +240,22 @@ class InterfaceServer(InterfaceServiceServicer):
 
     def DeleteInterface(self, request, context):
         """
-        Delete network interfaces for a pod
+        Delete network interface
         """
-        cni_params = request
-        pod_name = get_pod_name(cni_params.pod_id)
+        interface = request
+        pod_name = get_pod_name(interface.interface_id.pod_id)
         pod_interfaces = self.interfaces.get(pod_name, [])
-        iface = cni_params.interface
+        iface = interface.interface_id.interface
         logger.info("Deleting interfaces for pod {} with interfaces {}".format(
             pod_name, pod_interfaces))
 
-        for interface in pod_interfaces:
-            self.interfaces[pod_name].remove(interface)
-            if iface == interface and interface.interface_type == InterfaceType.veth:
+        for pod_interface in pod_interfaces:
+            self.interfaces[pod_name].remove(pod_interface)
+            if iface == pod_interface and pod_interface.interface_type == InterfaceType.veth:
                 logger.info("Deleting interface: {}".format(iface))
-                self._DeleteVethInterface(interface)
-                logger.info("Removed {}".format(interface))
+                self._DeleteVethInterface(pod_interface)
+                logger.info("Removed {}".format(pod_interface))
+
         return empty_pb2.Empty()
 
     def ActivateHostInterface(self, request, context):
@@ -329,8 +330,8 @@ class InterfaceServiceClient():
         resp = self.stub.ConsumeInterfaces(pod_id)
         return resp
 
-    def DeleteInterface(self, interfaces_list):
-        resp = self.stub.DeleteInterface(interfaces_list)
+    def DeleteInterface(self, interface):
+        resp = self.stub.DeleteInterface(interface)
         return resp
 
     def ActivateHostInterface(self, interface):

--- a/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
+++ b/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
@@ -357,6 +357,7 @@ class EndpointOperator(object):
             ep.set_droplet_ip(spec['droplet'].ip)
             ep.set_droplet_mac(spec['droplet'].mac)
             ep.set_interface(interface)
+            self.store_update(ep)
             ep.create_obj()
 
     def create_host_endpoint(self, ip, droplet, interfaces):
@@ -457,4 +458,8 @@ class EndpointOperator(object):
     def delete_simple_endpoint(self, ep):
         logger.info(
             "Delete endpoint object associated with interface {}".format(ep.name))
+        interface = self.store_get(ep.name).interface        
+        InterfaceServiceClient(
+                ep.droplet_obj.main_ip).DeleteInterface(Interface(interface_id=interface.interface_id))
+
         ep.delete_obj()

--- a/mizar/proto/mizar/proto/interface.proto
+++ b/mizar/proto/mizar/proto/interface.proto
@@ -10,7 +10,7 @@ service InterfaceService {
   rpc ProduceInterfaces(InterfacesList) returns (InterfacesList) {}
   rpc ConsumeInterfaces(CniParameters) returns (InterfacesList) {}
   rpc ActivateHostInterface(Interface) returns (Interface) {}
-  rpc DeleteInterface(CniParameters) returns (google.protobuf.Empty) {}
+  rpc DeleteInterface(Interface) returns (google.protobuf.Empty) {}
 }
 
 message PodId {

--- a/mizar/store/operator_store.py
+++ b/mizar/store/operator_store.py
@@ -168,6 +168,8 @@ class OprStore(object):
                 ep.egress_networkpolicies = old_ep.egress_networkpolicies
             if len(old_ep.data_for_networkpolicy) > 0 and len(ep.data_for_networkpolicy) == 0:
                 ep.data_for_networkpolicy = old_ep.data_for_networkpolicy
+            if old_ep.interface is not None and ep.interface is None:
+                ep.interface = old_ep.interface
 
         # logger.info('caller name:{}'.format(inspect.stack()[1][3]))
         self.eps_store[ep.name] = ep

--- a/pkg/util/grpcclientutil/grpcclientutil.go
+++ b/pkg/util/grpcclientutil/grpcclientutil.go
@@ -41,22 +41,6 @@ func ConsumeInterfaces(netVariables object.NetVariables) ([]*Interface, error) {
 	return clientResult.Interfaces, nil
 }
 
-func DeleteInterface(netVariables object.NetVariables) error {
-	client, conn, ctx, cancel, err := getInterfaceServiceClient()
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-	defer cancel()
-
-	_, err = client.DeleteInterface(ctx, GenerateCniParameters(netVariables))
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func getInterfaceServiceClient() (InterfaceServiceClient, *grpc.ClientConn, context.Context, context.CancelFunc, error) {
 	conn, err := grpc.Dial("localhost:50051", grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:
**The issue:**
When creating a pod, it creates an endpoint. Endpoint will invoke ProduceInterface. When cni does "Add" operation, cni will invoke ConsumeInterface. Eventually interface is produced and consumed, and the pod is running.
When cni sends "Del" operation, currently DeleteInterface will be invoked. It destroys objects from both ProduceInterface and DeleteInterface. So next time when cni sends "Add" operation, it will always fail because ProduceInterface is only invoked once and it's not there any more.

**Solution:**
Move DeleteInterface to only be invoked when deleting endpoint. In this way, ProduceInterface and DeleteInterface will both be invoked once. Cni retrying "Del", "Add" operations won't affect the pod creation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #588 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No