### PR TITLE
Use directory mount instead of file mount for optional KUBECONFIG in Mizar operator

### DIFF
--- a/etc/deploy/deploy.mizar.dev.yaml
+++ b/etc/deploy/deploy.mizar.dev.yaml
@@ -553,9 +553,9 @@ spec:
           privileged: true
         volumeMounts:
         - name: kubeconfig
-          mountPath: /admin.conf
+          mountPath: /kubeconf
       volumes:
       - name: kubeconfig
         hostPath:
-          path: /etc/kubernetes/admin.conf
-          type: File
+          path: /etc/kubernetes
+          type: Directory


### PR DESCRIPTION


<!--  Thanks for sending a pull request and contributing to Mizar!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind design
> /kind feature
/kind bug
> /kind cleanup
> /kind documentation

**What this PR does / why we need it**: For scaleup and upstream, we should in_cluster_config. kubelet expects /etc/kubernetes/admin.conf file to exist even if it is not used when in_cluster_config is to be used. Using directory mount instead of file mount fixes the issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
