### PR TITLE
Allow setting cluster VPC VNI via env var

### DIFF
--- a/mizar/common/common.py
+++ b/mizar/common/common.py
@@ -482,3 +482,12 @@ def load_k8s_config():
             logger.info("K8s config successfully initialized using in_cluster_config.")
         except config.ConfigException:
             raise Exception("Could not configure kubernetes python client from in_cluster_config.")
+
+def get_cluster_vpc_vni():
+    cluster_vpc_vni = os.environ.get('CLUSTER_VPC_VNI')
+    if cluster_vpc_vni:
+        logger.info("Using specified cluster VNI {}.".format(cluster_vpc_vni))
+    else:
+        cluster_vpc_vni = OBJ_DEFAULTS.default_vpc_vni
+        logger.info("Using default cluster VNI {}.".format(cluster_vpc_vni))
+    return cluster_vpc_vni

--- a/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
+++ b/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
@@ -369,7 +369,7 @@ class EndpointOperator(object):
             ep.set_type(OBJ_DEFAULTS.ep_type_host)
             ep.set_status(OBJ_STATUS.ep_status_init)
 
-            ep.set_vni(OBJ_DEFAULTS.default_vpc_vni)
+            ep.set_vni(get_cluster_vpc_vni())
             ep.set_vpc(OBJ_DEFAULTS.default_ep_vpc)
             ep.set_net(OBJ_DEFAULTS.default_ep_net)
             ep.set_gw(OBJ_DEFAULTS.default_net_gw)

--- a/mizar/dp/mizar/operators/vpcs/vpcs_operator.py
+++ b/mizar/dp/mizar/operators/vpcs/vpcs_operator.py
@@ -120,7 +120,7 @@ class VpcOperator(object):
         # Scrappy allocator for now!!
         # TODO: There is a tiny chance of collision here, not to worry about now
         if vpc.name == OBJ_DEFAULTS.default_ep_vpc:
-            return OBJ_DEFAULTS.default_vpc_vni
+            return get_cluster_vpc_vni()
         vpc.set_vni(str(uuid.uuid4().int & (1 << 24)-1))
 
     def deallocate_vni(self, vpc):

--- a/mizar/obj/net.py
+++ b/mizar/obj/net.py
@@ -36,7 +36,7 @@ class Net(object):
     def __init__(self, name, obj_api, opr_store, spec=None):
         self.name = name
         self.vpc = OBJ_DEFAULTS.default_ep_vpc
-        self.vni = OBJ_DEFAULTS.default_vpc_vni
+        self.vni = get_cluster_vpc_vni()
         self.n_bouncers = OBJ_DEFAULTS.default_n_bouncers
         self.n_allocated_bouncers = 0
         self.bouncers = {}

--- a/mizar/obj/vpc.py
+++ b/mizar/obj/vpc.py
@@ -35,7 +35,7 @@ logger = logging.getLogger()
 class Vpc(object):
     def __init__(self, name, obj_api, opr_store, spec=None):
         self.name = name
-        self.vni = OBJ_DEFAULTS.default_vpc_vni
+        self.vni = get_cluster_vpc_vni()
         self.n_dividers = OBJ_DEFAULTS.default_n_dividers
         self.n_allocated_dividers = 0
         self.obj_api = obj_api


### PR DESCRIPTION
<!--  Thanks for sending a pull request and contributing to Mizar!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind design
/kind feature
> /kind bug
> /kind cleanup
> /kind documentation

**What this PR does / why we need it**: This allows Mizar operator in scaleout tenant partitions to be started with tenant specific unique VPC VNI.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
