### PR TITLE
Fix For a given subnet, there is only 32 ip addresses allocatable #598

### DIFF
--- a/mizar/common/cidr.py
+++ b/mizar/common/cidr.py
@@ -21,6 +21,7 @@
 
 import ipaddress
 import logging
+from mizar.common.constants import *
 
 logger = logging.getLogger()
 
@@ -33,7 +34,7 @@ class Cidr:
         self.ip = ip
         self.ipnet = ipaddress.ip_network(
             "{}/{}".format(self.ip, self.prefixlen))
-        self.subnets = self.ipnet.subnets(new_prefix=32)
+        self.subnets = self.ipnet.subnets(new_prefix=CONSTANTS.SUBNETS_NEW_PREFIX)
 
         self._hosts = set()
         self.gw = self.get_ip(1)

--- a/mizar/common/cidr.py
+++ b/mizar/common/cidr.py
@@ -20,7 +20,9 @@
 # THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import ipaddress
+import logging
 
+logger = logging.getLogger()
 
 class Cidr:
     def __init__(self, prefixlen, ip):
@@ -31,7 +33,7 @@ class Cidr:
         self.ip = ip
         self.ipnet = ipaddress.ip_network(
             "{}/{}".format(self.ip, self.prefixlen))
-        self.subnets = self.ipnet.subnets(new_prefix=30)
+        self.subnets = self.ipnet.subnets(new_prefix=32)
 
         self._hosts = set()
         self.gw = self.get_ip(1)
@@ -52,13 +54,13 @@ class Cidr:
         return self.hosts
 
     def allocate_ip(self):
-        if not len(self.hosts):
-            return None
         ip = self.hosts.pop()
         # TODO: bad hack, search the list and remove it!!
         while ip in self.allocated:
             ip = self.hosts.pop()
         self.allocated.add(ip)
+        logger.info("ip {} is allocated. Currently there are {} ip addresses allocated under {}/{}."
+            .format(ip, len(self.allocated), self.ip, self.prefixlen))
         return str(ip)
 
     def mark_ip_as_allocated(self, ip):

--- a/mizar/common/cidr.py
+++ b/mizar/common/cidr.py
@@ -44,8 +44,16 @@ class Cidr:
     def hosts(self):
 
         pool = next(self.subnets)
-        self._hosts.update(set(pool.hosts()))
-        self._hosts.discard(self.gw)
+        # Avoid allocate special ip addresses such as net ip and gateway ip.
+        pool_hosts_set = set(pool.hosts())
+        pool_hosts_set.discard(ipaddress.IPv4Address(self.ip))
+        pool_hosts_set.discard(ipaddress.IPv4Address(self.gw))
+        while len(pool_hosts_set) == 0:
+            pool = next(self.subnets)
+            pool_hosts_set = set(pool.hosts())
+            pool_hosts_set.discard(ipaddress.IPv4Address(self.ip))
+            pool_hosts_set.discard(ipaddress.IPv4Address(self.gw))
+        self._hosts.update(pool_hosts_set)
         return self._hosts
 
     def get_ip(self, idx):

--- a/mizar/common/constants.py
+++ b/mizar/common/constants.py
@@ -46,6 +46,7 @@ class CONSTANTS:
     MIZAR_NETWORK_CLASS_TAG = "mizar.com/network-class"
     MIZAR_NETWORK_PRIORITY_TAG = "mizar.com/network-priority"
     MIZAR_DEFAULT_EGRESS_BW_LIMIT_PCT = 30
+    SUBNETS_NEW_PREFIX = 32
 
 
 class OBJ_STATUS:

--- a/mizar/dp/mizar/workflows/builtins/pods/create.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/create.py
@@ -114,6 +114,7 @@ class k8sPodCreate(WorkflowTask):
 
         n = net_opr.store.get_net(spec['subnet'])
         ip = n.allocate_ip()
+        logger.info("ip {} from {} is allocated to Pod {}.".format(ip, spec['subnet'], self.param.name))
         spec['ip'] = ip
 
         # Get 'mizar.com/egress-bandwidth' from pod annotations


### PR DESCRIPTION
This is to fix issue 598 For a given subnet, there is only 32 ip addresses allocatable.

Figured out there are two things need to be changed for the original code:
1. subnets(new_prefix=30)
Here 30 needs to be set to 32 to allow all the ips to be allocated.
2. Every time when invoke "self.hosts", there will be a ip address popped out from resource pool. 
There is a code to check the len(self.hosts). The code is not working, and wasted an ip. Remove the code.

This pr fixes what described above. It's e2e tested after the pr, there will be 255 ip addresses allocated for the given subnet.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #598 
