### PR TITLE
Fix issue 599 ip address kept allocating

### DIFF
--- a/mizar/dp/mizar/workflows/builtins/pods/create.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/create.py
@@ -112,11 +112,6 @@ class k8sPodCreate(WorkflowTask):
                 configs = json.loads(net_config)
                 spec['interfaces'] = configs
 
-        n = net_opr.store.get_net(spec['subnet'])
-        ip = n.allocate_ip()
-        logger.info("ip {} from {} is allocated to Pod {}.".format(ip, spec['subnet'], self.param.name))
-        spec['ip'] = ip
-
         # Get 'mizar.com/egress-bandwidth' from pod annotations
         egress_bw = int(0)
         pod_network_class_value = "Premium"
@@ -169,6 +164,11 @@ class k8sPodCreate(WorkflowTask):
             networkpolicy_util.handle_networkpolicy_change(policy_name_list)
             self.finalize()
             return
+
+        n = net_opr.store.get_net(spec['subnet'])
+        ip = n.allocate_ip()
+        logger.info("ip {} from {} is allocated to Pod {}.".format(ip, spec['subnet'], self.param.name))
+        spec['ip'] = ip
 
         # Init all interfaces on the host
         logger.info(


### PR DESCRIPTION
For issue 599, we observed ip keeps being allocated for the same pod.
After more investigating, I found every time when pod got updated, cluster will trigger pod updated event and will be handled by mizar  k8sPodCreate workflow. And in the workflow the ip will be allocated.

In the workflow, there are two parts: part 1 will be run again and again each time when the pod updated. And part 2 will be run only once when pod is in "pending" state. Current ip allocating is in part 1, hence ip will keep allocating.

The fix is to move ip allocating from part 1 to part 2. In this pr, the ip allocating part is moved right after part 2 starts.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind design
> /kind feature
/kind bug
> /kind cleanup
> /kind documentation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #599 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
