### PR TITLE
Refactor bootstrap, kernelupdate, and C code to work for Ubuntu 18.04 as well as Ubuntu 20.04

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,99 +1,168 @@
 #!/bin/bash
 
+logout_needed=false
+
+function install-dev-packages {
+  echo ""
+  echo "Installing dev packages ..."
+  sudo apt-get update -y
+  sudo apt-get install -y \
+    build-essential \
+    clang-7 \
+    llvm-7 \
+    libelf-dev \
+    libcmocka-dev \
+    lcov \
+    scapy \
+    pkg-config
+}
+
+function install-python {
+  echo ""
+  echo "Installing python3 dependencies ..."
+  sudo apt-get update -y
+  sudo apt-get install -y \
+    python3-pip \
+    python3-apt
+}
+
+function install-python-ubuntu-18 {
+  echo ""
+  echo "Installing python3 dependencies for ubuntu 18.04 ..."
+
+  sudo apt-get update -y
+  sudo apt-get install -y \
+    python3.7 \
+    python3.7-dev
+
+  # kopf no longer available in python3.6 via pip
+  sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
+  sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
+  sudo update-alternatives --set python3 /usr/bin/python3.7
+  # Fix for apt-pkg missing when using python3.7
+  sudo ln -s /usr/lib/python3/dist-packages/apt_pkg.cpython-36m-x86_64-linux-gnu.so /usr/lib/python3/dist-packages/apt_pkg.so
+}
+
+function install-go-for-mizar {
+  echo ""
+  echo "Installing go 1.13.9 ..."
+  wget -O /tmp/go1.13.9.linux-amd64.tar.gz https://dl.google.com/go/go1.13.9.linux-amd64.tar.gz
+  sudo tar -C /usr/local -xzf /tmp/go1.13.9.linux-amd64.tar.gz
+  rm -rf /tmp/go1.13.9.linux-amd64.tar.gz
+  export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
+  cat ~/.profile | grep "PATH" | egrep "/usr/local/go/bin"
+  if [ $? -ne 0 ]; then
+    echo "export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin" >> ~/.profile
+    source ~/.profile
+  fi
+  logout_needed=true
+}
+
+function install-docker {
+  echo ""
+  echo "Installing docker ..."
+  sudo apt-get update -y
+  sudo apt-get install -y docker.io
+  sudo systemctl unmask docker.service
+  sudo systemctl unmask docker.socket
+  cat /etc/group | grep docker | grep ${USER} &> /dev/null
+  if [ $? -ne 0 ]; then
+    sudo usermod -aG docker ${USER}
+    logout_needed=true
+  fi
+  sudo systemctl enable docker
+  sudo systemctl restart docker
+}
+
+function install-kubectl {
+  echo ""
+  echo "Installing kubectl ..."
+  curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+  chmod +x ./kubectl
+  sudo mv ./kubectl /usr/local/bin/kubectl
+}
+
+function install-kind {
+  echo ""
+  echo "Installing kind ..."
+  pushd /tmp
+  ver=$(curl -s https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
+  curl -Lo kind "https://github.com/kubernetes-sigs/kind/releases/download/$ver/kind-$(uname)-amd64"
+  chmod +x kind
+  sudo mv kind /usr/local/bin
+  popd
+}
+
+function install-protobuf-and-pip-deps {
+  echo ""
+  echo "Installing protobuf dependencies ..."
+  sudo apt-get update -y
+  sudo apt-get install -y protobuf-compiler libprotobuf-dev
+  GO111MODULE="on" go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
+  GO111MODULE="on" go get google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
+  GO111MODULE="on" go get github.com/smartystreets/goconvey@v1.6.4
+  sudo python3 -m pip install --upgrade pip
+  sudo pip3 install --upgrade setuptools netaddr docker scapy kubernetes
+  sudo pip3 install --upgrade grpcio grpcio-tools
+}
+
+# Main bootstrap script
 tput setaf 1
 echo "NOTE: This script will reboot the system if you opt to allow kernel update."
 echo "      If reboot is not required, it will log you out and require re-login for new permissions to take effect."
 echo ""
 read -n 1 -s -r -p "Press Ctrl-c to quit, any key to continue..."
 tput sgr0
+echo " "
 
-logout_needed=false
+# Install dev packages
+install-dev-packages
 
-sudo apt-get update
-sudo apt-get install -y \
-    build-essential \
-    clang-7 \
-    llvm-7 \
-    libelf-dev \
-    python3.7 \
-    python3-pip \
-    libcmocka-dev \
-    lcov \
-    scapy \
-    python3.7-dev \
-    python3-apt \
-    pkg-config \
-    docker.io
-sudo python3 -m pip install --upgrade pip
-
-sudo systemctl unmask docker.service
-sudo systemctl unmask docker.socket
-
-cat /etc/group | grep docker | grep ${USER} &> /dev/null
-if [ $? -ne 0 ]; then
-  sudo usermod -aG docker ${USER}
-  logout_needed=true
+# Install python
+install-python
+cat /etc/os-release | grep VERSION_ID | grep "18.04"
+if [ $? -eq 0 ]; then
+  install-python-ubuntu-18
 fi
 
-sudo systemctl start docker
-sudo systemctl enable docker
-# kopf no longer available in python3.6 via pip
-sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
-sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
-sudo update-alternatives --set python3 /usr/bin/python3.7
-# Fix for apt-pkg missing when using python3.7
-sudo ln -s /usr/lib/python3/dist-packages/apt_pkg.cpython-36m-x86_64-linux-gnu.so /usr/lib/python3/dist-packages/apt_pkg.so
-sudo pip3 install setuptools netaddr docker grpcio grpcio-tools scapy kubernetes
+# Install go
+which go
+if [ $? -ne 0 ]; then
+  install-go-for-mizar
+else
+  go_ver=$(go version | go version | awk '{print $3}')
+  if [[ "${go_ver}" != "go1.13.9" ]]; then
+    install-go-for-mizar
+  fi
+fi
 
-ver=$(curl -s https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
-curl -Lo kind "https://github.com/kubernetes-sigs/kind/releases/download/$ver/kind-$(uname)-amd64"
-chmod +x ./kind
-sudo mv ./kind /usr/local/bin
-
-curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
-chmod +x ./kubectl
-sudo mv ./kubectl /usr/local/bin/kubectl
+# Install docker
+which docker
+if [ $? -ne 0 ]; then
+  install-docker
+fi
 
 # Install kind
-if [ ! -f /usr/local/bin/kind ]; then
-    pushd /tmp
-    ver=$(curl -s https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
-    curl -Lo kind "https://github.com/kubernetes-sigs/kind/releases/download/$ver/kind-$(uname)-amd64"
-    chmod +x kind
-    sudo mv kind /usr/local/bin
-    popd
+which kind
+if [ $? -ne 0 ]; then
+  install-kind
 fi
 
-# Install go and related
-wget -O /tmp/go1.13.9.linux-amd64.tar.gz https://dl.google.com/go/go1.13.9.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf /tmp/go1.13.9.linux-amd64.tar.gz
-rm -rf /tmp/go1.13.9.linux-amd64.tar.gz
-export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
-sudo apt-get install -y protobuf-compiler libprotobuf-dev
-GO111MODULE="on" go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
-GO111MODULE="on" go get google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
-GO111MODULE="on" go get github.com/smartystreets/goconvey@v1.6.4
+# Install kubectl
+which kubectl
+if [ $? -ne 0 ]; then
+  install-kubectl
+fi
 
 git submodule update --init --recursive
 
-kernel_ver=`uname -r`
-echo "Running kernel version: $kernel_ver"
-mj_ver=$(echo $kernel_ver | cut -d. -f1)
-mn_ver=$(echo $kernel_ver | cut -d. -f2)
+# Install protobuf dependecies
+install-protobuf-and-pip-deps
 
-if [[ "$mj_ver" < "5" ]] || [[ "$mn_ver" < "6" ]]; then
-        tput setaf 1
-	echo "Mizar requires an updated kernel: linux-5.6-rc2 for TCP to function correctly. Current version is $kernel_ver"
-
-	read -p "Execute kernel update script (y/n)?" choice
-	tput sgr0
-	case "$choice" in
-	  y|Y ) sh ./kernelupdate.sh;;
-	  n|N ) echo "Please run kernelupdate.sh to download and update the kernel!"; exit;;
-	  * ) echo "Please run kernelupdate.sh to download and update the kernel!"; exit;;
-	esac
-fi
+# Install kernel needed for Mizar (if required)
+source ${PWD}/kernelupdate.sh
 
 if [ "$logout_needed" = true ]; then
-    logout
+  PPPID=$(awk '{print $4}' "/proc/$PPID/stat")
+  kill $PPPID
 fi

--- a/kernelupdate.sh
+++ b/kernelupdate.sh
@@ -1,27 +1,53 @@
 #!/bin/bash
 
-kernel_dir="../linux-5.6-rc2"
-mkdir -p $kernel_dir
+function update-kernel-for-mizar {
+  kernel_dir="/tmp/linux-5.6-rc2"
+  mkdir -p $kernel_dir
 
-wget https://mizar.s3.amazonaws.com/linux-5.6-rc2/linux-headers-5.6.0-rc2_5.6.0-rc2-1_amd64.deb -P $kernel_dir
-wget https://mizar.s3.amazonaws.com/linux-5.6-rc2/linux-image-5.6.0-rc2-dbg_5.6.0-rc2-1_amd64.deb -P $kernel_dir
-wget https://mizar.s3.amazonaws.com/linux-5.6-rc2/linux-image-5.6.0-rc2_5.6.0-rc2-1_amd64.deb -P $kernel_dir
-wget https://mizar.s3.amazonaws.com/linux-5.6-rc2/linux-libc-dev_5.6.0-rc2-1_amd64.deb -P $kernel_dir
+  wget https://mizar.s3.amazonaws.com/linux-5.6-rc2/linux-headers-5.6.0-rc2_5.6.0-rc2-1_amd64.deb -P $kernel_dir
+  wget https://mizar.s3.amazonaws.com/linux-5.6-rc2/linux-image-5.6.0-rc2-dbg_5.6.0-rc2-1_amd64.deb -P $kernel_dir
+  wget https://mizar.s3.amazonaws.com/linux-5.6-rc2/linux-image-5.6.0-rc2_5.6.0-rc2-1_amd64.deb -P $kernel_dir
+  wget https://mizar.s3.amazonaws.com/linux-5.6-rc2/linux-libc-dev_5.6.0-rc2-1_amd64.deb -P $kernel_dir
+  sudo dpkg -i $kernel_dir/*.deb
 
-read -p "Continue kernel update (y/n)?" choice
-case "$choice" in
-  y|Y ) echo "Updating kernel";;
-  n|N ) exit;;
-  * ) exit;;
-esac
+  read -p "Reboot host now? (y/n)?" choice
+  case "$choice" in
+    y|Y ) echo "Rebooting...";;
+    n|N ) echo "Please reboot for updated kernel to take effect."; return;;
+    * ) return;;
+  esac
 
-sudo dpkg -i $kernel_dir/*.deb
+  sudo reboot
+}
 
-read -p "Reboot host (y/n)?" choice
-case "$choice" in
-  y|Y ) echo "Rebooting";;
-  n|N ) exit;;
-  * ) exit;;
-esac
+function check-and-install-mizar-kernel {
+  kernel_ver=$(uname -r)
+  kernel_header_ver=$(sudo apt list linux-headers-$(uname -r) | grep "linux-headers-" | cut -d/ -f1 | sed 's/linux-headers-//')
+  echo "Currently running kernel version: $kernel_ver"
+  echo "Currently running kernel header version: $kernel_header_ver"
+  echo ".................................................."
 
-sudo reboot
+  mj_ver=$(echo $kernel_ver | cut -d. -f1)
+  mn_ver=$(echo $kernel_ver | cut -d. -f2)
+  if ([ "$mj_ver" -lt 5 ]) || ([ "$mj_ver" -eq 5 ] && [ "$mn_ver" -le 5 ]); then
+    tput setaf 1
+    echo "Mizar requires an updated kernel: linux-5.6 rc2 for TCP to function correctly. Current version is $kernel_ver"
+    read -p "Execute kernel update script (y/n)?" choice
+    tput sgr0
+    case "$choice" in
+      y|Y ) update-kernel-for-mizar;;
+      n|N ) echo "Please run kernelupdate.sh to download and update the kernel!"; return;;
+      * ) echo "Please run kernelupdate.sh to download and update the kernel!"; return;;
+    esac
+  fi
+
+  if [[ "$kernel_ver" != "$kernel_header_ver" ]]; then
+    tput setf 2
+    echo " Updating kernel_header.."
+    tput sgr0
+    sudo apt-get install linux-headers-$(uname -r) -y
+  fi
+}
+
+# Main
+check-and-install-mizar-kernel

--- a/src/dmn/trn_agent_xdp_usr.c
+++ b/src/dmn/trn_agent_xdp_usr.c
@@ -658,25 +658,26 @@ int trn_agent_metadata_init(struct agent_user_metadata_t *md, char *itf,
 	char *debug = strstr(agent_file_name, "debug");
 	char *prog_dir = dirname(agent_file_name);
 	for (enum tailcall_txstat t = 0; t < MAX_TXSTAT; t++) {
-		char fname[256] = {0};
-		sprintf(fname, "%s/trn_xdp_txstats_", prog_dir);
+		char fname[512] = {0};
+		char prog_name[256] = {0};
+		sprintf(prog_name, "%s/trn_xdp_txstats_", prog_dir);
 		switch (t) {
 		case txstat_redirect:
-			sprintf(fname, "%sredirect_ebpf", fname);
+			sprintf(fname, "%sredirect_ebpf", prog_name);
 			break;
 		case txstat_pass:
-			sprintf(fname, "%spass_ebpf", fname);
+			sprintf(fname, "%spass_ebpf", prog_name);
 			break;
 		case txstat_drop:
-			sprintf(fname, "%sdrop_ebpf", fname);
+			sprintf(fname, "%sdrop_ebpf", prog_name);
 			break;
 		default:
 			continue;
 		};
 		if (debug)
-			sprintf(fname, "%s_debug.o", fname);
+			strcat(fname, "_debug.o");
 		else
-			sprintf(fname, "%s.o", fname);
+			strcat(fname, ".o");
 		if (_trn_bpf_agent_prog_load_txstats(fname, &md->txstats_obj[t], &md->txstats_prog_fd[t])) {
 			TRN_LOG_ERROR("Error loading txstats xdp programs");
 			return 1;

--- a/src/dmn/trn_bw_qos_monitor.c
+++ b/src/dmn/trn_bw_qos_monitor.c
@@ -84,7 +84,7 @@ int get_link_speed(const char* name)
 	}
 
 	memset(&ifr, 0, sizeof(ifr));
-	strncpy(ifr.ifr_name, name, IFNAMSIZ);
+	strncpy(ifr.ifr_name, name, IFNAMSIZ-1);
 
 	fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
 	if (fd < 0)
@@ -126,7 +126,7 @@ int get_interface_ip(const char* name, unsigned int* ipaddr)
 
 	memset(&ifr, 0, sizeof(ifr));
 	ifr.ifr_addr.sa_family = AF_INET;
-	strncpy(ifr.ifr_name, name, IFNAMSIZ);
+	strncpy(ifr.ifr_name, name, IFNAMSIZ-1);
 
 	if (ioctl(fd, SIOCGIFADDR, &ifr) == -1) {
 		return -1;

--- a/src/rpcgen/module.mk
+++ b/src/rpcgen/module.mk
@@ -2,6 +2,8 @@
 
 dir = src/rpcgen
 
+CFLAGS += -Wno-cast-function-type
+
 protocol.x = $(dir)/trn_rpc_protocol.x
 
 rpcgen_svc_src.c = $(dir)/trn_rpc_protocol_svc.c
@@ -23,7 +25,7 @@ $(rpcgen_hdr.h): $(protocol.x)
 	rm -f $(dir)/trn_rpc_protocol.h && rpcgen -h $(RPCGENFLAGS) $(protocol.x) -o $(dir)/trn_rpc_protocol.h
 
 $(rpcgen_svc_src.c): $(protocol.x)
-	rm -f $(dir)/trn_rpc_protocol_svc.c &&rpcgen -m $(RPCGENFLAGS) $(protocol.x) -o $(dir)/trn_rpc_protocol_svc.c
+	rm -f $(dir)/trn_rpc_protocol_svc.c && rpcgen -m $(RPCGENFLAGS) $(protocol.x) -o $(dir)/trn_rpc_protocol_svc.c
 
 $(rpcgen_clnt_src.c): $(protocol.x)
 	rm -f $(dir)/trn_rpc_protocol_clnt.c && rpcgen -l $(RPCGENFLAGS) $(protocol.x) -o $(dir)/trn_rpc_protocol_clnt.c


### PR DESCRIPTION
<!--  Thanks for sending a pull request and contributing to Mizar!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind design
> /kind feature
> /kind bug
/kind cleanup
> /kind documentation

**What this PR does / why we need it**: This fixes known issues in bootstrap, kernelupdate, and Mizar code and enables it to work for Ubuntu 18.04 as well as Ubuntu 20.04 for creating dev cluster with kind.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #507 

**Special notes for your reviewer**: Tested by deploying fresh ubuntu 18.04 and 20.04 VMs in AWS and running ./bootstrap ; make all ; kind-setup.sh dev 2 and testing pings.
```
ubuntu@ip-192-168-1-85:~/vmizar$ cat /etc/os-release 
NAME="Ubuntu"
VERSION="20.04.3 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.3 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
ubuntu@ip-192-168-1-85:~/vmizar$ uname -a
Linux ip-192-168-1-85 5.11.0-1022-aws #23~20.04.1-Ubuntu SMP Mon Nov 15 14:03:19 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
ubuntu@ip-192-168-1-85:~/vmizar$ 
ubuntu@ip-192-168-1-85:~/vmizar$ kubectl get no -owide
NAME                 STATUS   ROLES    AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE           KERNEL-VERSION    CONTAINER-RUNTIME
kind-control-plane   Ready    master   10m     v1.18.2   172.18.0.3    <none>        Ubuntu 20.04 LTS   5.11.0-1022-aws   containerd://1.3.3-14-g449e9269
kind-worker          Ready    <none>   9m56s   v1.18.2   172.18.0.2    <none>        Ubuntu 20.04 LTS   5.11.0-1022-aws   containerd://1.3.3-14-g449e9269
kind-worker2         Ready    <none>   9m56s   v1.18.2   172.18.0.4    <none>        Ubuntu 20.04 LTS   5.11.0-1022-aws   containerd://1.3.3-14-g449e9269
ubuntu@ip-192-168-1-85:~/vmizar$ kubectl get po --all-namespaces -owide
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE     IP           NODE                 NOMINATED NODE   READINESS GATES
default              mizar-daemon-c5vxx                           1/1     Running   0          8m26s   172.18.0.4   kind-worker2         <none>           <none>
default              mizar-daemon-l6d28                           1/1     Running   0          8m26s   172.18.0.2   kind-worker          <none>           <none>
default              mizar-daemon-xxx9c                           1/1     Running   0          8m26s   172.18.0.3   kind-control-plane   <none>           <none>
default              mizar-operator-7775fcc5f4-hm26b              1/1     Running   0          7m54s   172.18.0.3   kind-control-plane   <none>           <none>
kube-system          coredns-66bff467f8-5jddn                     1/1     Running   0          10m     20.0.0.2     kind-control-plane   <none>           <none>
kube-system          coredns-66bff467f8-tz6fc                     1/1     Running   0          10m     20.0.0.3     kind-control-plane   <none>           <none>
kube-system          etcd-kind-control-plane                      1/1     Running   0          10m     172.18.0.3   kind-control-plane   <none>           <none>
kube-system          kube-apiserver-kind-control-plane            1/1     Running   0          10m     172.18.0.3   kind-control-plane   <none>           <none>
kube-system          kube-controller-manager-kind-control-plane   1/1     Running   0          10m     172.18.0.3   kind-control-plane   <none>           <none>
kube-system          kube-proxy-4nfwt                             1/1     Running   0          10m     172.18.0.4   kind-worker2         <none>           <none>
kube-system          kube-proxy-6w4cp                             1/1     Running   0          10m     172.18.0.3   kind-control-plane   <none>           <none>
kube-system          kube-proxy-l9whz                             1/1     Running   0          10m     172.18.0.2   kind-worker          <none>           <none>
kube-system          kube-scheduler-kind-control-plane            1/1     Running   0          10m     172.18.0.3   kind-control-plane   <none>           <none>
local-path-storage   local-path-provisioner-bd4bb6b75-2684n       1/1     Running   0          10m     20.0.0.4     kind-control-plane   <none>           <none>
ubuntu@ip-192-168-1-85:~/vmizar$ kubectl get vpcs
NAME   IP         PREFIX   VNI   DIVIDERS   STATUS        CREATETIME                   PROVISIONDELAY
vpc0   20.0.0.0   8        1     1          Provisioned   2022-02-01T16:58:25.605412   22.003923
ubuntu@ip-192-168-1-85:~/vmizar$ kubectl get subnets
NAME   IP         PREFIX   VNI   VPC    STATUS        BOUNCERS   CREATETIME                   PROVISIONDELAY
net0   20.0.0.0   8        1     vpc0   Provisioned   1          2022-02-01T16:58:25.683057   42.258779
ubuntu@ip-192-168-1-85:~/vmizar$ kubectl get dividers
NAME                                          VPC    IP           MAC                 DROPLET              STATUS        CREATETIME                   PROVISIONDELAY
vpc0-d-8ea9e02c-26ab-4550-83b6-c60c9c38ae6f   vpc0   172.18.0.3   02:42:ac:12:00:03   kind-control-plane   Provisioned   2022-02-01T16:58:47.592746   0.386164
ubuntu@ip-192-168-1-85:~/vmizar$ kubectl get bouncers
NAME                                          VPC    NET    IP           MAC                 DROPLET       STATUS        CREATETIME                   PROVISIONDELAY
net0-b-ce30f3f0-206b-4b1f-a234-aa80974a915e   vpc0   net0   172.18.0.2   02:42:ac:12:00:02   kind-worker   Provisioned   2022-02-01T16:59:07.923458   1.865405
ubuntu@ip-192-168-1-85:~/vmizar$ kubectl get droplets
NAME                 MAC                 IP           STATUS        INTERFACE   CREATETIME                   PROVISIONDELAY   MAINIP
kind-control-plane   02:42:ac:12:00:03   172.18.0.3   Provisioned   eth0        2022-02-01T16:58:27.060014   0.578656         
kind-worker          02:42:ac:12:00:02   172.18.0.2   Provisioned   eth0        2022-02-01T16:58:27.017288   0.589353         
kind-worker2         02:42:ac:12:00:04   172.18.0.4   Provisioned   eth0        2022-02-01T16:58:27.107147   0.564198         
ubuntu@ip-192-168-1-85:~/vmizar$ 
```


**Does this PR introduce a user-facing change?**: No.
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
