### PR TITLE
Fix issue 608 Mizar cni panic

### DIFF
--- a/pkg/util/netutil/netutil.go
+++ b/pkg/util/netutil/netutil.go
@@ -39,10 +39,12 @@ func ActivateInterface(
 	gatewayIp string) (string, error) {
 
 	link, err := netlink.LinkByName(vethName)
-	if err == nil {
-		if link.Attrs().OperState == netlink.OperUp {
-			return fmt.Sprintf("Interface %s has already been UP.", vethName), nil
-		}
+	if err != nil {
+		return fmt.Sprintf("Failed to get Interface %s", vethName), err
+	}
+
+	if link.Attrs().OperState == netlink.OperUp {
+		return fmt.Sprintf("Interface %s has already been UP.", vethName), nil
 	}
 
 	netNS, err := ns.GetNS(netNSName)


### PR DESCRIPTION
This pr is to fix issue 608 Mizar cni panic. The root cause is because inside mizar cni, after get interface, as normal go coding practise, it shall check error but in this case the code didn't. Hence it will cause null reference issue for later code.

The fix is to add error handling.

**What type of PR is this?**
/kind bug

**Which issue(s) this PR fixes**:
Fixes #608 
