### PR TITLE
Fix issue 607: Mizar cni log should be under /var/log

### DIFF
--- a/cmd/mizarcni/mizarcni.go
+++ b/cmd/mizarcni/mizarcni.go
@@ -37,7 +37,7 @@ func init() {
 	// Initial log
 	klog.InitFlags(nil)
 	flag.Set("logtostderr", "false")
-	flag.Set("log_file", "/tmp/mizarcni.log")
+	flag.Set("log_file", "/var/log/mizarcni.log")
 	defer klog.Flush()
 
 	info, err := app.DoInit(&netVariables)


### PR DESCRIPTION
This pr is to fix issue 607 that Mizar cni log should be under /var/log

**What type of PR is this?**
/kind bug

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #607 
