### PR TITLE
Fix CNI unit test failures

### DIFF
--- a/cmd/mizarcni/app/worker_test.go
+++ b/cmd/mizarcni/app/worker_test.go
@@ -64,8 +64,8 @@ func Test_DoCmdAdd(t *testing.T) {
 			})
 			defer patches.Reset()
 
-			info, err := app.DoCmdAdd(&netVariables, nil)
-			So(info, ShouldBeEmpty)
+			_, tracelog, err := app.DoCmdAdd(&netVariables, nil)
+			So(tracelog, ShouldBeEmpty)
 			So(err, ShouldEqual, expectedError)
 		})
 
@@ -79,9 +79,8 @@ func Test_DoCmdAdd(t *testing.T) {
 			})
 			defer patches.Reset()
 
-			info, err := app.DoCmdAdd(&netVariables, nil)
-			So(info, ShouldContainSubstring, "Network variables")
-			So(info, ShouldContainSubstring, "Doing CNI add")
+			_, tracelog, err := app.DoCmdAdd(&netVariables, nil)
+			So(tracelog, ShouldContainSubstring, "CNI_ADD: Args: ")
 			So(err, ShouldEqual, expectedError)
 		})
 
@@ -95,10 +94,9 @@ func Test_DoCmdAdd(t *testing.T) {
 			})
 			defer patches.Reset()
 
-			info, err := app.DoCmdAdd(&netVariables, nil)
-			So(info, ShouldContainSubstring, "Network variables")
-			So(info, ShouldContainSubstring, "Doing CNI add")
-			So(err.Error(), ShouldContainSubstring, "no interfaces found")
+			_, tracelog, err := app.DoCmdAdd(&netVariables, nil)
+			So(tracelog, ShouldContainSubstring, "CNI_ADD: Args: ")
+			So(err.Error(), ShouldContainSubstring, "No interfaces found for Pod")
 		})
 
 		Convey("Given ActivateInterface error, got expected result", func() {
@@ -127,11 +125,10 @@ func Test_DoCmdAdd(t *testing.T) {
 			})
 			defer patches.Reset()
 
-			info, err := app.DoCmdAdd(&netVariables, nil)
-			So(info, ShouldContainSubstring, "Network variables")
-			So(info, ShouldContainSubstring, "Doing CNI add")
-			So(info, ShouldContainSubstring, "Activating interface")
-			So(info, ShouldContainSubstring, expectedInfo)
+			_, tracelog, err := app.DoCmdAdd(&netVariables, nil)
+			So(tracelog, ShouldContainSubstring, "CNI_ADD: Args: ")
+			So(tracelog, ShouldContainSubstring, "Activating interface")
+			So(tracelog, ShouldContainSubstring, expectedInfo)
 			So(err, ShouldEqual, expectedError)
 		})
 
@@ -164,11 +161,10 @@ func Test_DoCmdAdd(t *testing.T) {
 			})
 			defer patches.Reset()
 
-			info, err := app.DoCmdAdd(&netVariables, nil)
-			So(info, ShouldContainSubstring, "Network variables")
-			So(info, ShouldContainSubstring, "Doing CNI add")
-			So(info, ShouldContainSubstring, "Activating interface")
-			So(info, ShouldContainSubstring, expectedInfo)
+			_, tracelog, err := app.DoCmdAdd(&netVariables, nil)
+			So(tracelog, ShouldContainSubstring, "CNI_ADD: Args: ")
+			So(tracelog, ShouldContainSubstring, "Activating interface")
+			So(tracelog, ShouldContainSubstring, expectedInfo)
 			So(err, ShouldEqual, expectedError)
 		})
 
@@ -201,11 +197,10 @@ func Test_DoCmdAdd(t *testing.T) {
 			})
 			defer patches.Reset()
 
-			info, err := app.DoCmdAdd(&netVariables, nil)
-			So(info, ShouldContainSubstring, "Network variables")
-			So(info, ShouldContainSubstring, "Doing CNI add")
-			So(info, ShouldContainSubstring, "Activating interface")
-			So(info, ShouldContainSubstring, expectedInfo)
+			_, tracelog, err := app.DoCmdAdd(&netVariables, nil)
+			So(tracelog, ShouldContainSubstring, "CNI_ADD: Args: ")
+			So(tracelog, ShouldContainSubstring, "Activating interface")
+			So(tracelog, ShouldContainSubstring, expectedInfo)
 			So(err, ShouldBeNil)
 		})
 	})
@@ -220,8 +215,8 @@ func Test_DoCmdDel(t *testing.T) {
 			})
 			defer patches.Reset()
 
-			info, err := app.DoCmdDel(&netVariables, nil)
-			So(info, ShouldBeEmpty)
+			_, tracelog, err := app.DoCmdDel(&netVariables, nil)
+			So(tracelog, ShouldBeEmpty)
 			So(err, ShouldEqual, expectedError)
 		})
 	})

--- a/pkg/util/netutil/netutil_test.go
+++ b/pkg/util/netutil/netutil_test.go
@@ -48,7 +48,7 @@ func Test_ActivateInterface(t *testing.T) {
 			hostVeth, _, err := ip.SetupVeth(ifName, 1500, netNS)
 			So(err, ShouldBeNil)
 
-			info, err := netutil.ActivateInterface(
+			log, err := netutil.ActivateInterface(
 				hostVeth.Name,
 				netNSName,
 				ifName,
@@ -56,7 +56,7 @@ func Test_ActivateInterface(t *testing.T) {
 				"20.0.0.81",
 				"20.0.0.1")
 			So(err, ShouldBeNil)
-			So(info, ShouldEqual, "Interface eth-894cad92 has already been UP.")
+			So(log, ShouldEqual, "Interface 'eth-894cad92' already UP.")
 		})
 
 		Reset(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request and contributing to Mizar!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind design
> /kind feature
/kind bug
> /kind cleanup
> /kind documentation

**What this PR does / why we need it**: This fixes the unit test failures that were missed when CI did not run for some reason on the last PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
