### PR TITLE
Fix issue 618 Recreated pod failed to be running

### DIFF
--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -145,6 +145,7 @@ class InterfaceServer(InterfaceServiceServicer):
 
         interfaces = InterfacesList(interfaces=interfaces)
         logger.info("Consumed {}".format(interfaces))
+        self.interfaces.pop(pod_name)
         return interfaces
 
     def _ProvisionInterface(self, interface, cni_params):
@@ -206,6 +207,7 @@ class InterfaceServer(InterfaceServiceServicer):
             if requested_pod_name in self.pod_dict:
                 if self.pod_dict[requested_pod_name]:
                     # Interfaces for the Pod has been produced
+                    self.pod_dict.pop(requested_pod_name)
                     return self._ConsumeInterfaces(requested_pod_name, request)
 
         # If we are here, the endpoint operator has not produced any interfaces


### PR DESCRIPTION
This pr is for issue 618 Recreated pod failed to be running. After consumed interface, the original code doesn't clean the wait list so has side impact to later request. This is to do the necessary list clean up. Tested the fix is working.

**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #618 
