### PR TITLE
Use while to let ConsumeInterfaces waiting for ProduceInterfaces

### DIFF
--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -29,6 +29,7 @@ logger.addHandler(handler)
 logger = logging.getLogger()
 
 CONSUME_INTERFACE_TIMEOUT = 5
+WAITING_SLEEP_INTERVAL = 0.5
 
 
 class InterfaceServer(InterfaceServiceServicer):
@@ -213,7 +214,7 @@ class InterfaceServer(InterfaceServiceServicer):
                         # Interfaces for the Pod has been produced
                         self.pod_dict.pop(requested_pod_name)
                         return self._ConsumeInterfaces(requested_pod_name, request)
-            time.sleep(0.5)
+            time.sleep(WAITING_SLEEP_INTERVAL)
             now = time.time()
             if now - start >= CONSUME_INTERFACE_TIMEOUT:
                 break

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -203,6 +203,8 @@ class InterfaceServer(InterfaceServiceServicer):
         logger.info("Consuming interfaces for pod: {} Current Queue: {}".format(
             requested_pod_name, list(self.pod_dict)))
 
+        # The success of this function depends on ProduceInterfaces which is executed in another process.
+        # So using while here to wait until ProduceInterfaces has been done.
         start = time.time()
         while True:
             if self.pod_dict:


### PR DESCRIPTION
When starting a pod, currently it may need 15 seconds to be in running state. After this pr, for a single pod, it reduces to 2 seconds to be in running state.

**The reason behind:**
ConsumeInterface and ProduceInterface are from two different process. ConsumeInterface depends on ProduceInterface. If ConsumeInterface runs first, the process will fail and will be retried after 15 seconds, that's the reason we see the pod is running after 15 seconds.
This pr is to add a wait for ConsumeInterface until ProduceInterface has done. Although the code sets a timeout of 5 seconds, I see a single pod will be running in 2 seconds.
