### PR TITLE
Subnet create - Retry host endpoint creation

### DIFF
--- a/mizar/dp/mizar/workflows/droplets/provisioned.py
+++ b/mizar/dp/mizar/workflows/droplets/provisioned.py
@@ -68,5 +68,5 @@ class DropletProvisioned(WorkflowTask):
                     vpcs_opr.store_update(vpc)
             else:
                 self.raise_temporary_error(
-                    "Host ep creation failed: no subnet created yet for VPC {}".format(vpc.get_name()))
+                    "Host ep creation failed: no subnet created yet for VPC {} node ip {}".format(vpc.get_name(), droplet.ip))
         self.finalize()

--- a/mizar/dp/mizar/workflows/nets/create.py
+++ b/mizar/dp/mizar/workflows/nets/create.py
@@ -82,6 +82,9 @@ class NetCreate(WorkflowTask):
                     "{}-{}".format(OBJ_DEFAULTS.host_ep_peer_name,
                                    vpc.get_vni()),
                 )
+                if not droplet.interfaces:
+                    self.raise_temporary_error(
+                        "Daemon not yet ready for droplet {}".format(droplet.main_ip))
                 droplets_opr.store_update(droplet)
                 host_ep = endpoints_opr.create_host_endpoint(
                     droplet.ip, droplet, droplet.interfaces,


### PR DESCRIPTION
This PR adds a retry to host endpoint creation when the subnet comes up.
Fixes an issue where operator tries to create a host endpoint before the daemon is up.