### PR TITLE
Avoid spurious XDP program reloads and dup eBPF map table entries

### DIFF
--- a/mizar/common/constants.py
+++ b/mizar/common/constants.py
@@ -118,9 +118,9 @@ class OBJ_DEFAULTS:
     mizar_ep_vpc_annotation = "mizar.com/vpc"
     mizar_ep_subnet_annotation = "mizar.com/subnet"
 
-    # 5 minutes of retries
-    kopf_max_retries = 15
-    kopf_retry_delay = 20
+    # 15 minutes of retries
+    kopf_max_retries = 60
+    kopf_retry_delay = 15
 
 
 class RESOURCES:

--- a/src/dmn/trn_agent_xdp_usr.c
+++ b/src/dmn/trn_agent_xdp_usr.c
@@ -219,7 +219,9 @@ int trn_agent_update_endpoint(struct agent_user_metadata_t *umd,
 {
 	int err = bpf_map_update_elem(umd->endpoints_map_fd, epkey, ep, 0);
 	if (err) {
-		TRN_LOG_ERROR("Store endpoint mapping failed (err:%d).", err);
+		int errnum = errno;
+		TRN_LOG_ERROR("Update agent endpoints_map failed for fd=%d - err: %d errno: %d '%s'.",
+				umd->endpoints_map_fd, err, errnum, strerror(errnum));
 		return 1;
 	}
 	return 0;
@@ -230,9 +232,9 @@ int trn_agent_get_endpoint(struct agent_user_metadata_t *umd,
 {
 	int err = bpf_map_lookup_elem(umd->endpoints_map_fd, epkey, ep);
 	if (err) {
-		TRN_LOG_ERROR(
-			"Querying agent endpoint mapping failed (err:%d).",
-			err);
+		int errnum = errno;
+		TRN_LOG_ERROR("Query agent endpoints_map failed for fd=%d - err: %d errno: %d '%s'.",
+				umd->endpoints_map_fd, err, errnum, strerror(errnum));
 		return 1;
 	}
 	return 0;
@@ -243,9 +245,9 @@ int trn_agent_delete_endpoint(struct agent_user_metadata_t *umd,
 {
 	int err = bpf_map_delete_elem(umd->endpoints_map_fd, epkey);
 	if (err) {
-		TRN_LOG_ERROR(
-			"Deleting agent endpoint mapping failed (err:%d).",
-			err);
+		int errnum = errno;
+		TRN_LOG_ERROR("Delete agent endpoints_map failed for fd=%d - err: %d errno: %d '%s'.",
+				umd->endpoints_map_fd, err, errnum, strerror(errnum));
 		return 1;
 	}
 	return 0;
@@ -631,7 +633,6 @@ int trn_agent_metadata_init(struct agent_user_metadata_t *md, char *itf,
 	}
 
 	rc = trn_agent_bpf_maps_init(md);
-
 	if (rc != 0) {
 		return 1;
 	}

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -605,7 +605,7 @@ error:
 int *load_transit_xdp_1_svc(rpc_trn_xdp_intf_t *xdp_intf, struct svc_req *rqstp)
 {
 	UNUSED(rqstp);
-	static int result = -1;
+	static int result = 0;
 
 	int rc;
 	bool unload_error = false;
@@ -616,12 +616,12 @@ int *load_transit_xdp_1_svc(rpc_trn_xdp_intf_t *xdp_intf, struct svc_req *rqstp)
 	struct user_metadata_t *md = trn_itf_table_find(itf);
 
 	if (md) {
-		TRN_LOG_INFO("meatadata for interface %s already exist.", itf);
-	} else {
-		TRN_LOG_INFO("creating meatadata for interface %s.", itf);
-		md = malloc(sizeof(struct user_metadata_t));
+		TRN_LOG_INFO("Transit XDP for interface %s already exist.", itf);
+		return &result;
 	}
 
+	TRN_LOG_INFO("Loading transit XDP for interface %s.", itf);
+	md = malloc(sizeof(struct user_metadata_t));
 	if (!md) {
 		TRN_LOG_ERROR("Failure allocating memory for user_metadata_t");
 		result = RPC_TRN_FATAL;
@@ -629,7 +629,6 @@ int *load_transit_xdp_1_svc(rpc_trn_xdp_intf_t *xdp_intf, struct svc_req *rqstp)
 	}
 
 	memset(md, 0, sizeof(struct user_metadata_t));
-
 	// Set all interface index slots to unused
 	int i;
 	for (i = 0; i < TRAN_MAX_ITF; i++) {
@@ -644,7 +643,6 @@ int *load_transit_xdp_1_svc(rpc_trn_xdp_intf_t *xdp_intf, struct svc_req *rqstp)
 		      xdp_intf->xdp_path, xdp_intf->pcapfile);
 
 	rc = trn_user_metadata_init(md, itf, kern_path, md->xdp_flags);
-
 	if (rc != 0) {
 		TRN_LOG_ERROR(
 			"Failure initializing or loading transit XDP program for interface %s",
@@ -665,7 +663,6 @@ int *load_transit_xdp_1_svc(rpc_trn_xdp_intf_t *xdp_intf, struct svc_req *rqstp)
 
 	TRN_LOG_INFO("Successfully loaded transit XDP on interface %s", itf);
 
-	result = 0;
 	return &result;
 
 error:
@@ -714,7 +711,7 @@ int *load_transit_agent_xdp_1_svc(rpc_trn_xdp_intf_t *xdp_intf,
 				  struct svc_req *rqstp)
 {
 	UNUSED(rqstp);
-	static int result = -1;
+	static int result = 0;
 
 	int rc;
 	bool unload_error = false;
@@ -725,10 +722,12 @@ int *load_transit_agent_xdp_1_svc(rpc_trn_xdp_intf_t *xdp_intf,
 
 	struct agent_user_metadata_t *md = trn_vif_table_find(itf);
 	if (md) {
-		TRN_LOG_INFO("meatadata for interface %s already exist.", itf);
-	} else {
-		md = malloc(sizeof(struct agent_user_metadata_t));
+		TRN_LOG_INFO("Agent XDP for interface %s alreay loaded.", itf);
+		return &result;
 	}
+
+	TRN_LOG_INFO("Loading agent XDP for interface %s.", itf);
+	md = malloc(sizeof(struct agent_user_metadata_t));
 	if (!md) {
 		TRN_LOG_ERROR(
 			"Failure allocating memory for agent_user_metadata_t");
@@ -737,7 +736,6 @@ int *load_transit_agent_xdp_1_svc(rpc_trn_xdp_intf_t *xdp_intf,
 	}
 
 	memset(md, 0, sizeof(struct agent_user_metadata_t));
-
 	strcpy(md->pcapfile, xdp_intf->pcapfile);
 	md->pcapfile[255] = '\0';
 	md->xdp_flags = xdp_intf->xdp_flag;
@@ -746,7 +744,6 @@ int *load_transit_agent_xdp_1_svc(rpc_trn_xdp_intf_t *xdp_intf,
 		      xdp_intf->xdp_path, xdp_intf->pcapfile);
 
 	rc = trn_agent_metadata_init(md, itf, kern_path, md->xdp_flags);
-
 	if (rc != 0) {
 		TRN_LOG_ERROR("Failure initializing or loading transit agent "
 			      "XDP program for interface %s",
@@ -765,7 +762,6 @@ int *load_transit_agent_xdp_1_svc(rpc_trn_xdp_intf_t *xdp_intf,
 		goto error;
 	}
 
-	result = 0;
 	return &result;
 
 error:
@@ -828,7 +824,6 @@ int *update_agent_ep_1_svc(rpc_trn_endpoint_t *ep, struct svc_req *rqstp)
 		      ep->hosted_interface);
 
 	struct agent_user_metadata_t *md = trn_vif_table_find(itf);
-
 	if (!md) {
 		TRN_LOG_ERROR("Cannot find virtual interface metadata for %s",
 			      itf);
@@ -875,7 +870,6 @@ int *update_agent_ep_1_svc(rpc_trn_endpoint_t *ep, struct svc_req *rqstp)
 	}
 
 	rc = trn_agent_update_endpoint(md, &epkey, &epval);
-
 	if (rc != 0) {
 		TRN_LOG_ERROR("Cannot update agent with ep %d on interface %s",
 			      epkey.tunip[2], itf);


### PR DESCRIPTION
<!--  Thanks for sending a pull request and contributing to Mizar!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind design
> /kind feature
/kind bug
> /kind cleanup
> /kind documentation

**What this PR does / why we need it**: Load agent/transit XDP programs tries to initialize and load program even though it has already been loaded. This avoids creation of spurious eBPF map entries by avoiding load (without unload) if XDP program has already been loaded.

**Which issue(s) this PR fixes**: Arktos issues 1360.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**: Tested scaleup with kube-up several times and scaleout 2x2.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
