### PR TITLE
Fix pod stuck in ContainerCreating issue

### DIFF
--- a/cmd/mizarcni/app/worker.go
+++ b/cmd/mizarcni/app/worker.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	klog "k8s.io/klog/v2"
+
 	"centaurusinfra.io/mizar/pkg/object"
 	"centaurusinfra.io/mizar/pkg/util/grpcclientutil"
 	"centaurusinfra.io/mizar/pkg/util/netutil"
@@ -38,6 +40,12 @@ func DoCmdAdd(netVariables *object.NetVariables, stdinData []byte) (cniTypesVer.
 	result := cniTypesVer.Result{
 		CNIVersion: netVariables.CniVersion,
 	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			klog.Errorf("System Error: '%+v'\n", r)
+		}
+	}()
 
 	if err := netvariablesutil.LoadCniConfig(netVariables, stdinData); err != nil {
 		return result, tracelog.String(), err

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -212,8 +212,9 @@ class InterfaceServer(InterfaceServiceServicer):
                 if requested_pod_name in self.pod_dict:
                     if self.pod_dict[requested_pod_name]:
                         # Interfaces for the Pod has been produced
+                        interfaces = self._ConsumeInterfaces(requested_pod_name, request)
                         self.pod_dict.pop(requested_pod_name)
-                        return self._ConsumeInterfaces(requested_pod_name, request)
+                        return interfaces
             time.sleep(WAITING_SLEEP_INTERVAL)
             now = time.time()
             if now - start >= CONSUME_INTERFACE_TIMEOUT:

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -145,7 +145,7 @@ class InterfaceServer(InterfaceServiceServicer):
                 interface.status = InterfaceStatus.consumed
 
         interfaces = InterfacesList(interfaces=interfaces)
-        logger.info("Consumed {}".format(interfaces))
+        logger.info("Pod {} Consumed {}".format(pod_name, interfaces))
         self.interfaces.pop(pod_name)
         return interfaces
 

--- a/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
+++ b/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
@@ -324,7 +324,7 @@ class EndpointOperator(object):
             interfaces = InterfaceServiceClient(
                 ep.droplet_obj.main_ip).ProduceInterfaces(InterfacesList(interfaces=interfaces_list))
 
-        logger.info("Produced {}".format(interfaces))
+        logger.info("Endpoint {} Produced {}".format(ep.name, interfaces))
 
     def create_simple_endpoints(self, interfaces, spec):
         """

--- a/mizar/dp/mizar/workflows/builtins/pods/create.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/create.py
@@ -160,7 +160,7 @@ class k8sPodCreate(WorkflowTask):
             self.param.name, self.param.namespace, spec['labels'], self.param.diff)
         spec['pod_label_value'] = pod_label_value
         spec['namespace_label_value'] = namespace_label_value
-        if spec['phase'] != 'Pending':
+        if spec['phase'] != 'Pending' and spec['phase'] != 'ContainerCreating':
             networkpolicy_util.handle_networkpolicy_change(policy_name_list)
             self.finalize()
             return
@@ -175,9 +175,6 @@ class k8sPodCreate(WorkflowTask):
             "Initing endpoint interface on for {} on host {}".format(self.param.name, spec['hostIP']))
         interfaces = endpoint_opr.init_simple_endpoint_interfaces(
             spec['hostIP'], spec)
-        if not interfaces:
-            self.raise_permanent_error(
-                "Endpoint {} already exists!".format(spec["name"]))
         # Create the corresponding simple endpoint objects
         endpoint_opr.create_simple_endpoints(interfaces, spec)
 


### PR DESCRIPTION
We are observing issue that system created pods may stuck in ContainerCreating, while normal pods we don't see the issue. For this issue, the major difference between system pods and normal pods is that system pods are created in very early stage, when system may not be ready, and mizar may not be ready.

When a pod is created, what happened in mizar is:
1. Produce interface, and put to a map, indicate the interface is produced
2. check the map to see whether the interface has been produced
3. If the interface is in the map, get it from the map, and remove it from the map.
4. Consume interface which is from the map

The ordering of 3 and 4 is the issue. We are doing it too early that remove the interface from the map. Let's assume if there is any exception happens in step 4, since the interface is removed, it has no chance to retry.

When pod is created in early stage, at that time mizar is not fully ready, or in a transition to ready state, it has chance to fail and throw exception in step 4.

The fix is to re-ordering step 3 and 4. After step 4 consuming interface succeed, we remove the interface from the map.

I tried the fix and the issue cannot repro.

**What type of PR is this?**
/kind bug