### PR TITLE
Fix Host Endpoint Create: Subnet prefix empty string issue

### DIFF
--- a/mizar/dp/mizar/workflows/droplets/provisioned.py
+++ b/mizar/dp/mizar/workflows/droplets/provisioned.py
@@ -51,6 +51,9 @@ class DropletProvisioned(WorkflowTask):
                 if nets_opr.store.nets_vpc_store[vpc.name]:
                     subnet = list(
                         nets_opr.store.nets_vpc_store[vpc.name].values())[0]
+                    if subnet.status != OBJ_STATUS.net_status_provisioned:
+                        self.raise_temporary_error(
+                            "Subnet {} not yet provisioned!".format(subnet.name))
                     logger.info("Droplet: Creating host endpoint for vpc {} on droplet {}".format(
                         vpc.name, droplet.ip))
                     droplet.interfaces = endpoint_opr.init_host_endpoint_interfaces(


### PR DESCRIPTION
This PR fixes a rare bug where the host endpoint is created but the subnet is not yet in provisioned state. 
Certain properties of the subnet may not yet be filled out which in turn causes issues with host endpoint creation.