### PR TITLE
Fix issue: After ConsumingInterface, pod-interface map shall delay pop until pod is running

### DIFF
--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -227,7 +227,6 @@ class InterfaceServer(InterfaceServiceServicer):
         """
         requested_pod_id = request
         requested_pod_name = get_pod_name(requested_pod_id)
-        logger.info("hochan 3 {}".format(requested_pod_name))
         if(requested_pod_name in self.pod_dict):
             self.pod_dict.pop(requested_pod_name)
         if(requested_pod_name in self.interfaces):

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -145,8 +145,6 @@ class InterfaceServer(InterfaceServiceServicer):
                 interface.status = InterfaceStatus.consumed
 
         interfaces = InterfacesList(interfaces=interfaces)
-        logger.info("Consumed {}".format(interfaces))
-        self.interfaces.pop(pod_name)
         return interfaces
 
     def _ProvisionInterface(self, interface, cni_params):
@@ -212,7 +210,6 @@ class InterfaceServer(InterfaceServiceServicer):
                 if requested_pod_name in self.pod_dict:
                     if self.pod_dict[requested_pod_name]:
                         # Interfaces for the Pod has been produced
-                        self.pod_dict.pop(requested_pod_name)
                         return self._ConsumeInterfaces(requested_pod_name, request)
             time.sleep(WAITING_SLEEP_INTERVAL)
             now = time.time()
@@ -223,6 +220,18 @@ class InterfaceServer(InterfaceServiceServicer):
         # for the Pod. Typically the CNI will retry to consume the interface.
         raise RuntimeError(
             "ConsumeInterfaces: Interface not found for pod '{}'".format(requested_pod_name))
+
+    def RemoveCachedInterfaces(self, request, context):
+        """
+        Called by the endpoints operator to remove cached interfaces.
+        """
+        requested_pod_id = request
+        requested_pod_name = get_pod_name(requested_pod_id)
+        logger.info("hochan 3 {}".format(requested_pod_name))
+        if(requested_pod_name in self.pod_dict):
+            self.pod_dict.pop(requested_pod_name)
+        if(requested_pod_name in self.interfaces):
+            self.interfaces.pop(requested_pod_name)
 
     def _DeleteVethInterface(self, interface):
         """
@@ -376,6 +385,17 @@ class InterfaceServiceClient():
                 task.raise_permanent_error(
                     "Produce host endpoint permanent error: Unknown {}".format(rpc_error.details()))
 
+    def RemoveCachedInterfaces(self, pod_id, task):
+        try:
+            resp = self.stub.RemoveCachedInterfaces(pod_id)
+            return resp
+        except grpc.RpcError as rpc_error:
+            if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
+                task.raise_temporary_error(
+                    "Remove cached interfaces temporary error: Daemon not yet ready! {}".format(rpc_error.details()))
+            else:
+                task.raise_permanent_error(
+                    "Remove cached interfaces temporary error: Unknown {}".format(rpc_error.details()))
 
 class LocalTransitRpc:
     def __init__(self, ip, mac, itf, benchmark=False):

--- a/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
+++ b/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
@@ -398,6 +398,15 @@ class EndpointOperator(object):
             ep.create_obj()
             return ep
 
+    def remove_cached_interfaces(self, worker_ip, spec, task):
+        """
+        Call the InitializeInterfaces gRPC on the hostIP to remove cached interfaces
+        """
+        pod_id = PodId(k8s_pod_name=spec['name'],
+                       k8s_namespace=spec['namespace'],
+                       k8s_pod_tenant=spec['tenant'])
+        InterfaceServiceClient(worker_ip).RemoveCachedInterfaces(pod_id, task)
+
     def init_simple_endpoint_interfaces(self, worker_ip, spec, task):
         """
         Construct the interface message and call the InitializeInterfaces gRPC on

--- a/mizar/dp/mizar/workflows/builtins/pods/create.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/create.py
@@ -160,6 +160,8 @@ class k8sPodCreate(WorkflowTask):
             self.param.name, self.param.namespace, spec['labels'], self.param.diff)
         spec['pod_label_value'] = pod_label_value
         spec['namespace_label_value'] = namespace_label_value
+        if spec['phase'] == 'Running':
+            endpoint_opr.remove_cached_interfaces(spec['hostIP'], spec, self)
         if spec['phase'] != 'Pending':
             networkpolicy_util.handle_networkpolicy_change(policy_name_list)
             self.finalize()

--- a/mizar/proto/mizar/proto/interface.proto
+++ b/mizar/proto/mizar/proto/interface.proto
@@ -11,6 +11,7 @@ service InterfaceService {
   rpc ConsumeInterfaces(CniParameters) returns (InterfacesList) {}
   rpc ActivateHostInterface(Interface) returns (Interface) {}
   rpc DeleteInterface(Interface) returns (google.protobuf.Empty) {}
+  rpc RemoveCachedInterfaces(PodId) returns (google.protobuf.Empty) {}
 }
 
 message PodId {

--- a/pkg/util/grpcclientutil/grpcclientutil.go
+++ b/pkg/util/grpcclientutil/grpcclientutil.go
@@ -42,12 +42,12 @@ func ConsumeInterfaces(netVariables object.NetVariables) ([]*Interface, error) {
 }
 
 func getInterfaceServiceClient() (InterfaceServiceClient, *grpc.ClientConn, context.Context, context.CancelFunc, error) {
-	conn, err := grpc.Dial("localhost:50051", grpc.WithInsecure(), grpc.WithBlock())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*8)
+	conn, err := grpc.DialContext(ctx, "localhost:50051", grpc.WithBlock(), grpc.WithInsecure())
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, cancel, err
 	}
 	client := NewInterfaceServiceClient(conn)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*8)
 	return client, conn, ctx, cancel, nil
 }
 

--- a/pkg/util/grpcclientutil/grpcclientutil.go
+++ b/pkg/util/grpcclientutil/grpcclientutil.go
@@ -25,6 +25,11 @@ import (
 	"google.golang.org/grpc"
 )
 
+const (
+	GrpcConnectionTimeout = time.Second * 2
+	GrpcRequestTimeout    = time.Second * 8
+)
+
 func ConsumeInterfaces(netVariables object.NetVariables) ([]*Interface, error) {
 	client, conn, ctx, cancel, err := getInterfaceServiceClient()
 	if err != nil {
@@ -42,12 +47,13 @@ func ConsumeInterfaces(netVariables object.NetVariables) ([]*Interface, error) {
 }
 
 func getInterfaceServiceClient() (InterfaceServiceClient, *grpc.ClientConn, context.Context, context.CancelFunc, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*8)
+	ctx, cancel := context.WithTimeout(context.Background(), GrpcConnectionTimeout)
 	conn, err := grpc.DialContext(ctx, "localhost:50051", grpc.WithBlock(), grpc.WithInsecure())
 	if err != nil {
 		return nil, nil, nil, cancel, err
 	}
 	client := NewInterfaceServiceClient(conn)
+	ctx, cancel = context.WithTimeout(context.Background(), GrpcRequestTimeout)
 	return client, conn, ctx, cancel, nil
 }
 


### PR DESCRIPTION
This pr is to fix issue 628 After ConsumingInterface, pod-interface map shall delay pop until pod is running.

I tried 10 times and the issue that pod stuck in ContainerCreating will be addressed by this fix.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #628 
