### PR TITLE
Fix host endpoint device busy error

### DIFF
--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -346,7 +346,7 @@ class InterfaceServiceClient():
                 task.raise_temporary_error(
                     "Produce endpoint temporary error: Daemon not yet ready! {}".format(rpc_error.details()))
             elif CONSTANTS.GRPC_DEVICE_BUSY_ERROR in rpc_error.details() or CONSTANTS.GRPC_FILE_EXISTS_ERROR in rpc_error.details():
-                logger.info(
+                task.raise_permanent_error(
                     "Produce endpoint permanent error: Repeat call veth device already created! RPC error : {}".format(rpc_error.details()))
                 return None
             else:
@@ -379,7 +379,7 @@ class InterfaceServiceClient():
                 task.raise_temporary_error(
                     "Produce host endpoint temporary error: Daemon not yet ready! {}".format(rpc_error.details()))
             elif CONSTANTS.GRPC_DEVICE_BUSY_ERROR in rpc_error.details() or CONSTANTS.GRPC_FILE_EXISTS_ERROR in rpc_error.details():
-                logger.info(
+                task.raise_permanent_error(
                     "Produce host endpoint: Repeat call, veth device already created! RPC error: {}".format(rpc_error.details()))
                 return None
             else:
@@ -397,6 +397,7 @@ class InterfaceServiceClient():
             else:
                 task.raise_permanent_error(
                     "Remove cached interfaces temporary error: Unknown {}".format(rpc_error.details()))
+
 
 class LocalTransitRpc:
     def __init__(self, ip, mac, itf, benchmark=False):

--- a/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
+++ b/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
@@ -313,8 +313,8 @@ class EndpointOperator(object):
             egress_bandwidth_bytes_per_sec=interface.egress_bandwidth_bytes_per_sec,
             pod_network_class=interface.pod_network_class,
             pod_network_priority=interface.pod_network_priority,
-            subnet_ip=ep.subnet_ip,
-            subnet_prefix=ep.subnet_prefix
+            vpc_ip=ep.vpc_ip,
+            vpc_prefix=ep.vpc_prefix
         )]
 
         if ep.type == OBJ_DEFAULTS.ep_type_host:
@@ -378,11 +378,11 @@ class EndpointOperator(object):
             ep.set_status(OBJ_STATUS.ep_status_init)
 
             ep.set_vni(get_cluster_vpc_vni())
-            ep.set_vpc(vpc)
+            ep.set_vpc(vpc.get_name())
             ep.set_net(subnet.get_name())
             ep.set_gw(subnet.get_gw_ip())
-            ep.set_subnet_ip(subnet.get_nip())
-            ep.set_subnet_prefix(subnet.get_prefixlen())
+            ep.set_vpc_ip(vpc.get_ip())
+            ep.set_vpc_prefix(vpc.get_prefixlen())
 
             ep.set_mac(interface.address.mac)
             ep.set_veth_name(interface.veth.name)

--- a/mizar/dp/mizar/operators/nets/nets_operator.py
+++ b/mizar/dp/mizar/operators/nets/nets_operator.py
@@ -108,7 +108,7 @@ class NetOperator(object):
 
         return
 
-    def allocate_endpoint(self, ep):
+    def allocate_endpoint(self, ep, vpc):
         n = self.store.get_net(ep.net)
         logger.info("IP {} for net {}".format(ep.ip, n.name))
         if ep.type == OBJ_DEFAULTS.ep_type_host:
@@ -130,8 +130,8 @@ class NetOperator(object):
         n.mark_ip_as_allocated(ep.ip)
         self.store.update_net(n)
         ep.set_vni(n.vni)
-        ep.set_subnet_ip(n.get_nip())
-        ep.set_subnet_prefix(n.get_prefixlen())
+        ep.set_vpc_ip(vpc.get_ip())
+        ep.set_vpc_prefix(vpc.get_prefixlen())
 
     def deallocate_endpoint(self, ep):
         n = self.store.get_net(ep.net)

--- a/mizar/dp/mizar/workflows/droplets/provisioned.py
+++ b/mizar/dp/mizar/workflows/droplets/provisioned.py
@@ -67,17 +67,11 @@ class DropletProvisioned(WorkflowTask):
                         self
                     )
                     droplets_opr.store_update(droplet)
-                    host_ep = endpoint_opr.create_host_endpoint(
+                    endpoint_opr.create_host_endpoint(
                         droplet.ip, droplet, droplet.interfaces,
                         vpc.get_name(),
                         subnet
                     )
-                    interface = endpoint_opr.produce_simple_endpoint_interface(
-                        host_ep, self)
-                    if interface:
-                        droplets_opr.store_update_vpc_to_droplet(vpc, droplet)
-                        logger.info("Droplet: Created host endpoint for vpc {} on droplet {}".format(
-                            vpc.name, droplet.ip))
                 else:
                     self.raise_temporary_error(
                         "Host ep creation failed: no subnet created yet for VPC {} node ip {}".format(vpc.get_name(), droplet.ip))

--- a/mizar/dp/mizar/workflows/droplets/provisioned.py
+++ b/mizar/dp/mizar/workflows/droplets/provisioned.py
@@ -69,7 +69,7 @@ class DropletProvisioned(WorkflowTask):
                     droplets_opr.store_update(droplet)
                     endpoint_opr.create_host_endpoint(
                         droplet.ip, droplet, droplet.interfaces,
-                        vpc.get_name(),
+                        vpc,
                         subnet
                     )
                 else:

--- a/mizar/dp/mizar/workflows/endpoints/create.py
+++ b/mizar/dp/mizar/workflows/endpoints/create.py
@@ -51,13 +51,13 @@ class EndpointCreate(WorkflowTask):
         if ep.type in OBJ_DEFAULTS.droplet_eps and not ep.droplet_obj:
             self.raise_temporary_error(
                 "Task: {} Endpoint: {} Droplet Object {} not ready. ".format(self.__class__.__name__, ep.name, ep.droplet))
-        nets_opr.allocate_endpoint(ep)
+        vpc = vpcs_opr.store.get_vpc(ep.vpc)
+        nets_opr.allocate_endpoint(ep, vpc)
         bouncers_opr.update_endpoint_with_bouncers(ep, self)
         if ep.type == OBJ_DEFAULTS.ep_type_simple or ep.type == OBJ_DEFAULTS.ep_type_host:
             if ep.type == OBJ_DEFAULTS.ep_type_host:
                 logger.info("Activate host interface for vpc {} on droplet {}".format(
                     ep.vpc, ep.droplet_obj.ip))
-                vpc = vpcs_opr.store.get_vpc(ep.vpc)
                 droplets_opr.store_update_vpc_to_droplet(vpc, ep.droplet_obj)
             endpoints_opr.produce_simple_endpoint_interface(ep, self)
         if ep.bouncers:

--- a/mizar/dp/mizar/workflows/nets/provisioned.py
+++ b/mizar/dp/mizar/workflows/nets/provisioned.py
@@ -71,13 +71,12 @@ class NetProvisioned(WorkflowTask):
                 droplets_opr.store_update(droplet)
                 endpoints_opr.create_host_endpoint(
                     droplet.ip, droplet, droplet.interfaces,
-                    vpc.get_name(),
+                    vpc,
                     net
                 )
             else:
                 logger.info("Net: Host endpoint already created for vpc {} on droplet {}".format(
                     vpc.name, droplet.ip))
-                logger.info()
         self.finalize()
 
     def process_change(self, net, field, old, new):

--- a/mizar/dp/mizar/workflows/nets/provisioned.py
+++ b/mizar/dp/mizar/workflows/nets/provisioned.py
@@ -69,17 +69,11 @@ class NetProvisioned(WorkflowTask):
                     self
                 )
                 droplets_opr.store_update(droplet)
-                host_ep = endpoints_opr.create_host_endpoint(
+                endpoints_opr.create_host_endpoint(
                     droplet.ip, droplet, droplet.interfaces,
                     vpc.get_name(),
                     net
                 )
-                interface = endpoints_opr.produce_simple_endpoint_interface(
-                    host_ep, self)
-                if interface:
-                    droplets_opr.store_update_vpc_to_droplet(vpc, droplet)
-                    logger.info("Net: Created host endpoint for vpc {} on droplet {}".format(
-                        vpc.name, droplet.ip))
             else:
                 logger.info("Net: Host endpoint already created for vpc {} on droplet {}".format(
                     vpc.name, droplet.ip))

--- a/mizar/obj/endpoint.py
+++ b/mizar/obj/endpoint.py
@@ -63,8 +63,8 @@ class Endpoint:
         self.backends = []
         self.ports = []
         self.pod = ""
-        self.subnet_prefix = ""
-        self.subnet_ip = ""
+        self.vpc_prefix = ""
+        self.vpc_ip = ""
         self.deleted = False
         self.interface = None
         self.ingress_networkpolicies = []
@@ -252,11 +252,11 @@ class Endpoint:
     def set_pod(self, pod):
         self.pod = pod
 
-    def set_subnet_ip(self, subnet_ip):
-        self.subnet_ip = subnet_ip
+    def set_vpc_ip(self, vpc_ip):
+        self.vpc_ip = vpc_ip
 
-    def set_subnet_prefix(self, subnet_prefix):
-        self.subnet_prefix = subnet_prefix
+    def set_vpc_prefix(self, vpc_prefix):
+        self.vpc_prefix = vpc_prefix
 
     def update_bouncers(self, bouncers, task, add=True):
         for bouncer in bouncers.values():

--- a/mizar/obj/vpc.py
+++ b/mizar/obj/vpc.py
@@ -112,6 +112,12 @@ class Vpc(object):
     def get_vni(self):
         return self.vni
 
+    def get_ip(self):
+        return str(self.ip)
+
+    def get_prefixlen(self):
+        return str(self.prefix)
+
     def set_status(self, status):
         self.status = status
 

--- a/mizar/proto/mizar/proto/interface.proto
+++ b/mizar/proto/mizar/proto/interface.proto
@@ -82,8 +82,8 @@ message Interface {
   string egress_bandwidth_bytes_per_sec = 11;
   string pod_network_priority = 12;
   string pod_network_class = 13;
-  string subnet_ip = 14;
-  string subnet_prefix = 15;
+  string vpc_ip = 14;
+  string vpc_prefix = 15;
 }
 
 message InterfacesList {


### PR DESCRIPTION
This PR fixes the following:

- iproute device busy error from two threads attempting to to activate the host endpoint at the same time.
- Changes host endpoint route from subnet CIDR to VPC CIDR