### PR TITLE
Fix Startup Failures Without Retry

### DIFF
--- a/mizar/common/constants.py
+++ b/mizar/common/constants.py
@@ -48,6 +48,8 @@ class CONSTANTS:
     MIZAR_DEFAULT_EGRESS_BW_LIMIT_PCT = 30
     SUBNETS_NEW_PREFIX = 32
     RPC_ERROR_CODE = "error"
+    RPC_FATAL_CODE = "fatal"
+    RPC_FAILED_CODE = "failed"
     GRPC_DEVICE_BUSY_ERROR = "Device or resource busy"
     GRPC_FILE_EXISTS_ERROR = "File exists"
     GRPC_UNAVAILABLE = "failed to connect to all addresses"

--- a/mizar/common/constants.py
+++ b/mizar/common/constants.py
@@ -53,6 +53,7 @@ class CONSTANTS:
     GRPC_DEVICE_BUSY_ERROR = "Device or resource busy"
     GRPC_FILE_EXISTS_ERROR = "File exists"
     GRPC_UNAVAILABLE = "failed to connect to all addresses"
+    NETLINK_FILE_EXISTS_ERROR = 17
 
 
 class OBJ_STATUS:

--- a/mizar/common/rpc.py
+++ b/mizar/common/rpc.py
@@ -98,12 +98,18 @@ class TrnRpc:
         jsonconf = json.dumps(jsonconf)
         return jsonconf
 
-    def update_substrate_ep(self, ip, mac):
+    def update_substrate_ep(self, ip, mac, task):
         jsonconf = self.get_substrate_ep_json(ip, mac)
         cmd = f'''{self.trn_cli_update_ep} \'{jsonconf}\''''
         logger.info("update_substrate_ep: {}".format(cmd))
         returncode, text = run_cmd(cmd)
-        logger.info("returns {} {}".format(returncode, text))
+        logger.info("update_subpstrate_ep {} returns {} {}".format(
+            cmd, text, returncode))
+        if (CONSTANTS.RPC_ERROR_CODE in text or
+            CONSTANTS.RPC_FAILED_CODE in text or
+                CONSTANTS.RPC_FATAL_CODE in text):
+            task.raise_temporary_error(
+                "Update_agent_substrate ep returned ERROR! Retrying as agent may have not yet been loaded.")
 
     def update_agent_substrate_ep(self, ep, ip, mac, task):
         itf = ep.get_veth_peer()
@@ -111,11 +117,13 @@ class TrnRpc:
         cmd = f'''{self.trn_cli_update_agent_ep} -i \'{itf}\' -j \'{jsonconf}\''''
         logger.info("update_agent_substrate_ep: {}".format(cmd))
         returncode, text = run_cmd(cmd)
-        if CONSTANTS.RPC_ERROR_CODE in text:
+        logger.info(
+            "update_agent_substrate_ep {} returns {} {}".format(cmd, text, returncode))
+        if (CONSTANTS.RPC_ERROR_CODE in text or
+            CONSTANTS.RPC_FAILED_CODE in text or
+                CONSTANTS.RPC_FATAL_CODE in text):
             task.raise_temporary_error(
                 "Update_agent_substrate ep returned ERROR! Retrying as agent may have not yet been loaded.")
-        logger.info(
-            "update_agent_substrate_ep returns {} {}".format(returncode, text))
 
     def delete_agent_substrate_ep(self, ep, ip):
         itf = ep.get_veth_peer()
@@ -144,7 +152,7 @@ class TrnRpc:
         logger.info(
             "update_packet_metadata returns {} {}".format(returncode, text))
 
-    def update_ep(self, ep):
+    def update_ep(self, ep, task):
         peer = ""
         droplet_ip = ep.get_droplet_ip()
         # Only detail veth info if the droplet is also a host
@@ -165,15 +173,20 @@ class TrnRpc:
         cmd = f'''{self.trn_cli_update_ep} \'{jsonconf}\''''
         logger.info("update_ep: {}".format(cmd))
         returncode, text = run_cmd(cmd)
-        logger.info("returns {} {}".format(returncode, text))
+        logger.info("update_ep {} returns {} {}".format(cmd, text, returncode))
+        if (CONSTANTS.RPC_ERROR_CODE in text or
+            CONSTANTS.RPC_FAILED_CODE in text or
+                CONSTANTS.RPC_FATAL_CODE in text):
+            task.raise_temporary_error(
+                "update ep returned ERROR! Retrying as agent may have not yet been loaded.")
         remote_ports = ep.get_remote_ports()
         frontend_ports = ep.get_frontend_ports()
         protocols = ep.get_port_protocols()
         for i in range(len(remote_ports)):
             self.update_port(ep.get_tunnel_id(), ep.get_ip(),
-                             frontend_ports[i], remote_ports[i], protocols[i])
+                             frontend_ports[i], remote_ports[i], protocols[i], task)
 
-    def update_port(self, tunid, ip, port, target_port, protocol):
+    def update_port(self, tunid, ip, port, target_port, protocol, task):
         jsonconf = {
             "tunnel_id": tunid,
             "ip": ip,
@@ -185,7 +198,13 @@ class TrnRpc:
         cmd = f'''{self.trn_cli_update_port} \'{jsonconf}\''''
         logger.info("update_port: {}".format(cmd))
         returncode, text = run_cmd(cmd)
-        logger.info("returns {} {}".format(returncode, text))
+        logger.info("update_port {} returns {} {}".format(
+            cmd, text, returncode))
+        if (CONSTANTS.RPC_ERROR_CODE in text or
+            CONSTANTS.RPC_FAILED_CODE in text or
+                CONSTANTS.RPC_FATAL_CODE in text):
+            task.raise_temporary_error(
+                "update port returned ERROR! Retrying as agent may have not yet been loaded.")
 
     def update_agent_metadata(self, ep, task):
         itf = ep.get_veth_peer()
@@ -215,11 +234,13 @@ class TrnRpc:
         cmd = f'''{self.trn_cli_update_agent_metadata} -i \'{itf}\' -j \'{jsonconf}\''''
         logger.info("update_agent_metadata: {}".format(cmd))
         returncode, text = run_cmd(cmd)
-        if CONSTANTS.RPC_ERROR_CODE in text:
+        logger.info(
+            "update_agent_metadata {} returns {} {}".format(cmd, text, returncode))
+        if (CONSTANTS.RPC_ERROR_CODE in text or
+            CONSTANTS.RPC_FAILED_CODE in text or
+                CONSTANTS.RPC_FATAL_CODE in text):
             task.raise_temporary_error(
                 "Update_agent_metadata returned ERROR! Retrying as agent may have not yet been loaded.")
-        logger.info(
-            "update_agent_metadata returns {} {}".format(returncode, text))
 
     def load_transit_agent_xdp(self, veth_peer):
         itf = veth_peer
@@ -236,7 +257,7 @@ class TrnRpc:
         logger.info(
             "load_transit_agent_xdp returns {} {}".format(returncode, text))
 
-    def load_transit_xdp_pipeline_stage(self, stage, obj_file):
+    def load_transit_xdp_pipeline_stage(self, stage, obj_file, task):
         jsonconf = {
             "xdp_path": obj_file,
             "stage": stage
@@ -246,7 +267,12 @@ class TrnRpc:
         logger.info("load_transit_xdp_pipeline_stage: {}".format(cmd))
         returncode, text = run_cmd(cmd)
         logger.info(
-            "load_transit_xdp_pipeline_stage returns {} {}".format(returncode, text))
+            "load_transit_xdp_pipeline_stage returns {} {}".format(text, returncode))
+        if (CONSTANTS.RPC_ERROR_CODE in text or
+            CONSTANTS.RPC_FAILED_CODE in text or
+                CONSTANTS.RPC_FATAL_CODE in text):
+            task.raise_temporary_error(
+                "load_transit_xdp_pipeline_stage returned ERROR! Retrying as agent may have not yet been loaded.")
 
     def unload_transit_xdp_pipeline_stage(self, stage, obj_file):
         jsonconf = {
@@ -292,7 +318,7 @@ class TrnRpc:
         logger.info(
             "unload_transit_agent_xdp returns {} {}".format(returncode, text))
 
-    def update_vpc(self, bouncer):
+    def update_vpc(self, bouncer, task):
         if len(bouncer.get_divider_ips()) < 1:
             logger.info("Bouncer list of dividers, LEN IS ZERO")
             return
@@ -305,6 +331,11 @@ class TrnRpc:
         logger.info("update_vpc: {}".format(cmd))
         returncode, text = run_cmd(cmd)
         logger.info("update_vpc returns {} {}".format(returncode, text))
+        if (CONSTANTS.RPC_ERROR_CODE in text or
+            CONSTANTS.RPC_FAILED_CODE in text or
+                CONSTANTS.RPC_FATAL_CODE in text):
+            task.raise_temporary_error(
+                "update_vpc returned ERROR! Retrying as agent may have not yet been loaded.")
 
     def delete_vpc(self, bouncer):
         jsonconf = {
@@ -316,7 +347,7 @@ class TrnRpc:
         returncode, text = run_cmd(cmd)
         logger.info("delete_vpc returns {} {}".format(returncode, text))
 
-    def update_net(self, net):
+    def update_net(self, net, task):
         if len(net.get_bouncers_ips()) < 1:
             logger.info("net list of bouncers LEN IS ZERO")
             return
@@ -330,7 +361,13 @@ class TrnRpc:
         cmd = f'''{self.trn_cli_update_net} \'{jsonconf}\''''
         logger.info("update_net: {}".format(cmd))
         returncode, text = run_cmd(cmd)
-        logger.info("update_net returns {} {}".format(returncode, text))
+        logger.info("update_net {} returns {} {}".format(
+            cmd, text, returncode))
+        if (CONSTANTS.RPC_ERROR_CODE in text or
+            CONSTANTS.RPC_FAILED_CODE in text or
+                CONSTANTS.RPC_FATAL_CODE in text):
+            task.raise_temporary_error(
+                "update_net returned ERROR! Retrying as agent may have not yet been loaded.")
 
     def delete_net(self, net):
         jsonconf = {

--- a/mizar/common/rpc.py
+++ b/mizar/common/rpc.py
@@ -109,7 +109,7 @@ class TrnRpc:
             CONSTANTS.RPC_FAILED_CODE in text or
                 CONSTANTS.RPC_FATAL_CODE in text):
             task.raise_temporary_error(
-                "Update_agent_substrate ep returned ERROR! Retrying as agent may have not yet been loaded.")
+                "update_substrate_ep returned ERROR! Retrying as agent may have not yet been loaded.")
 
     def update_agent_substrate_ep(self, ep, ip, mac, task):
         itf = ep.get_veth_peer()
@@ -123,7 +123,7 @@ class TrnRpc:
             CONSTANTS.RPC_FAILED_CODE in text or
                 CONSTANTS.RPC_FATAL_CODE in text):
             task.raise_temporary_error(
-                "Update_agent_substrate ep returned ERROR! Retrying as agent may have not yet been loaded.")
+                "update_agent_substrate_ep returned ERROR! Retrying as agent may have not yet been loaded.")
 
     def delete_agent_substrate_ep(self, ep, ip):
         itf = ep.get_veth_peer()
@@ -178,7 +178,7 @@ class TrnRpc:
             CONSTANTS.RPC_FAILED_CODE in text or
                 CONSTANTS.RPC_FATAL_CODE in text):
             task.raise_temporary_error(
-                "update ep returned ERROR! Retrying as agent may have not yet been loaded.")
+                "update_ep returned ERROR! Retrying as agent may have not yet been loaded.")
         remote_ports = ep.get_remote_ports()
         frontend_ports = ep.get_frontend_ports()
         protocols = ep.get_port_protocols()
@@ -204,7 +204,7 @@ class TrnRpc:
             CONSTANTS.RPC_FAILED_CODE in text or
                 CONSTANTS.RPC_FATAL_CODE in text):
             task.raise_temporary_error(
-                "update port returned ERROR! Retrying as agent may have not yet been loaded.")
+                "update_port returned ERROR! Retrying as agent may have not yet been loaded.")
 
     def update_agent_metadata(self, ep, task):
         itf = ep.get_veth_peer()
@@ -240,7 +240,7 @@ class TrnRpc:
             CONSTANTS.RPC_FAILED_CODE in text or
                 CONSTANTS.RPC_FATAL_CODE in text):
             task.raise_temporary_error(
-                "Update_agent_metadata returned ERROR! Retrying as agent may have not yet been loaded.")
+                "update_agent_metadata returned ERROR! Retrying as agent may have not yet been loaded.")
 
     def load_transit_agent_xdp(self, veth_peer):
         itf = veth_peer

--- a/mizar/dp/mizar/operators/bouncers/bouncers_operator.py
+++ b/mizar/dp/mizar/operators/bouncers/bouncers_operator.py
@@ -71,15 +71,15 @@ class BouncerOperator(object):
         bouncer.set_status(OBJ_STATUS.bouncer_status_provisioned)
         bouncer.update_obj()
 
-    def update_bouncers_with_divider(self, div):
+    def update_bouncers_with_divider(self, div, task):
         bouncers = self.store.get_bouncers_of_vpc(div.vpc)
         for b in bouncers.values():
-            b.update_vpc(set([div]))
+            b.update_vpc(set([div]), task)
 
-    def delete_divider_from_bouncers(self, div):
+    def delete_divider_from_bouncers(self, div, task):
         bouncers = self.store.get_bouncers_of_vpc(div.vpc)
         for b in bouncers.values():
-            b.update_vpc(set([div]), False)
+            b.update_vpc(set([div]), task, False)
 
     def update_endpoint_with_bouncers(self, ep, task):
         bouncers = self.store.get_bouncers_of_net(ep.net)

--- a/mizar/dp/mizar/operators/dividers/dividers_operator.py
+++ b/mizar/dp/mizar/operators/dividers/dividers_operator.py
@@ -71,21 +71,21 @@ class DividerOperator(object):
         div.set_status(OBJ_STATUS.divider_status_provisioned)
         div.update_obj()
 
-    def update_divider_with_bouncers(self, bouncer, net):
+    def update_divider_with_bouncers(self, bouncer, net, task):
         dividers = self.store.get_dividers_of_vpc(bouncer.vpc).values()
         for d in dividers:
-            d.update_net(net)
+            d.update_net(net, task)
 
-    def delete_bouncer_from_dividers(self, bouncer, net):
+    def delete_bouncer_from_dividers(self, bouncer, net, task):
         dividers = self.store.get_dividers_of_vpc(bouncer.vpc).values()
         for d in dividers:
-            d.update_net(net, False)
+            d.update_net(net, task, False)
 
-    def update_net(self, net, dividers=None):
+    def update_net(self, net, task, dividers=None):
         if not dividers:
             dividers = self.store.get_dividers_of_vpc(net.vpc).values()
         for d in dividers:
-            d.update_net(net)
+            d.update_net(net, task)
 
     def delete_net(self, net):
         dividers = self.store.get_dividers_of_vpc(net.vpc).values()
@@ -96,6 +96,6 @@ class DividerOperator(object):
         for net in nets:
             divider.delete_net(net)
 
-    def update_vpc(self, bouncer):
+    def update_vpc(self, bouncer, task):
         dividers = self.store.get_dividers_of_vpc(bouncer.vpc).values()
-        bouncer.update_vpc(dividers)
+        bouncer.update_vpc(dividers, task)

--- a/mizar/dp/mizar/workflows/bouncers/create.py
+++ b/mizar/dp/mizar/workflows/bouncers/create.py
@@ -65,14 +65,14 @@ class BouncerCreate(WorkflowTask):
         # Update vpc on bouncer
         # Needs a list of all dividers
         bouncer.set_vni(vpcs_opr.store.get_vpc(bouncer.vpc).vni)
-        dividers_opr.update_vpc(bouncer)
+        dividers_opr.update_vpc(bouncer, self)
 
         # Update net on dividers
 
         net.bouncers[bouncer.name] = bouncer
-        dividers_opr.update_divider_with_bouncers(bouncer, net)
+        dividers_opr.update_divider_with_bouncers(bouncer, net, self)
         endpoints_opr.update_bouncer_with_endpoints(bouncer, self)
         endpoints_opr.update_endpoints_with_bouncers(bouncer, self)
-        bouncer.load_transit_xdp_pipeline_stage()
+        bouncer.load_transit_xdp_pipeline_stage(self)
         bouncers_opr.set_bouncer_provisioned(bouncer)
         self.finalize()

--- a/mizar/dp/mizar/workflows/dividers/create.py
+++ b/mizar/dp/mizar/workflows/dividers/create.py
@@ -51,12 +51,12 @@ class DividerCreate(WorkflowTask):
                 "Task: {} Divider: {} No droplets available.".format(self.__class__.__name__, divider.name))
 
         # Update vpc on bouncers
-        bouncers_opr.update_bouncers_with_divider(divider)
+        bouncers_opr.update_bouncers_with_divider(divider, self)
 
         # Update divider with bouncers
         nets = nets_opr.store.get_nets_in_vpc(divider.vpc)
         for net in nets.values():
-            dividers_opr.update_net(net, set([divider]))
+            dividers_opr.update_net(net, self, set([divider]))
 
         dividers_opr.set_divider_provisioned(divider)
         dividers_opr.store.update_divider(divider)

--- a/mizar/dp/mizar/workflows/dividers/delete.py
+++ b/mizar/dp/mizar/workflows/dividers/delete.py
@@ -50,7 +50,7 @@ class DividerDelete(WorkflowTask):
 
         # Call update_vpc on all bouncer droplets
         # Call delete_substrate of divider droplet on all bouncer droplets
-        bouncers_opr.delete_divider_from_bouncers(divider)
+        bouncers_opr.delete_divider_from_bouncers(divider, self)
         divider.delete_obj()
         dividers_opr.store.delete_divider(divider.name)
         self.finalize()

--- a/mizar/dp/mizar/workflows/endpoints/create.py
+++ b/mizar/dp/mizar/workflows/endpoints/create.py
@@ -60,11 +60,5 @@ class EndpointCreate(WorkflowTask):
                     ep.vpc, ep.droplet_obj.ip))
                 droplets_opr.store_update_vpc_to_droplet(vpc, ep.droplet_obj)
             endpoints_opr.produce_simple_endpoint_interface(ep, self)
-        if ep.bouncers:
-            if ep.type == OBJ_DEFAULTS.ep_type_simple or ep.type == OBJ_DEFAULTS.ep_type_host:
-                for bouncer in ep.bouncers:
-                    logger.info(
-                        "EP {} has bouncer {}. Updating.".format(ep.name, bouncer))
-                ep.update_bouncers(ep.bouncers, self)
         endpoints_opr.set_endpoint_provisioned(ep)
         self.finalize()

--- a/mizar/dp/mizar/workflows/endpoints/provisioned.py
+++ b/mizar/dp/mizar/workflows/endpoints/provisioned.py
@@ -25,12 +25,14 @@ from mizar.common.workflow import *
 from mizar.dp.mizar.operators.endpoints.endpoints_operator import *
 from mizar.dp.mizar.operators.droplets.droplets_operator import *
 from mizar.networkpolicy.networkpolicy_util import *
+from mizar.dp.mizar.operators.bouncers.bouncers_operator import *
 
 logger = logging.getLogger()
 
 endpoints_opr = EndpointOperator()
 droplets_opr = DropletOperator()
 networkpolicy_util = NetworkPolicyUtil()
+bouncers_opr = BouncerOperator()
 
 
 class EndpointProvisioned(WorkflowTask):
@@ -44,11 +46,20 @@ class EndpointProvisioned(WorkflowTask):
         endpoint = endpoints_opr.get_endpoint_stored_obj(
             self.param.name, self.param.spec)
         endpoint.droplet_obj = droplets_opr.store.get_droplet(endpoint.droplet)
+        bouncers_opr.update_endpoint_with_bouncers(endpoint, self)
+        if endpoint.bouncers:
+            if endpoint.type == OBJ_DEFAULTS.ep_type_simple or endpoint.type == OBJ_DEFAULTS.ep_type_host:
+                for bouncer in endpoint.bouncers:
+                    logger.info(
+                        "EP {} has bouncer {}. Updating.".format(endpoint.name, bouncer))
+                endpoint.update_bouncers(endpoint.bouncers, self)
         endpoints_opr.store_update(endpoint)
 
         if self.param.name in endpoints_opr.store.eps_store_to_be_updated_networkpolicy:
-            endpoints_opr.store.eps_store_to_be_updated_networkpolicy.remove(self.param.name)
-            time.sleep(1) # Wait a little time for newly created endpoint network.
+            endpoints_opr.store.eps_store_to_be_updated_networkpolicy.remove(
+                self.param.name)
+            # Wait a little time for newly created endpoint network.
+            time.sleep(1)
             if len(endpoint.ingress_networkpolicies) == 1:
                 endpoint.update_network_policy_enforcement_map_ingress()
             if len(endpoint.egress_networkpolicies) == 1:
@@ -57,7 +68,9 @@ class EndpointProvisioned(WorkflowTask):
 
         if endpoint.pod in endpoints_opr.store.networkpolicies_to_be_updated_store:
             networkpolicy_util.wait_until_pod_has_ip(endpoint.pod)
-            networkpolicy_util.handle_networkpolicy_change(endpoints_opr.store.networkpolicies_to_be_updated_store[endpoint.pod])
-            endpoints_opr.store.networkpolicies_to_be_updated_store.pop(endpoint.pod)
+            networkpolicy_util.handle_networkpolicy_change(
+                endpoints_opr.store.networkpolicies_to_be_updated_store[endpoint.pod])
+            endpoints_opr.store.networkpolicies_to_be_updated_store.pop(
+                endpoint.pod)
 
         self.finalize()

--- a/mizar/obj/bouncer.py
+++ b/mizar/obj/bouncer.py
@@ -132,51 +132,55 @@ class Bouncer(object):
     def set_status(self, status):
         self.status = status
 
-    def load_transit_xdp_pipeline_stage(self):
+    def load_transit_xdp_pipeline_stage(self, task):
         self.rpc.load_transit_xdp_pipeline_stage(CONSTANTS.ON_XDP_SCALED_EP,
-                                                 self.scaled_ep_obj)
+                                                 self.scaled_ep_obj, task)
 
     def update_eps(self, eps, task):
         for ep in eps:
             self.eps[ep.name] = ep
             if ep.type in OBJ_DEFAULTS.droplet_eps:
                 if not ep.droplet_obj:
-                    task.raise_temporary_error("Task: {} Endpoint: {} Droplet Object not ready.".format(self.__class__.__name__, ep.name))
-                self._update_simple_ep(ep)
-            if ep.type == OBJ_DEFAULTS.ep_type_scaled:
-                self._update_scaled_ep(ep)
-            if ep.type == OBJ_DEFAULTS.ep_type_gateway:
-                self.update_gw_ep(ep)
+                    task.raise_temporary_error("Task: {} Endpoint: {} Droplet Object not ready.".format(
+                        self.__class__.__name__, ep.name))
+                self._update_simple_ep(ep, task)
+            elif ep.type == OBJ_DEFAULTS.ep_type_scaled:
+                self._update_scaled_ep(ep, task)
+            elif ep.type == OBJ_DEFAULTS.ep_type_gateway:
+                self.update_gw_ep(ep, task)
+            else:
+                task.raise_permenant_error(
+                    "Unknown Endpoint! {}".formatr(ep.type))
 
-    def update_gw_ep(self, ep):
+    def update_gw_ep(self, ep, task):
         logger.info("Update gateway endpoint")
         ep.set_backends([self.ip])
-        self.droplet_obj.update_ep(self.name, ep)
+        self.droplet_obj.update_ep(self.name, ep, task)
 
-    def _update_simple_ep(self, ep):
+    def _update_simple_ep(self, ep, task):
         logger.info(
             "Update Bouncer with Simple EP:{}, type:{}".format(ep.name, ep.type))
         logger.info("self ip {} epfuncip {}, field ip {}".format(
             self.ip, ep.get_droplet_ip(), ep.droplet_obj.ip))
-        self.droplet_obj.update_ep(self.name, ep)
-        self.droplet_obj.update_substrate(ep)
+        self.droplet_obj.update_ep(self.name, ep, task)
+        self.droplet_obj.update_substrate(ep, task)
 
-    def _update_scaled_ep(self, ep):
+    def _update_scaled_ep(self, ep, task):
         logger.info("Bouncer update scaled ep. {}".format(ep.backends))
         if ep.backends:
-            self.droplet_obj.update_ep(self.name, ep)
+            self.droplet_obj.update_ep(self.name, ep, task)
 
-    def update_vpc(self, dividers, add=True):
+    def update_vpc(self, dividers, task, add=True):
         for divider in dividers:
             if add:
                 logger.info("Divider added: {}".format(divider.name))
                 self.dividers[divider.name] = divider
-                self.droplet_obj.update_substrate(divider)
+                self.droplet_obj.update_substrate(divider, task)
             else:
                 logger.info("Divider removed: {}".format(divider.name))
                 self.dividers[divider.name] = divider
                 self.droplet_obj.delete_substrate(divider)
-        self.droplet_obj.update_vpc(self)
+        self.droplet_obj.update_vpc(self, task)
 
     def delete_vpc(self):
         for name in list(self.dividers.keys()):

--- a/mizar/obj/divider.py
+++ b/mizar/obj/divider.py
@@ -114,21 +114,21 @@ class Divider(object):
         self.ip = droplet.ip
         self.mac = droplet.mac
 
-    def update_net(self, net, add=True):
+    def update_net(self, net, task, add=True):
         for bouncer in list(net.bouncers.values()):
             if add:
                 if bouncer.name not in self.bouncers.keys():
                     logger.info("Bouncer {} added for Net {}".format(
                         bouncer.name, net.name))
                     self.bouncers[bouncer.name] = bouncer
-                    self.droplet_obj.update_substrate(bouncer)
+                    self.droplet_obj.update_substrate(bouncer, task)
             else:
                 if bouncer.name in self.bouncers.keys():
                     logger.info("Bouncer {} removed from Net {}".format(
                         bouncer.name, net.name))
                     self.bouncers[bouncer.name] = bouncer
                     self.droplet_obj.delete_substrate(bouncer)
-        self.droplet_obj.update_net(net)
+        self.droplet_obj.update_net(net, task)
 
     def delete_net(self, net):
         for name in net.bouncers.values():

--- a/mizar/obj/droplet.py
+++ b/mizar/obj/droplet.py
@@ -105,11 +105,12 @@ class Droplet(object):
     def set_status(self, status):
         self.status = status
 
-    def update_substrate(self, obj):
+    def update_substrate(self, obj, task):
         if obj.name not in self.known_substrates.keys():
             logger.info("DROPLET_SUBSTRATE: Updated")
             self.known_substrates[obj.name] = obj.droplet_obj.ip
-        self.rpc.update_substrate_ep(obj.droplet_obj.ip, obj.droplet_obj.mac)
+        self.rpc.update_substrate_ep(
+            obj.droplet_obj.ip, obj.droplet_obj.mac, task)
 
     def delete_substrate(self, obj):
         if obj.name in self.known_substrates.keys():
@@ -118,10 +119,10 @@ class Droplet(object):
                 logger.info("DROPLET_SUBSTRATE: Deleted")
                 self.rpc.delete_substrate_ep(obj.droplet_obj.ip)
 
-    def update_vpc(self, bouncer):
+    def update_vpc(self, bouncer, task):
         if bouncer.name not in self.known_bouncers.keys():
             self.known_bouncers[bouncer.name] = bouncer.vpc
-        self.rpc.update_vpc(bouncer)
+        self.rpc.update_vpc(bouncer, task)
 
     def delete_vpc(self, bouncer):
         if bouncer.name in self.known_bouncers.keys():
@@ -129,11 +130,11 @@ class Droplet(object):
             if bouncer.vpc not in self.known_bouncers.values():
                 self.rpc.delete_vpc(bouncer)
 
-    def update_net(self, net):
+    def update_net(self, net, task):
         nip = net.get_nip()
         if net.name not in self.known_nets.keys():
             self.known_nets[net.name] = nip
-        self.rpc.update_net(net)
+        self.rpc.update_net(net, task)
 
     def delete_net(self, net):
         nip = net.get_nip()
@@ -142,11 +143,11 @@ class Droplet(object):
             if nip not in self.known_nets.values():
                 self.rpc.delete_net(net)
 
-    def update_ep(self, name, ep):
+    def update_ep(self, name, ep, task):
         name = name + ep.name
         if name not in self.known_eps.keys():
             self.known_eps[name] = ep.ip
-        self.rpc.update_ep(ep)
+        self.rpc.update_ep(ep, task)
 
     def delete_ep(self, name, ep):
         name = name + ep.name

--- a/mizar/obj/endpoint.py
+++ b/mizar/obj/endpoint.py
@@ -267,7 +267,7 @@ class Endpoint:
                 self.bouncers.pop(bouncer.name)
                 self.droplet_obj.delete_agent_substrate(self, bouncer)
         self.rpc.update_agent_metadata(self, task)
-        self.droplet_obj.update_ep(self.name, self)
+        self.droplet_obj.update_ep(self.name, self, task)
 
     def update_bouncers_list(self, bouncers, add=True):
         for bouncer in bouncers.values():


### PR DESCRIPTION
This PR fixes the following issues

- Fixed an issue where early RPC calls such as update-vpc, update-net, etc failed without retry on cluster startup
- Fixed an issue where the same route is added more than once on host-endpoint create (to be redesigned)
- Fixed an issue where endpoint create was not idempotent on an RPC retry.