### PR TITLE
Fix issue: Arkto pod stuck at ContainerCreating due to cni error 'NoneType' object has no attribute 'metadata' #638

### DIFF
--- a/mizar/networkpolicy/networkpolicy_util.py
+++ b/mizar/networkpolicy/networkpolicy_util.py
@@ -581,7 +581,16 @@ class NetworkPolicyUtil:
         namespace_obj = kube_get_namespace(networkpolicy_opr.core_api, namespace)
         pod_label_combination = self.get_label_combination(pod_labels)
         is_new_pod_label_combination = False if pod_label_combination in networkpolicy_opr.store.pod_label_value_store else True
-        namespace_label_combination = self.get_label_combination(namespace_obj.metadata.labels)
+        if namespace_obj is not None and namespace_obj.metadata.labels is not None:
+            namespace_label_combination = self.get_label_combination(namespace_obj.metadata.labels)
+        else:
+            # Currently if cluster is arktos, and the namespace belongs to a tenant,
+            # kube_get_namespace will return None because the kubernetes client is not
+            # for arktos and it cannot retrieve the namespace of non-system tenant.
+            # For now we have to ignore the namespace of non-system tenant.
+            # TODO: Fix the issue in the future by sending namespace info via
+            # mizar operators inside arktos.
+            namespace_label_combination = ""
         is_new_namespace_label_combination = False if namespace_label_combination in networkpolicy_opr.store.namespace_label_value_store else True
 
         # Followed code piece is to calculate how many policy are affected by the label change, and form data of policy_name_list.


### PR DESCRIPTION
This pr is to fix issue 638. It's a known issue that  currently if cluster is arktos, and the namespace belongs to a tenant, kube_get_namespace will return None because the kubernetes client is not for arktos and it cannot retrieve the namespace of non-system tenant. For now we have to ignore the namespace of non-system tenant.

couple month ago there was a member tried to solve the issue by sending needed namespace info from arktos to mizar. But the work was not done successfully and the member left the project. In the future we shall consider how to resolve this known issue.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #638 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
