### PR TITLE
Fix cluster startup issues

### DIFF
--- a/mizar/common/constants.py
+++ b/mizar/common/constants.py
@@ -125,8 +125,8 @@ class OBJ_DEFAULTS:
     mizar_ep_vpc_annotation = "mizar.com/vpc"
     mizar_ep_subnet_annotation = "mizar.com/subnet"
 
-    # 15 minutes of retries
-    kopf_max_retries = 60
+    # 60 minutes of retries
+    kopf_max_retries = 240
     kopf_retry_delay = 15
 
 

--- a/mizar/common/rpc.py
+++ b/mizar/common/rpc.py
@@ -118,7 +118,7 @@ class TrnRpc:
         logger.info("update_agent_substrate_ep: {}".format(cmd))
         returncode, text = run_cmd(cmd)
         logger.info(
-            "update_agent_substrate_ep {} returns {} {}".format(cmd, text, returncode))
+            "update_agent_substrate_ep {} {} returns {} {}".format(ep.name, cmd, text, returncode))
         if (CONSTANTS.RPC_ERROR_CODE in text or
             CONSTANTS.RPC_FAILED_CODE in text or
                 CONSTANTS.RPC_FATAL_CODE in text):
@@ -173,7 +173,8 @@ class TrnRpc:
         cmd = f'''{self.trn_cli_update_ep} \'{jsonconf}\''''
         logger.info("update_ep: {}".format(cmd))
         returncode, text = run_cmd(cmd)
-        logger.info("update_ep {} returns {} {}".format(cmd, text, returncode))
+        logger.info("update_ep {} {} returns {} {}".format(
+            ep.name, cmd, text, returncode))
         if (CONSTANTS.RPC_ERROR_CODE in text or
             CONSTANTS.RPC_FAILED_CODE in text or
                 CONSTANTS.RPC_FATAL_CODE in text):
@@ -235,7 +236,7 @@ class TrnRpc:
         logger.info("update_agent_metadata: {}".format(cmd))
         returncode, text = run_cmd(cmd)
         logger.info(
-            "update_agent_metadata {} returns {} {}".format(cmd, text, returncode))
+            "update_agent_metadata ep {} {} returns {} {}".format(ep.name, cmd, text, returncode))
         if (CONSTANTS.RPC_ERROR_CODE in text or
             CONSTANTS.RPC_FAILED_CODE in text or
                 CONSTANTS.RPC_FATAL_CODE in text):

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -105,13 +105,16 @@ class InterfaceServer(InterfaceServiceServicer):
             logger.info("Interface {} already exists!".format(veth_name))
 
         veth_index = get_iface_index(veth_name, self.iproute)
+        mac_address = ""
+        if veth_index != -1:
+            mac_address = get_iface_mac(veth_index, self.iproute)
         # Update the mac address with the interface address
         address = InterfaceAddress(
             version=interface.address.version,
             ip_address=interface.address.ip_address,
             ip_prefix=interface.address.ip_prefix,
             gateway_ip=interface.address.gateway_ip,
-            mac=get_iface_mac(veth_index, self.iproute),
+            mac=mac_address,
             tunnel_id=interface.address.tunnel_id
         )
         interface.address.CopyFrom(address)

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -91,19 +91,20 @@ class InterfaceServer(InterfaceServiceServicer):
             try:
                 logger.info("Creating interface {}".format(veth_name))
                 self.iproute.link('add', ifname=veth_name,
-                                peer=veth_peer, kind='veth')
+                                  peer=veth_peer, kind='veth')
             except Exception as e:
                 if e.code == CONSTANTS.NETLINK_FILE_EXISTS_ERROR:
-                    logger.info("Veth already exists! Continuing")
+                    veth_index = get_iface_index(veth_name, self.iproute)
+                    logger.info(
+                        "Veth already exists! veth index is {} Continuing".format(veth_index))
                     pass
-
                 else:
                     logger.info(
                         "Unknown exception occured when creating veth {}".format(e))
-            veth_index = get_iface_index(veth_name, self.iproute)
         else:
             logger.info("Interface {} already exists!".format(veth_name))
 
+        veth_index = get_iface_index(veth_name, self.iproute)
         # Update the mac address with the interface address
         address = InterfaceAddress(
             version=interface.address.version,
@@ -189,7 +190,8 @@ class InterfaceServer(InterfaceServiceServicer):
         update the agent metadata and endpoint.
         """
         pod_name = get_pod_name(interface.interface_id.pod_id)
-        logger.info("Loading transit agent and configuring for pod {}".format(pod_name))
+        logger.info(
+            "Loading transit agent and configuring for pod {}".format(pod_name))
         self.rpc.load_transit_agent_xdp(interface)
 
         for bouncer in interface.bouncers:

--- a/mizar/dp/mizar/operators/bouncers/bouncers_operator.py
+++ b/mizar/dp/mizar/operators/bouncers/bouncers_operator.py
@@ -84,10 +84,10 @@ class BouncerOperator(object):
     def update_endpoint_with_bouncers(self, ep, task):
         self.update_endpoint_obj_with_bouncers(ep)
         bouncers = self.store.get_bouncers_of_net(ep.net)
-        eps = set([ep])
         if not bouncers:
             task.raise_temporary_error(
                 "Provisiond EP {}: Bouncers not yet ready!".format(ep.name))
+        eps = set([ep])
         for key in list(bouncers):
             bouncers[key].update_eps(eps, task)
 

--- a/mizar/dp/mizar/operators/bouncers/bouncers_operator.py
+++ b/mizar/dp/mizar/operators/bouncers/bouncers_operator.py
@@ -73,27 +73,33 @@ class BouncerOperator(object):
 
     def update_bouncers_with_divider(self, div, task):
         bouncers = self.store.get_bouncers_of_vpc(div.vpc)
-        for b in bouncers.values():
+        for b in list(bouncers.values()):
             b.update_vpc(set([div]), task)
 
     def delete_divider_from_bouncers(self, div, task):
         bouncers = self.store.get_bouncers_of_vpc(div.vpc)
-        for b in bouncers.values():
+        for b in list(bouncers.values()):
             b.update_vpc(set([div]), task, False)
 
     def update_endpoint_with_bouncers(self, ep, task):
+        self.update_endpoint_obj_with_bouncers(ep)
         bouncers = self.store.get_bouncers_of_net(ep.net)
         eps = set([ep])
-        for key in bouncers:
+        if not bouncers:
+            task.raise_temporary_error(
+                "Provisiond EP {}: Bouncers not yet ready!".format(ep.name))
+        for key in list(bouncers):
             bouncers[key].update_eps(eps, task)
 
+    def update_endpoint_obj_with_bouncers(self, ep):
+        bouncers = self.store.get_bouncers_of_net(ep.net)
         if ep.type == OBJ_DEFAULTS.ep_type_simple or ep.type == OBJ_DEFAULTS.ep_type_host:
             ep.update_bouncers_list(bouncers)
 
     def delete_endpoint_from_bouncers(self, ep):
         bouncers = self.store.get_bouncers_of_net(ep.net)
         eps = set([ep])
-        for key in bouncers:
+        for key in list(bouncers):
             bouncers[key].delete_eps(eps)
         self.store.update_bouncers_of_net(ep.net, bouncers)
         if ep.type == OBJ_DEFAULTS.ep_type_simple:

--- a/mizar/dp/mizar/operators/bouncers/bouncers_operator.py
+++ b/mizar/dp/mizar/operators/bouncers/bouncers_operator.py
@@ -69,6 +69,7 @@ class BouncerOperator(object):
 
     def set_bouncer_provisioned(self, bouncer):
         bouncer.set_status(OBJ_STATUS.bouncer_status_provisioned)
+        self.store_update(bouncer)
         bouncer.update_obj()
 
     def update_bouncers_with_divider(self, div, task):

--- a/mizar/dp/mizar/operators/dividers/dividers_operator.py
+++ b/mizar/dp/mizar/operators/dividers/dividers_operator.py
@@ -73,23 +73,23 @@ class DividerOperator(object):
 
     def update_divider_with_bouncers(self, bouncer, net, task):
         dividers = self.store.get_dividers_of_vpc(bouncer.vpc).values()
-        for d in dividers:
+        for d in list(dividers):
             d.update_net(net, task)
 
     def delete_bouncer_from_dividers(self, bouncer, net, task):
         dividers = self.store.get_dividers_of_vpc(bouncer.vpc).values()
-        for d in dividers:
+        for d in list(dividers):
             d.update_net(net, task, False)
 
     def update_net(self, net, task, dividers=None):
         if not dividers:
             dividers = self.store.get_dividers_of_vpc(net.vpc).values()
-        for d in dividers:
+        for d in list(dividers):
             d.update_net(net, task)
 
     def delete_net(self, net):
         dividers = self.store.get_dividers_of_vpc(net.vpc).values()
-        for d in dividers:
+        for d in list(dividers):
             d.delete_net(net)
 
     def delete_nets_from_divider(self, nets, divider):

--- a/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
+++ b/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
@@ -454,7 +454,13 @@ class EndpointOperator(object):
             # allocate the mac addresses for us.
             logger.info("init_simple_endpoint_interface on {} for {}".format(
                 worker_ip, spec['name']))
-            return InterfaceServiceClient(worker_ip).InitializeInterfaces(interfaces, task)
+            interfaces = InterfaceServiceClient(
+                worker_ip).InitializeInterfaces(interfaces, task)
+            for interface in interfaces.interfaces:
+                if not interface.address.mac:
+                    task.raise_temporary_error(
+                        "Veth did not come up in time for pod {} interface {}".format(pod_id, interface))
+            return interfaces
         return None
 
     def init_host_endpoint_interfaces(self, droplet, ifname, veth_name, peer_name, task):

--- a/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
+++ b/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
@@ -271,7 +271,7 @@ class EndpointOperator(object):
 
     def delete_bouncer_from_endpoints(self, bouncer, task):
         eps = self.store.get_eps_in_net(bouncer.net).values()
-        for ep in eps:
+        for ep in list(eps):
             if ep.type == OBJ_DEFAULTS.ep_type_simple or ep.type == OBJ_DEFAULTS.ep_type_host:
                 ep.update_bouncers({bouncer.name: bouncer}, task, False)
 

--- a/mizar/dp/mizar/workflows/bouncers/create.py
+++ b/mizar/dp/mizar/workflows/bouncers/create.py
@@ -71,8 +71,6 @@ class BouncerCreate(WorkflowTask):
 
         net.bouncers[bouncer.name] = bouncer
         dividers_opr.update_divider_with_bouncers(bouncer, net, self)
-        endpoints_opr.update_bouncer_with_endpoints(bouncer, self)
-        endpoints_opr.update_endpoints_with_bouncers(bouncer, self)
         bouncer.load_transit_xdp_pipeline_stage(self)
         bouncers_opr.set_bouncer_provisioned(bouncer)
         self.finalize()

--- a/mizar/dp/mizar/workflows/bouncers/provisioned.py
+++ b/mizar/dp/mizar/workflows/bouncers/provisioned.py
@@ -24,12 +24,14 @@ from mizar.common.workflow import *
 from mizar.dp.mizar.operators.bouncers.bouncers_operator import *
 from mizar.dp.mizar.operators.droplets.droplets_operator import *
 from mizar.dp.mizar.operators.vpcs.vpcs_operator import *
+from mizar.dp.mizar.operators.endpoints.endpoints_operator import *
 
 logger = logging.getLogger()
 
 bouncers_opr = BouncerOperator()
 vpcs_opr = VpcOperator()
 droplets_opr = DropletOperator()
+endpoints_opr = EndpointOperator()
 
 
 class BouncerProvisioned(WorkflowTask):
@@ -44,5 +46,7 @@ class BouncerProvisioned(WorkflowTask):
             self.param.name, self.param.spec)
         bouncer.set_vni(vpcs_opr.store.get_vpc(bouncer.vpc).vni)
         bouncer.droplet_obj = droplets_opr.store.get_droplet(bouncer.droplet)
+        endpoints_opr.update_bouncer_with_endpoints(bouncer, self)
+        endpoints_opr.update_endpoints_with_bouncers(bouncer, self)
         bouncers_opr.store_update(bouncer)
         self.finalize()

--- a/mizar/dp/mizar/workflows/builtins/pods/create.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/create.py
@@ -95,6 +95,10 @@ class k8sPodCreate(WorkflowTask):
                             "VPC {} has no subnets to allocate pod {}!".format(vpc_name, self.param.name))
                 spec['vpc'] = vpc_name
                 spec['subnet'] = subnet_name
+        else:
+            if not COMPUTE_PROVIDER.k8s:
+                self.raise_temporary_error(
+                    "VPC for pod {} not yet created!".format(self.param.name))
 
         spec['vni'] = vpc_opr.store_get(spec['vpc']).vni
         spec['droplet'] = droplet_opr.store_get_by_main_ip(spec['hostIP'])

--- a/mizar/dp/mizar/workflows/droplets/provisioned.py
+++ b/mizar/dp/mizar/workflows/droplets/provisioned.py
@@ -43,7 +43,7 @@ class DropletProvisioned(WorkflowTask):
         logger.info("Run {task}".format(task=self.__class__.__name__))
         droplet = droplets_opr.get_droplet_stored_obj(
             self.param.name, self.param.spec)
-        for vpc in vpcs_opr.store.get_all_vpcs():
+        for vpc in list(vpcs_opr.store.get_all_vpcs()):
             if droplet.name not in droplets_opr.store.vpc_droplet_store[vpc.name]:
                 if vpc.name not in nets_opr.store.nets_vpc_store:
                     self.raise_temporary_error(

--- a/mizar/dp/mizar/workflows/endpoints/create.py
+++ b/mizar/dp/mizar/workflows/endpoints/create.py
@@ -53,7 +53,7 @@ class EndpointCreate(WorkflowTask):
                 "Task: {} Endpoint: {} Droplet Object {} not ready. ".format(self.__class__.__name__, ep.name, ep.droplet))
         vpc = vpcs_opr.store.get_vpc(ep.vpc)
         nets_opr.allocate_endpoint(ep, vpc)
-        bouncers_opr.update_endpoint_with_bouncers(ep, self)
+        bouncers_opr.update_endpoint_obj_with_bouncers(ep)
         if ep.type == OBJ_DEFAULTS.ep_type_simple or ep.type == OBJ_DEFAULTS.ep_type_host:
             if ep.type == OBJ_DEFAULTS.ep_type_host:
                 logger.info("Activate host interface for vpc {} on droplet {}".format(

--- a/mizar/dp/mizar/workflows/endpoints/provisioned.py
+++ b/mizar/dp/mizar/workflows/endpoints/provisioned.py
@@ -53,9 +53,6 @@ class EndpointProvisioned(WorkflowTask):
                     logger.info(
                         "EP {} has bouncer {}. Updating.".format(endpoint.name, bouncer))
                 endpoint.update_bouncers(endpoint.bouncers, self)
-        else:
-            self.raise_temporary_error(
-                "Endpoint {} does not have any bouncers yet!".format(endpoint.name))
         endpoints_opr.store_update(endpoint)
 
         if self.param.name in endpoints_opr.store.eps_store_to_be_updated_networkpolicy:

--- a/mizar/dp/mizar/workflows/endpoints/provisioned.py
+++ b/mizar/dp/mizar/workflows/endpoints/provisioned.py
@@ -53,6 +53,9 @@ class EndpointProvisioned(WorkflowTask):
                     logger.info(
                         "EP {} has bouncer {}. Updating.".format(endpoint.name, bouncer))
                 endpoint.update_bouncers(endpoint.bouncers, self)
+        else:
+            self.raise_temporary_error(
+                "Endpoint {} does not have any bouncers yet!".format(endpoint.name))
         endpoints_opr.store_update(endpoint)
 
         if self.param.name in endpoints_opr.store.eps_store_to_be_updated_networkpolicy:

--- a/mizar/dp/mizar/workflows/nets/provisioned.py
+++ b/mizar/dp/mizar/workflows/nets/provisioned.py
@@ -52,7 +52,7 @@ class NetProvisioned(WorkflowTask):
             if d[0] == 'change':
                 self.process_change(net=net, field=d[1], old=d[2], new=d[3])
         vpc = vpcs_opr.store.get_vpc(net.vpc)
-        for droplet in droplets_opr.store.get_all_droplets():
+        for droplet in list(droplets_opr.store.get_all_droplets()):
             logger.info("Net: Available droplets for vpc {}: {}".format(
                 vpc.name, droplets_opr.store.droplets_store.keys()))
             if vpc.name not in droplets_opr.store_get_vpc_to_droplet(droplet):

--- a/mizar/obj/endpoint.py
+++ b/mizar/obj/endpoint.py
@@ -261,6 +261,8 @@ class Endpoint:
     def update_bouncers(self, bouncers, task, add=True):
         for bouncer in bouncers.values():
             if add:
+                logger.info("endpoint obj: update_bouncer: ep {} update agent with bouncer {}".format(
+                    self.name, bouncer.name))
                 self.bouncers[bouncer.name] = bouncer
                 self.update_agent_substrate(self, bouncer, task)
             else:

--- a/mizar/store/operator_store.py
+++ b/mizar/store/operator_store.py
@@ -439,11 +439,12 @@ class OprStore(object):
         self.update_namespace_pod_store(namespace_name, pod_name)
 
     def delete_pod_namespace_store(self, pod_name):
-        ns = self.pod_namespace_store[pod_name]
-        if ns in self.namespace_pod_store and pod_name in self.namespace_pod_store[ns]:
-            self.namespace_pod_store[ns].remove(pod_name)
         if pod_name in self.pod_namespace_store:
-            del self.pod_namespace_store[pod_name]
+            ns = self.pod_namespace_store[pod_name]
+            if ns in self.namespace_pod_store and pod_name in self.namespace_pod_store[ns]:
+                self.namespace_pod_store[ns].remove(pod_name)
+            if pod_name in self.pod_namespace_store:
+                del self.pod_namespace_store[pod_name]
 
     def update_droplet(self, droplet):
         self.droplets_store[droplet.name] = droplet


### PR DESCRIPTION
This PR fixes the following issues:

1. Runtime errors where a dictionary changed size while being iterated through.
2. An issue where the veth creation returned before the device was created.
3. Timeout errors caused by the mizar-daemon taking longer than 15 minutes to come up in the Arktos kube-up environment.
4. A runtime error where delete was called on a nonexistent key in a dictionary.
5. An issue where pods deployed before mizar did not have network connectivity