### PR TITLE
Fix cluster startup errors

### DIFF
--- a/mizar/common/constants.py
+++ b/mizar/common/constants.py
@@ -125,8 +125,8 @@ class OBJ_DEFAULTS:
     mizar_ep_vpc_annotation = "mizar.com/vpc"
     mizar_ep_subnet_annotation = "mizar.com/subnet"
 
-    # 15 minutes of retries
-    kopf_max_retries = 60
+    # 60 minutes of retries
+    kopf_max_retries = 240
     kopf_retry_delay = 15
 
 

--- a/mizar/common/rpc.py
+++ b/mizar/common/rpc.py
@@ -118,7 +118,7 @@ class TrnRpc:
         logger.info("update_agent_substrate_ep: {}".format(cmd))
         returncode, text = run_cmd(cmd)
         logger.info(
-            "update_agent_substrate_ep {} returns {} {}".format(cmd, text, returncode))
+            "update_agent_substrate_ep {} {} returns {} {}".format(ep.name, cmd, text, returncode))
         if (CONSTANTS.RPC_ERROR_CODE in text or
             CONSTANTS.RPC_FAILED_CODE in text or
                 CONSTANTS.RPC_FATAL_CODE in text):
@@ -173,7 +173,8 @@ class TrnRpc:
         cmd = f'''{self.trn_cli_update_ep} \'{jsonconf}\''''
         logger.info("update_ep: {}".format(cmd))
         returncode, text = run_cmd(cmd)
-        logger.info("update_ep {} returns {} {}".format(cmd, text, returncode))
+        logger.info("update_ep {} {} returns {} {}".format(
+            ep.name, cmd, text, returncode))
         if (CONSTANTS.RPC_ERROR_CODE in text or
             CONSTANTS.RPC_FAILED_CODE in text or
                 CONSTANTS.RPC_FATAL_CODE in text):
@@ -235,7 +236,7 @@ class TrnRpc:
         logger.info("update_agent_metadata: {}".format(cmd))
         returncode, text = run_cmd(cmd)
         logger.info(
-            "update_agent_metadata {} returns {} {}".format(cmd, text, returncode))
+            "update_agent_metadata ep {} {} returns {} {}".format(ep.name, cmd, text, returncode))
         if (CONSTANTS.RPC_ERROR_CODE in text or
             CONSTANTS.RPC_FAILED_CODE in text or
                 CONSTANTS.RPC_FATAL_CODE in text):

--- a/mizar/daemon/app.py
+++ b/mizar/daemon/app.py
@@ -77,7 +77,7 @@ def init(benchmark=False):
     output = r.stdout.read().decode().strip()
     logging.info("Removed existing XDP program: {}".format(output))
 
-    cmd = "nsenter -t 1 -m -u -n -i /trn_bin/transitd &"
+    cmd = "nsenter -t 1 -m -u -n -i /trn_bin/transitd >transitd.log &"
     r = subprocess.Popen(cmd, shell=True)
     logging.info("Running transitd")
     time.sleep(1)

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -105,13 +105,16 @@ class InterfaceServer(InterfaceServiceServicer):
             logger.info("Interface {} already exists!".format(veth_name))
 
         veth_index = get_iface_index(veth_name, self.iproute)
+        mac_address = ""
+        if veth_index != -1:
+            mac_address = get_iface_mac(veth_index, self.iproute)
         # Update the mac address with the interface address
         address = InterfaceAddress(
             version=interface.address.version,
             ip_address=interface.address.ip_address,
             ip_prefix=interface.address.ip_prefix,
             gateway_ip=interface.address.gateway_ip,
-            mac=get_iface_mac(veth_index, self.iproute),
+            mac=mac_address,
             tunnel_id=interface.address.tunnel_id
         )
         interface.address.CopyFrom(address)

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -91,19 +91,20 @@ class InterfaceServer(InterfaceServiceServicer):
             try:
                 logger.info("Creating interface {}".format(veth_name))
                 self.iproute.link('add', ifname=veth_name,
-                                peer=veth_peer, kind='veth')
+                                  peer=veth_peer, kind='veth')
             except Exception as e:
                 if e.code == CONSTANTS.NETLINK_FILE_EXISTS_ERROR:
-                    logger.info("Veth already exists! Continuing")
+                    veth_index = get_iface_index(veth_name, self.iproute)
+                    logger.info(
+                        "Veth already exists! veth index is {} Continuing".format(veth_index))
                     pass
-
                 else:
                     logger.info(
                         "Unknown exception occured when creating veth {}".format(e))
-            veth_index = get_iface_index(veth_name, self.iproute)
         else:
             logger.info("Interface {} already exists!".format(veth_name))
 
+        veth_index = get_iface_index(veth_name, self.iproute)
         # Update the mac address with the interface address
         address = InterfaceAddress(
             version=interface.address.version,
@@ -189,7 +190,8 @@ class InterfaceServer(InterfaceServiceServicer):
         update the agent metadata and endpoint.
         """
         pod_name = get_pod_name(interface.interface_id.pod_id)
-        logger.info("Loading transit agent and configuring for pod {}".format(pod_name))
+        logger.info(
+            "Loading transit agent and configuring for pod {}".format(pod_name))
         self.rpc.load_transit_agent_xdp(interface)
 
         for bouncer in interface.bouncers:

--- a/mizar/dp/mizar/operators/bouncers/bouncers_operator.py
+++ b/mizar/dp/mizar/operators/bouncers/bouncers_operator.py
@@ -84,10 +84,10 @@ class BouncerOperator(object):
     def update_endpoint_with_bouncers(self, ep, task):
         self.update_endpoint_obj_with_bouncers(ep)
         bouncers = self.store.get_bouncers_of_net(ep.net)
-        eps = set([ep])
         if not bouncers:
             task.raise_temporary_error(
                 "Provisiond EP {}: Bouncers not yet ready!".format(ep.name))
+        eps = set([ep])
         for key in list(bouncers):
             bouncers[key].update_eps(eps, task)
 

--- a/mizar/dp/mizar/operators/bouncers/bouncers_operator.py
+++ b/mizar/dp/mizar/operators/bouncers/bouncers_operator.py
@@ -73,27 +73,33 @@ class BouncerOperator(object):
 
     def update_bouncers_with_divider(self, div, task):
         bouncers = self.store.get_bouncers_of_vpc(div.vpc)
-        for b in bouncers.values():
+        for b in list(bouncers.values()):
             b.update_vpc(set([div]), task)
 
     def delete_divider_from_bouncers(self, div, task):
         bouncers = self.store.get_bouncers_of_vpc(div.vpc)
-        for b in bouncers.values():
+        for b in list(bouncers.values()):
             b.update_vpc(set([div]), task, False)
 
     def update_endpoint_with_bouncers(self, ep, task):
+        self.update_endpoint_obj_with_bouncers(ep)
         bouncers = self.store.get_bouncers_of_net(ep.net)
         eps = set([ep])
-        for key in bouncers:
+        if not bouncers:
+            task.raise_temporary_error(
+                "Provisiond EP {}: Bouncers not yet ready!".format(ep.name))
+        for key in list(bouncers):
             bouncers[key].update_eps(eps, task)
 
+    def update_endpoint_obj_with_bouncers(self, ep):
+        bouncers = self.store.get_bouncers_of_net(ep.net)
         if ep.type == OBJ_DEFAULTS.ep_type_simple or ep.type == OBJ_DEFAULTS.ep_type_host:
             ep.update_bouncers_list(bouncers)
 
     def delete_endpoint_from_bouncers(self, ep):
         bouncers = self.store.get_bouncers_of_net(ep.net)
         eps = set([ep])
-        for key in bouncers:
+        for key in list(bouncers):
             bouncers[key].delete_eps(eps)
         self.store.update_bouncers_of_net(ep.net, bouncers)
         if ep.type == OBJ_DEFAULTS.ep_type_simple:

--- a/mizar/dp/mizar/operators/bouncers/bouncers_operator.py
+++ b/mizar/dp/mizar/operators/bouncers/bouncers_operator.py
@@ -69,6 +69,7 @@ class BouncerOperator(object):
 
     def set_bouncer_provisioned(self, bouncer):
         bouncer.set_status(OBJ_STATUS.bouncer_status_provisioned)
+        self.store_update(bouncer)
         bouncer.update_obj()
 
     def update_bouncers_with_divider(self, div, task):

--- a/mizar/dp/mizar/operators/dividers/dividers_operator.py
+++ b/mizar/dp/mizar/operators/dividers/dividers_operator.py
@@ -73,23 +73,23 @@ class DividerOperator(object):
 
     def update_divider_with_bouncers(self, bouncer, net, task):
         dividers = self.store.get_dividers_of_vpc(bouncer.vpc).values()
-        for d in dividers:
+        for d in list(dividers):
             d.update_net(net, task)
 
     def delete_bouncer_from_dividers(self, bouncer, net, task):
         dividers = self.store.get_dividers_of_vpc(bouncer.vpc).values()
-        for d in dividers:
+        for d in list(dividers):
             d.update_net(net, task, False)
 
     def update_net(self, net, task, dividers=None):
         if not dividers:
             dividers = self.store.get_dividers_of_vpc(net.vpc).values()
-        for d in dividers:
+        for d in list(dividers):
             d.update_net(net, task)
 
     def delete_net(self, net):
         dividers = self.store.get_dividers_of_vpc(net.vpc).values()
-        for d in dividers:
+        for d in list(dividers):
             d.delete_net(net)
 
     def delete_nets_from_divider(self, nets, divider):

--- a/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
+++ b/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
@@ -454,7 +454,13 @@ class EndpointOperator(object):
             # allocate the mac addresses for us.
             logger.info("init_simple_endpoint_interface on {} for {}".format(
                 worker_ip, spec['name']))
-            return InterfaceServiceClient(worker_ip).InitializeInterfaces(interfaces, task)
+            interfaces = InterfaceServiceClient(
+                worker_ip).InitializeInterfaces(interfaces, task)
+            for interface in interfaces.interfaces:
+                if not interface.address.mac:
+                    task.raise_temporary_error(
+                        "Veth did not come up in time for pod {} interface {}".format(pod_id, interface))
+            return interfaces
         return None
 
     def init_host_endpoint_interfaces(self, droplet, ifname, veth_name, peer_name, task):

--- a/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
+++ b/mizar/dp/mizar/operators/endpoints/endpoints_operator.py
@@ -271,7 +271,7 @@ class EndpointOperator(object):
 
     def delete_bouncer_from_endpoints(self, bouncer, task):
         eps = self.store.get_eps_in_net(bouncer.net).values()
-        for ep in eps:
+        for ep in list(eps):
             if ep.type == OBJ_DEFAULTS.ep_type_simple or ep.type == OBJ_DEFAULTS.ep_type_host:
                 ep.update_bouncers({bouncer.name: bouncer}, task, False)
 

--- a/mizar/dp/mizar/workflows/bouncers/create.py
+++ b/mizar/dp/mizar/workflows/bouncers/create.py
@@ -71,8 +71,6 @@ class BouncerCreate(WorkflowTask):
 
         net.bouncers[bouncer.name] = bouncer
         dividers_opr.update_divider_with_bouncers(bouncer, net, self)
-        endpoints_opr.update_bouncer_with_endpoints(bouncer, self)
-        endpoints_opr.update_endpoints_with_bouncers(bouncer, self)
         bouncer.load_transit_xdp_pipeline_stage(self)
         bouncers_opr.set_bouncer_provisioned(bouncer)
         self.finalize()

--- a/mizar/dp/mizar/workflows/bouncers/provisioned.py
+++ b/mizar/dp/mizar/workflows/bouncers/provisioned.py
@@ -24,12 +24,14 @@ from mizar.common.workflow import *
 from mizar.dp.mizar.operators.bouncers.bouncers_operator import *
 from mizar.dp.mizar.operators.droplets.droplets_operator import *
 from mizar.dp.mizar.operators.vpcs.vpcs_operator import *
+from mizar.dp.mizar.operators.endpoints.endpoints_operator import *
 
 logger = logging.getLogger()
 
 bouncers_opr = BouncerOperator()
 vpcs_opr = VpcOperator()
 droplets_opr = DropletOperator()
+endpoints_opr = EndpointOperator()
 
 
 class BouncerProvisioned(WorkflowTask):
@@ -44,5 +46,7 @@ class BouncerProvisioned(WorkflowTask):
             self.param.name, self.param.spec)
         bouncer.set_vni(vpcs_opr.store.get_vpc(bouncer.vpc).vni)
         bouncer.droplet_obj = droplets_opr.store.get_droplet(bouncer.droplet)
+        endpoints_opr.update_bouncer_with_endpoints(bouncer, self)
+        endpoints_opr.update_endpoints_with_bouncers(bouncer, self)
         bouncers_opr.store_update(bouncer)
         self.finalize()

--- a/mizar/dp/mizar/workflows/builtins/pods/create.py
+++ b/mizar/dp/mizar/workflows/builtins/pods/create.py
@@ -95,6 +95,10 @@ class k8sPodCreate(WorkflowTask):
                             "VPC {} has no subnets to allocate pod {}!".format(vpc_name, self.param.name))
                 spec['vpc'] = vpc_name
                 spec['subnet'] = subnet_name
+        else:
+            if not COMPUTE_PROVIDER.k8s:
+                self.raise_temporary_error(
+                    "VPC for pod {} not yet created!".format(self.param.name))
 
         spec['vni'] = vpc_opr.store_get(spec['vpc']).vni
         spec['droplet'] = droplet_opr.store_get_by_main_ip(spec['hostIP'])

--- a/mizar/dp/mizar/workflows/builtins/services/create.py
+++ b/mizar/dp/mizar/workflows/builtins/services/create.py
@@ -82,6 +82,8 @@ class k8sServiceCreate(WorkflowTask):
         if not net:
             self.raise_temporary_error(
                 "Task: {} Net not yet created.".format(self.__class__.__name__))
+        if not net.vni:
+            self.raise_temporary_error("k8sServiceCreate: Net {} does not yet have a vni!".format(net.name))
         logger.info("Creating scaled endpoint in subnet: {}.".format(net.name))
         ep = endpoints_opr.create_scaled_endpoint(
             self.param.name, name, self.param.spec, net, self.param.extra, self.param.body['metadata']['namespace'])

--- a/mizar/dp/mizar/workflows/droplets/provisioned.py
+++ b/mizar/dp/mizar/workflows/droplets/provisioned.py
@@ -43,7 +43,7 @@ class DropletProvisioned(WorkflowTask):
         logger.info("Run {task}".format(task=self.__class__.__name__))
         droplet = droplets_opr.get_droplet_stored_obj(
             self.param.name, self.param.spec)
-        for vpc in vpcs_opr.store.get_all_vpcs():
+        for vpc in list(vpcs_opr.store.get_all_vpcs()):
             if droplet.name not in droplets_opr.store.vpc_droplet_store[vpc.name]:
                 if vpc.name not in nets_opr.store.nets_vpc_store:
                     self.raise_temporary_error(

--- a/mizar/dp/mizar/workflows/endpoints/create.py
+++ b/mizar/dp/mizar/workflows/endpoints/create.py
@@ -52,7 +52,6 @@ class EndpointCreate(WorkflowTask):
             self.raise_temporary_error(
                 "Task: {} Endpoint: {} Droplet Object {} not ready. ".format(self.__class__.__name__, ep.name, ep.droplet))
         vpc = vpcs_opr.store.get_vpc(ep.vpc)
-        nets_opr.allocate_endpoint(ep, vpc)
         # EP create wait for bouncer
         net_bouncer = list(
             bouncers_opr.store.get_bouncers_of_net(ep.net).values())
@@ -62,6 +61,7 @@ class EndpointCreate(WorkflowTask):
         if net_bouncer[0].status != OBJ_STATUS.bouncer_status_provisioned:
             self.raise_temporary_error(
                 "EP create {}: bouncers not yet ready for net {}".format(ep.name, ep.net))
+        nets_opr.allocate_endpoint(ep, vpc)
         bouncers_opr.update_endpoint_obj_with_bouncers(ep)
 
         if ep.type == OBJ_DEFAULTS.ep_type_simple or ep.type == OBJ_DEFAULTS.ep_type_host:

--- a/mizar/dp/mizar/workflows/endpoints/create.py
+++ b/mizar/dp/mizar/workflows/endpoints/create.py
@@ -53,7 +53,7 @@ class EndpointCreate(WorkflowTask):
                 "Task: {} Endpoint: {} Droplet Object {} not ready. ".format(self.__class__.__name__, ep.name, ep.droplet))
         vpc = vpcs_opr.store.get_vpc(ep.vpc)
         nets_opr.allocate_endpoint(ep, vpc)
-        bouncers_opr.update_endpoint_with_bouncers(ep, self)
+        bouncers_opr.update_endpoint_obj_with_bouncers(ep)
         if ep.type == OBJ_DEFAULTS.ep_type_simple or ep.type == OBJ_DEFAULTS.ep_type_host:
             if ep.type == OBJ_DEFAULTS.ep_type_host:
                 logger.info("Activate host interface for vpc {} on droplet {}".format(

--- a/mizar/dp/mizar/workflows/endpoints/provisioned.py
+++ b/mizar/dp/mizar/workflows/endpoints/provisioned.py
@@ -53,9 +53,6 @@ class EndpointProvisioned(WorkflowTask):
                     logger.info(
                         "EP {} has bouncer {}. Updating.".format(endpoint.name, bouncer))
                 endpoint.update_bouncers(endpoint.bouncers, self)
-        else:
-            self.raise_temporary_error(
-                "Endpoint {} does not have any bouncers yet!".format(endpoint.name))
         endpoints_opr.store_update(endpoint)
 
         if self.param.name in endpoints_opr.store.eps_store_to_be_updated_networkpolicy:

--- a/mizar/dp/mizar/workflows/endpoints/provisioned.py
+++ b/mizar/dp/mizar/workflows/endpoints/provisioned.py
@@ -53,6 +53,9 @@ class EndpointProvisioned(WorkflowTask):
                     logger.info(
                         "EP {} has bouncer {}. Updating.".format(endpoint.name, bouncer))
                 endpoint.update_bouncers(endpoint.bouncers, self)
+        else:
+            self.raise_temporary_error(
+                "Endpoint {} does not have any bouncers yet!".format(endpoint.name))
         endpoints_opr.store_update(endpoint)
 
         if self.param.name in endpoints_opr.store.eps_store_to_be_updated_networkpolicy:

--- a/mizar/dp/mizar/workflows/nets/create.py
+++ b/mizar/dp/mizar/workflows/nets/create.py
@@ -62,7 +62,7 @@ class NetCreate(WorkflowTask):
         if len(dividers_opr.store.get_dividers_of_vpc(n.vpc)) < 1:
             self.raise_temporary_error(
                 "Task: {} Net: {} Dividers not available".format(self.__class__.__name__, n.name))
-        logger.info("NetCreate Net ip is {}".format(n.ip))
+        logger.info("NetCreate Net ip is {}, VNI is {}".format(n.ip, n.vni))
         nets_opr.create_net_bouncers(n, n.n_bouncers)
         nets_opr.store_update(n)
         ep = endpoints_opr.create_gw_endpoint(

--- a/mizar/dp/mizar/workflows/nets/provisioned.py
+++ b/mizar/dp/mizar/workflows/nets/provisioned.py
@@ -52,7 +52,7 @@ class NetProvisioned(WorkflowTask):
             if d[0] == 'change':
                 self.process_change(net=net, field=d[1], old=d[2], new=d[3])
         vpc = vpcs_opr.store.get_vpc(net.vpc)
-        for droplet in droplets_opr.store.get_all_droplets():
+        for droplet in list(droplets_opr.store.get_all_droplets()):
             logger.info("Net: Available droplets for vpc {}: {}".format(
                 vpc.name, droplets_opr.store.droplets_store.keys()))
             if vpc.name not in droplets_opr.store_get_vpc_to_droplet(droplet):

--- a/mizar/obj/endpoint.py
+++ b/mizar/obj/endpoint.py
@@ -261,6 +261,8 @@ class Endpoint:
     def update_bouncers(self, bouncers, task, add=True):
         for bouncer in bouncers.values():
             if add:
+                logger.info("endpoint obj: update_bouncer: ep {} update agent with bouncer {}".format(
+                    self.name, bouncer.name))
                 self.bouncers[bouncer.name] = bouncer
                 self.update_agent_substrate(self, bouncer, task)
             else:

--- a/mizar/store/operator_store.py
+++ b/mizar/store/operator_store.py
@@ -439,11 +439,12 @@ class OprStore(object):
         self.update_namespace_pod_store(namespace_name, pod_name)
 
     def delete_pod_namespace_store(self, pod_name):
-        ns = self.pod_namespace_store[pod_name]
-        if ns in self.namespace_pod_store and pod_name in self.namespace_pod_store[ns]:
-            self.namespace_pod_store[ns].remove(pod_name)
         if pod_name in self.pod_namespace_store:
-            del self.pod_namespace_store[pod_name]
+            ns = self.pod_namespace_store[pod_name]
+            if ns in self.namespace_pod_store and pod_name in self.namespace_pod_store[ns]:
+                self.namespace_pod_store[ns].remove(pod_name)
+            if pod_name in self.pod_namespace_store:
+                del self.pod_namespace_store[pod_name]
 
     def update_droplet(self, droplet):
         self.droplets_store[droplet.name] = droplet

--- a/src/dmn/trn_agent_xdp_usr.c
+++ b/src/dmn/trn_agent_xdp_usr.c
@@ -521,7 +521,7 @@ static int _trn_bpf_agent_prog_load_xattr(struct agent_user_metadata_t *md,
 	_REUSE_MAP_IF_PINNED(conn_track_cache);
 	_REUSE_MAP_IF_PINNED(ing_pod_label_policy_map);
 	_REUSE_MAP_IF_PINNED(ing_namespace_label_policy_map);
-	_REUSE_MAP_IF_PINNED(ing_pod_and_namespace_label_policy_map);	
+	_REUSE_MAP_IF_PINNED(ing_pod_and_namespace_label_policy_map);
 	_REUSE_MAP_IF_PINNED(tx_stats_map);
 
 	/* Only one prog is supported */
@@ -625,6 +625,7 @@ int trn_agent_metadata_init(struct agent_user_metadata_t *md, char *itf,
 		TRN_LOG_ERROR("Error retrieving index of interface");
 		return 1;
 	}
+	TRN_LOG_DEBUG("trn_agent_metadata_init: mapped hosted_interface:%s to index %d", itf, md->ifindex);
 
 	if (_trn_bpf_agent_prog_load_xattr(md, &prog_load_attr, &md->obj,
 					   &md->prog_fd)) {

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -253,6 +253,7 @@ int *update_ep_1_svc(rpc_trn_endpoint_t *ep, struct svc_req *rqstp)
 
 	if (strcmp(ep->hosted_interface, "") != 0) {
 		epval.hosted_iface = if_nametoindex(ep->hosted_interface);
+		TRN_LOG_DEBUG("update_ep: mapped hosted_interface:%s to index %d", ep->hosted_interface, epval.hosted_iface);
 	} else {
 		epval.hosted_iface = -1;
 	}
@@ -854,6 +855,7 @@ int *update_agent_ep_1_svc(rpc_trn_endpoint_t *ep, struct svc_req *rqstp)
 
 	if (strcmp(ep->hosted_interface, "") != 0) {
 		epval.hosted_iface = if_nametoindex(ep->hosted_interface);
+		TRN_LOG_DEBUG("update_agent_md: mapped hosted_interface:%s to index %d", ep->hosted_interface, epval.hosted_iface);
 	} else {
 		epval.hosted_iface = -1;
 	}
@@ -1014,7 +1016,7 @@ int *update_packet_metadata_1_svc(rpc_trn_packet_metadata_t *packet_metadata, st
 		goto error;
 	}
 
-	memcpy(key.tunip, &packet_metadata->tunid, sizeof(packet_metadata->tunid));	
+	memcpy(key.tunip, &packet_metadata->tunid, sizeof(packet_metadata->tunid));
 	key.tunip[2] = packet_metadata->ip;
 	value.pod_label_value = packet_metadata->pod_label_value;
 	value.namespace_label_value = packet_metadata->namespace_label_value;
@@ -1412,7 +1414,7 @@ int *update_transit_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc
 	cidr.prefixlen = policy->cidr_prefixlen + 96;
 	cidr.local_ip = policy->local_ip;
 	cidr.remote_ip = policy->cidr_ip;
-	TRN_LOG_INFO("policy: tunnel_id  %ld; local ip  0x%x; cidr ip  0x%x\n", 
+	TRN_LOG_INFO("policy: tunnel_id  %ld; local ip  0x%x; cidr ip  0x%x\n",
 			policy->tunid, policy->local_ip, policy->cidr_ip);
 
 	if (type == PRIMARY) {
@@ -1468,7 +1470,7 @@ int *update_agent_network_policy_1_svc(rpc_trn_vsip_cidr_t *policy, struct svc_r
 	cidr.prefixlen = policy->cidr_prefixlen + 96;
 	cidr.local_ip = policy->local_ip;
 	cidr.remote_ip = policy->cidr_ip;
-	TRN_LOG_INFO("policy: tunnel_id  %ld; local ip  0x%x; cidr ip  0x%x \n", 
+	TRN_LOG_INFO("policy: tunnel_id  %ld; local ip  0x%x; cidr ip  0x%x \n",
 			policy->tunid, policy->local_ip, policy->cidr_ip);
 
 	if (type == PRIMARY) {
@@ -1523,7 +1525,7 @@ int *delete_transit_network_policy_1_svc(rpc_trn_vsip_cidr_key_t *policy_key, st
 	cidr.prefixlen = policy_key->cidr_prefixlen + 96;
 	cidr.local_ip = policy_key->local_ip;
 	cidr.remote_ip = policy_key->cidr_ip;
-	TRN_LOG_INFO("policy: tunnel_id  %ld; local ip  0x%x; cidr ip  0x%x\n", 
+	TRN_LOG_INFO("policy: tunnel_id  %ld; local ip  0x%x; cidr ip  0x%x\n",
 			policy_key->tunid, policy_key->local_ip, policy_key->cidr_ip);
 
 	if (type == PRIMARY) {
@@ -1578,7 +1580,7 @@ int *delete_agent_network_policy_1_svc(rpc_trn_vsip_cidr_key_t *policy_key, stru
 	cidr.prefixlen = policy_key->cidr_prefixlen + 96;
 	cidr.local_ip = policy_key->local_ip;
 	cidr.remote_ip = policy_key->cidr_ip;
-	TRN_LOG_INFO("policy: tunnel_id  %ld; local ip  0x%x; cidr ip  0x%x\n", 
+	TRN_LOG_INFO("policy: tunnel_id  %ld; local ip  0x%x; cidr ip  0x%x\n",
 			policy_key->tunid, policy_key->local_ip, policy_key->cidr_ip);
 
 	if (type == PRIMARY) {
@@ -1762,7 +1764,7 @@ int *update_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_t *ppo, 
 	static int result = -1;
 	int rc;
 	char *itf = ppo->interface;
-	
+
 	TRN_LOG_INFO("update_transit_network_policy_protocol_port_1_svc service");
 	struct vsip_ppo_t policy;
 	struct user_metadata_t *md = trn_itf_table_find(itf);
@@ -1776,7 +1778,7 @@ int *update_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_t *ppo, 
 	policy.local_ip = ppo->local_ip;
 	policy.proto = ppo->proto;
 	policy.port = ppo->port;
-	TRN_LOG_INFO("ppo: tunnel_id  %ld; local ip  0x%x; protocol  %d; port  %d\n", 
+	TRN_LOG_INFO("ppo: tunnel_id  %ld; local ip  0x%x; protocol  %d; port  %d\n",
 				ppo->tunid, ppo->local_ip, ppo->proto, ppo->port);
 
 	rc = trn_update_transit_network_policy_protocol_port_map(md, &policy, ppo->bit_val);
@@ -1814,7 +1816,7 @@ int *update_agent_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_t *ppo, st
 	policy.local_ip = ppo->local_ip;
 	policy.proto = ppo->proto;
 	policy.port = ppo->port;
-	TRN_LOG_INFO("ppo: tunnel_id  %ld; local ip  0x%x; protocol  %d; port  %d\n", 
+	TRN_LOG_INFO("ppo: tunnel_id  %ld; local ip  0x%x; protocol  %d; port  %d\n",
 				ppo->tunid, ppo->local_ip, ppo->proto, ppo->port);
 
 	rc = trn_update_agent_network_policy_protocol_port_map(md, &policy, ppo->bit_val);
@@ -1838,7 +1840,7 @@ int *delete_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_key_t *p
 	static int result = -1;
 	int rc;
 	char *itf = ppo_key->interface;
-	
+
 	TRN_LOG_INFO("delete_transit_network_policy_protocol_port_1 service");
 	struct vsip_ppo_t policy;
 	struct user_metadata_t *md = trn_itf_table_find(itf);
@@ -1852,7 +1854,7 @@ int *delete_transit_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_key_t *p
 	policy.local_ip = ppo_key->local_ip;
 	policy.proto = ppo_key->proto;
 	policy.port = ppo_key->port;
-	TRN_LOG_INFO("ppo: tunnel_id  %ld; local ip  0x%x; protocol  %d; port  %d\n", 
+	TRN_LOG_INFO("ppo: tunnel_id  %ld; local ip  0x%x; protocol  %d; port  %d\n",
 				ppo_key->tunid, ppo_key->local_ip, ppo_key->proto, ppo_key->port);
 
 	rc = trn_delete_transit_network_policy_protocol_port_map(md, &policy);
@@ -1891,7 +1893,7 @@ int *delete_agent_network_policy_protocol_port_1_svc(rpc_trn_vsip_ppo_key_t *ppo
 	policy.proto = ppo_key->proto;
 	policy.port = ppo_key->port;
 
-	TRN_LOG_INFO("ppo: tunnel_id  %ld; local ip  0x%x; protocol  %d; port  %d \n", 
+	TRN_LOG_INFO("ppo: tunnel_id  %ld; local ip  0x%x; protocol  %d; port  %d \n",
 				ppo_key->tunid, ppo_key->local_ip, ppo_key->proto, ppo_key->port);
 
 	rc = trn_delete_agent_network_policy_protocol_port_map(md, &policy);
@@ -1915,7 +1917,7 @@ int *update_transit_pod_label_policy_1_svc(rpc_trn_pod_label_policy_t *rpc_obj, 
 	static int result = -1;
 	int rc;
 	char *itf = rpc_obj->interface;
-	
+
 	TRN_LOG_INFO("update_transit_pod_label_policy_1_svc service");
 	struct pod_label_policy_t policy;
 	struct user_metadata_t *md = trn_itf_table_find(itf);
@@ -1924,10 +1926,10 @@ int *update_transit_pod_label_policy_1_svc(rpc_trn_pod_label_policy_t *rpc_obj, 
 		result = RPC_TRN_ERROR;
 		goto error;
 	}
-	
+
 	policy.tunnel_id = rpc_obj->tunid;
 	policy.pod_label_value = rpc_obj->pod_label_value;
-	TRN_LOG_INFO("rpc_obj: pod_label_value %d\n", 
+	TRN_LOG_INFO("rpc_obj: pod_label_value %d\n",
 				rpc_obj->pod_label_value);
 
 	rc = trn_update_transit_pod_label_policy_map(md, &policy, rpc_obj->bit_val);
@@ -1951,7 +1953,7 @@ int *delete_transit_pod_label_policy_1_svc(rpc_trn_pod_label_policy_key_t *key, 
 	static int result = -1;
 	int rc;
 	char *itf = key->interface;
-	
+
 	TRN_LOG_INFO("delete_transit_network_policy_protocol_port_1 service");
 	struct pod_label_policy_t policy;
 	struct user_metadata_t *md = trn_itf_table_find(itf);
@@ -1963,7 +1965,7 @@ int *delete_transit_pod_label_policy_1_svc(rpc_trn_pod_label_policy_key_t *key, 
 
 	policy.tunnel_id = key->tunid;
 	policy.pod_label_value = key->pod_label_value;
-	TRN_LOG_INFO("key: pod_label_value %d\n", 
+	TRN_LOG_INFO("key: pod_label_value %d\n",
 				key->pod_label_value);
 
 	rc = trn_delete_transit_pod_label_policy_map(md, &policy);
@@ -1987,7 +1989,7 @@ int *update_transit_namespace_label_policy_1_svc(rpc_trn_namespace_label_policy_
 	static int result = -1;
 	int rc;
 	char *itf = rpc_obj->interface;
-	
+
 	TRN_LOG_INFO("update_transit_namespace_label_policy_1_svc service");
 	struct namespace_label_policy_t policy;
 	struct user_metadata_t *md = trn_itf_table_find(itf);
@@ -1996,10 +1998,10 @@ int *update_transit_namespace_label_policy_1_svc(rpc_trn_namespace_label_policy_
 		result = RPC_TRN_ERROR;
 		goto error;
 	}
-	
+
 	policy.tunnel_id = rpc_obj->tunid;
 	policy.namespace_label_value = rpc_obj->namespace_label_value;
-	TRN_LOG_INFO("rpc_obj: namespace_label_value %d\n", 
+	TRN_LOG_INFO("rpc_obj: namespace_label_value %d\n",
 				rpc_obj->namespace_label_value);
 
 	rc = trn_update_transit_namespace_label_policy_map(md, &policy, rpc_obj->bit_val);
@@ -2023,7 +2025,7 @@ int *delete_transit_namespace_label_policy_1_svc(rpc_trn_namespace_label_policy_
 	static int result = -1;
 	int rc;
 	char *itf = key->interface;
-	
+
 	TRN_LOG_INFO("delete_transit_network_policy_protocol_port_1 service");
 	struct namespace_label_policy_t policy;
 	struct user_metadata_t *md = trn_itf_table_find(itf);
@@ -2035,7 +2037,7 @@ int *delete_transit_namespace_label_policy_1_svc(rpc_trn_namespace_label_policy_
 
 	policy.tunnel_id = key->tunid;
 	policy.namespace_label_value = key->namespace_label_value;
-	TRN_LOG_INFO("key: namespace_label_value %d\n", 
+	TRN_LOG_INFO("key: namespace_label_value %d\n",
 				key->namespace_label_value);
 
 	rc = trn_delete_transit_namespace_label_policy_map(md, &policy);
@@ -2059,7 +2061,7 @@ int *update_transit_pod_and_namespace_label_policy_1_svc(rpc_trn_pod_and_namespa
 	static int result = -1;
 	int rc;
 	char *itf = rpc_obj->interface;
-	
+
 	TRN_LOG_INFO("update_transit_pod_and_namespace_label_policy_1_svc service");
 	struct pod_and_namespace_label_policy_t policy;
 	struct user_metadata_t *md = trn_itf_table_find(itf);
@@ -2068,11 +2070,11 @@ int *update_transit_pod_and_namespace_label_policy_1_svc(rpc_trn_pod_and_namespa
 		result = RPC_TRN_ERROR;
 		goto error;
 	}
-	
+
 	policy.tunnel_id = rpc_obj->tunid;
 	policy.pod_label_value = rpc_obj->pod_label_value;
 	policy.namespace_label_value = rpc_obj->namespace_label_value;
-	TRN_LOG_INFO("rpc_obj: pod_label_value %d namespace_label_value %d\n", 
+	TRN_LOG_INFO("rpc_obj: pod_label_value %d namespace_label_value %d\n",
 				rpc_obj->pod_label_value, rpc_obj->namespace_label_value);
 
 	rc = trn_update_transit_pod_and_namespace_label_policy_map(md, &policy, rpc_obj->bit_val);
@@ -2096,7 +2098,7 @@ int *delete_transit_pod_and_namespace_label_policy_1_svc(rpc_trn_pod_and_namespa
 	static int result = -1;
 	int rc;
 	char *itf = key->interface;
-	
+
 	TRN_LOG_INFO("delete_transit_network_policy_protocol_port_1 service");
 	struct pod_and_namespace_label_policy_t policy;
 	struct user_metadata_t *md = trn_itf_table_find(itf);
@@ -2109,7 +2111,7 @@ int *delete_transit_pod_and_namespace_label_policy_1_svc(rpc_trn_pod_and_namespa
 	policy.tunnel_id = key->tunid;
 	policy.pod_label_value = key->pod_label_value;
 	policy.namespace_label_value = key->namespace_label_value;
-	TRN_LOG_INFO("key: pod_label_value %d namespace_label_value %d\n", 
+	TRN_LOG_INFO("key: pod_label_value %d namespace_label_value %d\n",
 				key->pod_label_value, key->namespace_label_value);
 
 	rc = trn_delete_transit_pod_and_namespace_label_policy_map(md, &policy);

--- a/src/dmn/trn_transit_xdp_usr.c
+++ b/src/dmn/trn_transit_xdp_usr.c
@@ -566,7 +566,7 @@ int trn_user_metadata_init(struct user_metadata_t *md, char *itf,
 		TRN_LOG_ERROR("if_nametoindex");
 		return 1;
 	}
-
+	TRN_LOG_DEBUG("trn_user_metadata_init: mapped hosted_interface:%s to index %d", itf, md->ifindex);
 	md->eth.ip = trn_get_interface_ipv4(md->ifindex);
 	md->eth.iface_index = md->ifindex;
 


### PR DESCRIPTION
This PR fixes the following issues:

- Runtime errors where a dictionary changed size while being iterated through.
- An issue where the veth creation returned before the device was created.
- Timeout errors caused by the mizar-daemon taking longer than 15 minutes to come up in the Arktos kube-up environment.
- A runtime error where delete was called on a nonexistent key in a dictionary.
- An issue where pods deployed before mizar did not have network connectivity