### PR TITLE
Reduce memory footprint of XDP maps

### DIFF
--- a/src/include/trn_datamodel.h
+++ b/src/include/trn_datamodel.h
@@ -28,11 +28,12 @@
 #define __ALIGNED_64__ __attribute__((aligned(64)))
 #define __ALWAYS_INLINE__ __attribute__((__always_inline__))
 
-#define TRAN_MAX_NEP 65537
-#define TRAN_MAX_NSWITCH 32768
-#define TRAN_MAX_NROUTER 16384
-#define TRAN_MAX_REMOTES 256
-#define TRAN_MAX_ITF 256
+#define TRAN_MAX_NEP 4096
+#define TRAN_MAX_NSWITCH 128
+#define TRAN_MAX_NROUTER 128
+#define TRAN_MAX_REMOTES 128
+#define TRAN_MAX_ITF 128
+
 #define TRAN_UNUSED_ITF_IDX -1
 
 #define TRAN_SUBSTRT_VNI 0
@@ -61,7 +62,7 @@ enum tailcall_txstat { TAILCALL_SUPPORTED_TXSTATS MAX_TXSTAT };
 static const char * const tailcall_txstat_name[] = { TAILCALL_SUPPORTED_TXSTATS };
 
 /* Cache related const */
-#define TRAN_MAX_CACHE_SIZE 1000000
+#define TRAN_MAX_CACHE_SIZE 50000
 
 /* XDP programs keys in transit XDP */
 enum trn_xdp_stage_t {


### PR DESCRIPTION
<!--  Thanks for sending a pull request and contributing to Mizar!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind design
> /kind feature
/kind bug
> /kind cleanup
> /kind documentation

**What this PR does / why we need it**: This reduces the excessive memory footprint used by XDP maps in order for it to work with newer kernels.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
