### PR TITLE
Fix CNI driver to generate SPEC compliant response

### DIFF
--- a/cmd/mizarcni/app/worker.go
+++ b/cmd/mizarcni/app/worker.go
@@ -77,7 +77,10 @@ func DoCmdAdd(netVariables *object.NetVariables, stdinData []byte) (cni.Result, 
 				Mac:     intf.Address.Mac,
 				Sandbox: netVariables.NetNS,
 			})
-		ipAddr, ipNet, _ := net.ParseCIDR(fmt.Sprintf("%s/%s", intf.Address.IpAddress, intf.Address.IpPrefix))
+		ipAddr, ipNet, err := net.ParseCIDR(fmt.Sprintf("%s/%s", intf.Address.IpAddress, intf.Address.IpPrefix))
+		if err != nil {
+			return result, tracelog.String(), err
+		}
 		result.IPs = append(result.IPs,
 			&cni.IPConfig{
 				Version:   intf.Address.Version,

--- a/cmd/mizarcni/app/worker_test.go
+++ b/cmd/mizarcni/app/worker_test.go
@@ -134,8 +134,8 @@ func Test_DoCmdAdd(t *testing.T) {
 
 		Convey("Given ParseCIDR error, got expected result", func() {
 			expectedInfo := "Expected Info"
-			expectedErrorStr "invalid CIDR address: /"
-			expectedError errors.New(expectedErrorStr)
+			expectedErrorStr := "invalid CIDR address"
+			expectedError := errors.New(expectedErrorStr)
 			patches := ApplyFunc(netvariablesutil.LoadCniConfig, func(_ *object.NetVariables, _ []byte) error {
 				return nil
 			})
@@ -166,12 +166,12 @@ func Test_DoCmdAdd(t *testing.T) {
 			So(tracelog, ShouldContainSubstring, "CNI_ADD: Args: ")
 			So(tracelog, ShouldContainSubstring, "Activating interface")
 			So(tracelog, ShouldContainSubstring, expectedInfo)
-			So(err.Error(), ShouldEqual, expectedErrorStr)
+			So(err.Error(), ShouldContainSubstring, expectedErrorStr)
 		})
 
 		Convey("Given no error, got expected result", func() {
 			expectedInfo := "Expected Info"
-			expectedErrorStr "invalid CIDR address: /"
+			expectedErrorStr := "invalid CIDR address"
 			patches := ApplyFunc(netvariablesutil.LoadCniConfig, func(_ *object.NetVariables, _ []byte) error {
 				return nil
 			})
@@ -203,7 +203,7 @@ func Test_DoCmdAdd(t *testing.T) {
 			So(tracelog, ShouldContainSubstring, "CNI_ADD: Args: ")
 			So(tracelog, ShouldContainSubstring, "Activating interface")
 			So(tracelog, ShouldContainSubstring, expectedInfo)
-			So(err.Error(), ShouldEqual, expectedErrorStr)
+			So(err.Error(), ShouldContainSubstring, expectedErrorStr)
 		})
 	})
 }

--- a/cmd/mizarcni/app/worker_test.go
+++ b/cmd/mizarcni/app/worker_test.go
@@ -134,7 +134,8 @@ func Test_DoCmdAdd(t *testing.T) {
 
 		Convey("Given ParseCIDR error, got expected result", func() {
 			expectedInfo := "Expected Info"
-			expectedError := errors.New("Expected Error")
+			expectedErrorStr "invalid CIDR address: /"
+			expectedError errors.New(expectedErrorStr)
 			patches := ApplyFunc(netvariablesutil.LoadCniConfig, func(_ *object.NetVariables, _ []byte) error {
 				return nil
 			})
@@ -165,11 +166,12 @@ func Test_DoCmdAdd(t *testing.T) {
 			So(tracelog, ShouldContainSubstring, "CNI_ADD: Args: ")
 			So(tracelog, ShouldContainSubstring, "Activating interface")
 			So(tracelog, ShouldContainSubstring, expectedInfo)
-			So(err, ShouldEqual, expectedError)
+			So(err.Error(), ShouldEqual, expectedErrorStr)
 		})
 
 		Convey("Given no error, got expected result", func() {
 			expectedInfo := "Expected Info"
+			expectedErrorStr "invalid CIDR address: /"
 			patches := ApplyFunc(netvariablesutil.LoadCniConfig, func(_ *object.NetVariables, _ []byte) error {
 				return nil
 			})
@@ -201,7 +203,7 @@ func Test_DoCmdAdd(t *testing.T) {
 			So(tracelog, ShouldContainSubstring, "CNI_ADD: Args: ")
 			So(tracelog, ShouldContainSubstring, "Activating interface")
 			So(tracelog, ShouldContainSubstring, expectedInfo)
-			So(err, ShouldBeNil)
+			So(err.Error(), ShouldEqual, expectedErrorStr)
 		})
 	})
 }

--- a/cmd/mizarcni/mizarcni.go
+++ b/cmd/mizarcni/mizarcni.go
@@ -65,6 +65,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		klog.Infof("CNI_ADD: Success - interface added for pod '%s/%s'\n",
 				netVariables.K8sPodNamespace, netVariables.K8sPodName)
 	}
+	klog.Infof("CNI_ADD: RESULT= '%+v'\n", result)
 	klog.Infof("CNI_ADD: <<<<\n--------------------------------\n")
 	result.Print()
 	return err
@@ -84,6 +85,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		klog.Infof("CNI_DEL: Success - interface deleted for pod '%s/%s'\n",
 				netVariables.K8sPodNamespace, netVariables.K8sPodName)
 	}
+	klog.Infof("CNI_DEL: RESULT= '%+v'\n", result)
 	klog.Infof("CNI_DEL: <<<<\n--------------------------------\n")
 	result.Print()
 	return err

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
 	google.golang.org/grpc v1.39.0
-	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 // indirect
 	google.golang.org/protobuf v1.26.0
 	k8s.io/klog/v2 v2.10.0
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request and contributing to Mizar!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind design
> /kind feature
/kind bug
> /kind cleanup
> /kind documentation

**What this PR does / why we need it**: The current CNI implementation does not return CNI ADD response compliant to the CNI spec. This causes CNI ADD failure in newer versions of containerd that has stricter checking.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
