### PR TITLE
Override MAC address in Tx eBPF program for kubemark

### DIFF
--- a/etc/deploy/deploy.mizar.dev.yaml
+++ b/etc/deploy/deploy.mizar.dev.yaml
@@ -523,6 +523,8 @@ spec:
       - name: mizar-daemon
         image: mizarnet/dropletd:dev
         env:
+        - name: FEATUREGATE_KUBEMARK_NETWORK_PERF
+          value: 'false'
         - name: FEATUREGATE_BWQOS
           value: 'false'
         securityContext:
@@ -567,6 +569,8 @@ spec:
       - name: mizar-operator
         image: mizarnet/endpointopr:dev
         env:
+        - name: FEATUREGATE_KUBEMARK_NETWORK_PERF
+          value: 'false'
         - name: FEATUREGATE_BWQOS
           value: 'false'
         securityContext:

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -613,9 +613,10 @@ class LocalTransitRpc:
                 "ip": interface.droplet.ip_address,
                 "mac": interface.droplet.mac,
                 "iface": default_itf
-            },
-            "dst_mac_override": dst_mac
+            }
         }
+        if dst_mac != "":
+            jsonconf["dst_mac_override"] = dst_mac
         jsonconf = json.dumps(jsonconf)
         cmd = f'''{self.trn_cli_update_agent_metadata} -i \'{itf}\' -j \'{jsonconf}\''''
         logger.info("update_agent_metadata: {}".format(cmd))

--- a/mizar/daemon/interface_service.py
+++ b/mizar/daemon/interface_service.py
@@ -576,6 +576,23 @@ class LocalTransitRpc:
         bouncers = []
         for bouncer in interface.bouncers:
             bouncers.append(bouncer.ip_address)
+        dst_mac = ""
+        if os.getenv('FEATUREGATE_KUBEMARK_NETWORK_PERF', 'false').lower() in ('true', '1'):
+            cmd = "cat /proc/1/sched | head -n 1"
+            r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+            outstr = r.stdout.read().decode().strip()
+            if not "systemd" in outstr:
+                logger.info("Overriding default-gateway/bouncer MAC address for kubemark virtual node")
+                cmd = "ip route show default | awk \'{print $3}\'"
+                r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+                default_gw_ip = r.stdout.read().decode().strip()
+                logger.info("Default gateway IP: {}".format(default_gw_ip))
+                cmd = 'arp ' + f'''{default_gw_ip}''' + ' | grep ' + f'''{default_gw_ip}''' + ' | awk \'{print $3}\''
+                r = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+                default_gw_mac = r.stdout.read().decode().strip()
+                logger.info("Default gateway MAC: {}".format(default_gw_mac))
+                dst_mac = default_gw_mac
+                logger.info("Override MAC: {}".format(dst_mac))
         jsonconf = {
             "ep": {
                 "tunnel_id": interface.address.tunnel_id,
@@ -596,7 +613,8 @@ class LocalTransitRpc:
                 "ip": interface.droplet.ip_address,
                 "mac": interface.droplet.mac,
                 "iface": default_itf
-            }
+            },
+            "dst_mac_override": dst_mac
         }
         jsonconf = json.dumps(jsonconf)
         cmd = f'''{self.trn_cli_update_agent_metadata} -i \'{itf}\' -j \'{jsonconf}\''''

--- a/src/cli/trn_cli_agent.c
+++ b/src/cli/trn_cli_agent.c
@@ -214,6 +214,7 @@ int trn_cli_update_agent_md_subcmd(CLIENT *clnt, int argc, char *argv[])
 
 	char eth_itf[20];
 	agent_md.eth.interface = eth_itf;
+	memset(agent_md.dst_mac_override, 0, sizeof(agent_md.dst_mac_override));
 	int err = trn_cli_parse_agent_md(json_str, &agent_md);
 	cJSON_Delete(json_str);
 

--- a/src/cli/trn_cli_common.c
+++ b/src/cli/trn_cli_common.c
@@ -611,10 +611,24 @@ int trn_cli_parse_agent_md(const cJSON *jsonobj,
 	cJSON *ep = cJSON_GetObjectItem(jsonobj, "ep");
 	cJSON *net = cJSON_GetObjectItem(jsonobj, "net");
 	cJSON *eth = cJSON_GetObjectItem(jsonobj, "eth");
+	cJSON *mac_override = cJSON_GetObjectItem(jsonobj, "dst_mac_override");
 	int err_ep, err_net, err_eth;
 	err_ep = trn_cli_parse_ep(ep, &agent_md->ep);
 	err_net = trn_cli_parse_net(net, &agent_md->net);
 	err_eth = trn_cli_parse_tun_intf(eth, &agent_md->eth);
+
+	if (mac_override != NULL && cJSON_IsString(mac_override)) {
+		if (6 == sscanf(mac_override->valuestring,
+				"%hhx:%hhx:%hhx:%hhx:%hhx:%hhx%*c",
+				&agent_md->dst_mac_override[0], &agent_md->dst_mac_override[1],
+				&agent_md->dst_mac_override[2], &agent_md->dst_mac_override[3],
+				&agent_md->dst_mac_override[4], &agent_md->dst_mac_override[5])) {
+		} else {
+			/* invalid mac override */
+			print_err("Error: Invalid MAC Override\n");
+			return -EINVAL;
+		}
+	}
 
 	if (err_ep || err_net || err_eth) {
 		return -EINVAL;

--- a/src/dmn/trn_rpc_protocol_handlers_1.c
+++ b/src/dmn/trn_rpc_protocol_handlers_1.c
@@ -1159,6 +1159,11 @@ int *update_agent_md_1_svc(rpc_trn_agent_metadata_t *agent_md,
 	amd.ep.hosted_iface = amd.eth.iface_index;
 	memcpy(amd.ep.mac, agent_md->ep.mac, 6 * sizeof(amd.ep.mac[0]));
 
+	amd.dst_mac_override = 0;
+	unsigned char *dst_mac = (unsigned char *)&amd.dst_mac_override;
+	memcpy(dst_mac, agent_md->dst_mac_override, 6 * sizeof(unsigned char));
+	TRN_LOG_DEBUG("Override MAC: [%lx]", amd.dst_mac_override);
+
 	rc = trn_agent_update_agent_metadata(md, &amd, eth_md);
 
 	if (rc != 0) {

--- a/src/include/trn_datamodel.h
+++ b/src/include/trn_datamodel.h
@@ -149,6 +149,7 @@ struct agent_metadata_t {
 	struct network_t net;
 	struct endpoint_key_t epkey;
 	struct endpoint_t ep;
+	__u64 dst_mac_override;
 } __attribute__((packed, aligned(4)));
 
 struct ipv4_tuple_t {

--- a/src/rpcgen/trn_rpc_protocol.x
+++ b/src/rpcgen/trn_rpc_protocol.x
@@ -170,6 +170,7 @@ struct rpc_trn_agent_metadata_t {
        rpc_trn_tun_intf_t eth;
        rpc_trn_endpoint_t ep;
        rpc_trn_network_t net;
+       unsigned char dst_mac_override[6];
 };
 
 enum rpc_trn_pipeline_stage {

--- a/src/xdp/trn_agent_xdp.c
+++ b/src/xdp/trn_agent_xdp.c
@@ -161,9 +161,13 @@ static __inline int trn_encapsulate(struct transit_packet *pkt,
 		}
 
 		d_mac = r_ep->mac;
-
 	} else {
 		return XDP_DROP;
+	}
+
+	if (metadata->dst_mac_override != 0) {
+		__builtin_memcpy(d_mac, (unsigned char *)&metadata->dst_mac_override,
+			 6 * sizeof(unsigned char));
 	}
 
 	struct packet_metadata_key_t packet_metadata_key;


### PR DESCRIPTION
<!--  Thanks for sending a pull request and contributing to Mizar!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind design
/kind feature
> /kind bug
> /kind cleanup
> /kind documentation

**What this PR does / why we need it**: We use the MAC address of target host NIC for pod to pod communication. However this leads to filtering drops for kubemark case where the node is really a pod, being served by kubenet CNI. We need to keep the same behavior that as the host stack for populating destination MAC.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
